### PR TITLE
Bugfixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,5 @@
 	url = https://github.com/NCAR/ccpp-framework
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
+	url = https://github.com/junwang-noaa/ccpp-physics
+        branch = gfdlmp_update

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-	branch = dev/emc
+	url = https://github.com/junwang-noaa/GFDL_atmos_cubed_sphere
+	branch = regfv3_rst
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/junwang-noaa/GFDL_atmos_cubed_sphere
-	branch = regfv3_rst
+	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/junwang-noaa/ccpp-physics
-        branch = gfdlmp_update
+	url = https://github.com/NCAR/ccpp-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
 	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework

--- a/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -1149,7 +1149,7 @@ module module_physics_driver
             if (fice(i) < one) then
               wet(i) = .true.
 !             Sfcprop%tsfco(i) = tgice
-              Sfcprop%tsfco(i) = max(Sfcprop%tisfc(i), tgice)
+              if (.not. Model%cplflx) Sfcprop%tsfco(i) = max(Sfcprop%tisfc(i), tgice)
 !             Sfcprop%tsfco(i) = max((Sfcprop%tsfc(i) - fice(i)*sfcprop%tisfc(i)) &
 !                                     / (one - fice(i)), tgice)
             endif

--- a/gfsphysics/GFS_layer/GFS_restart.F90
+++ b/gfsphysics/GFS_layer/GFS_restart.F90
@@ -117,6 +117,9 @@ module GFS_restart
 #endif
 
     Restart%num3d = Model%ntot3d
+    if(Model%lrefres) then
+       Restart%num3d = Model%ntot3d+1
+    endif
 #ifdef CCPP
     ! GF
     if (Model%imfdeepcnv == 3) then
@@ -252,7 +255,13 @@ module GFS_restart
         Restart%data(nb,num)%var3p => Tbd(nb)%phy_f3d(:,:,num)
       enddo
     enddo
-
+    if (Model%lrefres) then
+      num = Model%ntot3d+1
+      restart%name3d(num) = 'ref_f3d'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var3p => IntDiag(nb)%refl_10cm(:,:)
+      enddo
+    endif
 #ifdef CCPP
     !--- RAP/HRRR-specific variables, 3D
     num = Model%ntot3d

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -701,6 +701,9 @@ module GFS_typedefs
     !--- GFDL microphysical paramters
     logical              :: lgfdlmprad      !< flag for GFDL mp scheme and radiation consistency 
 
+    !--- Thompson,GFDL mp parameter
+    logical              :: lrefres          !< flag for radar reflectivity in restart file
+
     !--- land/surface model parameters
     integer              :: lsm             !< flag for land surface model lsm=1 for noah lsm
     integer              :: lsm_noah=1      !< flag for NOAH land surface model
@@ -2740,6 +2743,9 @@ module GFS_typedefs
     !--- GFDL microphysical parameters
     logical              :: lgfdlmprad     = .false.            !< flag for GFDLMP radiation interaction 
 
+    !--- Thompson,GFDL microphysical parameter
+    logical              :: lrefres        = .false.            !< flag for radar reflectivity in restart file
+
     !--- land/surface model parameters
     integer              :: lsm            =  1              !< flag for land surface model to use =0  for osu lsm; =1  for noah lsm; =2  for noah mp lsm; =3  for RUC lsm
     integer              :: lsoil          =  4              !< number of soil layers
@@ -3023,7 +3029,7 @@ module GFS_typedefs
                                mg_do_graupel, mg_do_hail, mg_nccons, mg_nicons, mg_ngcons,  &
                                mg_ncnst, mg_ninst, mg_ngnst, sed_supersat, do_sb_physics,   &
                                mg_alf,   mg_qcmin, mg_do_ice_gmao, mg_do_liq_liu,           &
-                               ltaerosol, lradar, ttendlim, lgfdlmprad,                     &
+                               ltaerosol, lradar, lrefres, ttendlim, lgfdlmprad,            &
                           !--- max hourly
                                avg_max_length,                                              &
                           !--- land/surface model control
@@ -3312,6 +3318,8 @@ module GFS_typedefs
     Model%ttendlim         = ttendlim
 !--- gfdl  MP parameters
     Model%lgfdlmprad       = lgfdlmprad
+!--- Thompson,GFDL MP parameter
+    Model%lrefres          = lrefres
 
 !--- land/surface model parameters
     Model%lsm              = lsm
@@ -4310,6 +4318,7 @@ module GFS_typedefs
         print *, ' Thompson microphysical parameters'
         print *, ' ltaerosol         : ', Model%ltaerosol
         print *, ' lradar            : ', Model%lradar
+        print *, ' lrefres           : ', Model%lrefres
         print *, ' ttendlim          : ', Model%ttendlim
         print *, ' '
       endif
@@ -4327,6 +4336,7 @@ module GFS_typedefs
       if (Model%imp_physics == Model%imp_physics_gfdl) then
         print *, ' GFDL microphysical parameters'
         print *, ' GFDL MP radiation inter: ', Model%lgfdlmprad
+        print *, ' lrefres                : ', Model%lrefres
         print *, ' '
       endif
 

--- a/gfsphysics/physics/gfdl_cloud_microphys.F90
+++ b/gfsphysics/physics/gfdl_cloud_microphys.F90
@@ -4688,7 +4688,7 @@ subroutine cloud_diagnosis (is, ie, ks, ke, den, delp, lsm, qmw, qmi, qmr, qms, 
     real :: n0r = 8.0e6, n0s = 3.0e6, n0g = 4.0e6
     real :: alphar = 0.8, alphas = 0.25, alphag = 0.5
     real :: gammar = 17.837789, gammas = 8.2850630, gammag = 11.631769
-    real :: qmin = 1.0e-12, beta = 1.22
+    real :: qmin = 1.0e-12, beta = 1.22, qmin1 = 9.e-6
     
     do k = ks, ke
         do i = is, ie
@@ -4718,7 +4718,7 @@ subroutine cloud_diagnosis (is, ie, ks, ke, den, delp, lsm, qmw, qmi, qmr, qms, 
                 ! cloud ice (Heymsfield and Mcfarquhar, 1996)
                 ! -----------------------------------------------------------------------
                 
-                if (qmi (i, k) .gt. qmin) then
+                if (qmi (i, k) .gt. qmin1) then
                     qci (i, k) = dpg * qmi (i, k) * 1.0e3
                     rei_fac = log (1.0e3 * qmi (i, k) * den (i, k))
                     if (t (i, k) - tice .lt. - 50) then
@@ -4744,7 +4744,7 @@ subroutine cloud_diagnosis (is, ie, ks, ke, den, delp, lsm, qmw, qmi, qmr, qms, 
                 ! cloud ice (Wyser, 1998)
                 ! -----------------------------------------------------------------------
                 
-                if (qmi (i, k) .gt. qmin) then
+                if (qmi (i, k) .gt. qmin1) then
                     qci (i, k) = dpg * qmi (i, k) * 1.0e3
                     bw = - 2. + 1.e-3 * log10 (den (i, k) * qmi (i, k) / rho_0) * max (0.0, tice - t (i, k)) ** 1.5
                     rei (i, k) = 377.4 + bw * (203.3 + bw * (37.91 + 2.3696 * bw))
@@ -4774,7 +4774,7 @@ subroutine cloud_diagnosis (is, ie, ks, ke, den, delp, lsm, qmw, qmi, qmr, qms, 
             ! snow (Lin et al., 1983)
             ! -----------------------------------------------------------------------
             
-            if (qms (i, k) .gt. qmin) then
+            if (qms (i, k) .gt. qmin1) then
                 qcs (i, k) = dpg * qms (i, k) * 1.0e3
                 lambdas = exp (0.25 * log (pi * rhos * n0s / qms (i, k) / den (i, k)))
                 res (i, k) = 0.5 * exp (log (gammas / 6) / alphas) / lambdas * 1.0e6

--- a/gfsphysics/physics/satmedmfvdifq.f
+++ b/gfsphysics/physics/satmedmfvdifq.f
@@ -151,7 +151,7 @@
      &                     rlmn,    rlmn1,  rlmx,   elmx,
      &                     ttend,   utend,  vtend,  qtend,
      &                     zfac,    zfmin,  vk,     spdk2,
-     &                     tkmin,   xkzinv, xkgdx,
+     &                     tkmin,   tkminx, xkzinv, xkgdx,
      &                     zlup,    zldn,   bsum,
      &                     tem,     tem1,   tem2,
      &                     ptem,    ptem0,  ptem1,  ptem2
@@ -176,11 +176,11 @@
       parameter(prmin=0.25,prmax=4.0)
       parameter(pr0=1.0,prtke=1.0,prscu=0.67)
       parameter(f0=1.e-4,crbmin=0.15,crbmax=0.35)
-      parameter(tkmin=1.e-9,dspmax=10.0)
+      parameter(tkmin=1.e-9,tkminx=0.2,dspmax=10.0)
       parameter(qmin=1.e-8,qlmin=1.e-12,zfmin=1.e-8)
       parameter(aphi5=5.,aphi16=16.)
       parameter(elmfac=1.0,elefac=1.0,cql=100.)
-      parameter(dw2min=1.e-4,dkmax=1000.,xkgdx=25000.)
+      parameter(dw2min=1.e-4,dkmax=1000.,xkgdx=5000.)
       parameter(qlcr=3.5e-5,zstblmax=2500.,xkzinv=0.1)
       parameter(h1=0.33333333)
       parameter(ck0=0.4,ck1=0.15,ch0=0.4,ch1=0.15)
@@ -273,20 +273,20 @@
           xkzo(i,k)  = 0.0
           xkzmo(i,k) = 0.0
           if (k < kinver(i)) then
-!                                  vertical background diffusivity
-            ptem      = prsi(i,k+1) * tx1(i)
-            tem1      = 1.0 - ptem
-            tem2      = tem1 * tem1 * 10.0
-            tem2      = min(1.0, exp(-tem2))
-            xkzo(i,k) = xkzm_hx(i) * tem2
-!
+!                               minimum turbulent mixing length
             ptem      = prsl(i,k) * tx1(i)
             tem1      = 1.0 - ptem
             tem2      = tem1 * tem1 * 2.5
             tem2      = min(1.0, exp(-tem2))
             rlmnz(i,k)= rlmn * tem2
             rlmnz(i,k)= max(rlmnz(i,k), rlmn1)
-!                                 vertical background diffusivity for momentum
+!                               vertical background diffusivity
+            ptem      = prsi(i,k+1) * tx1(i)
+            tem1      = 1.0 - ptem
+            tem2      = tem1 * tem1 * 10.0
+            tem2      = min(1.0, exp(-tem2))
+            xkzo(i,k) = xkzm_hx(i) * tem2
+!                               vertical background diffusivity for momentum
             if (ptem >= xkzm_s) then
               xkzmo(i,k) = xkzm_mx(i)
               kx1(i)     = k + 1
@@ -674,20 +674,20 @@
 !
 !  background diffusivity decreasing with increasing surface layer stability
 !
-      do i = 1, im
-        if(.not.sfcflg(i)) then
-          tem = (1. + 5. * rbsoil(i))**2.
-!         tem = (1. + 5. * zol(i))**2.
-          frik(i) = 0.1 + 0.9 / tem
-        endif
-      enddo
+!     do i = 1, im
+!       if(.not.sfcflg(i)) then
+!         tem = (1. + 5. * rbsoil(i))**2.
+!!        tem = (1. + 5. * zol(i))**2.
+!         frik(i) = 0.1 + 0.9 / tem
+!       endif
+!     enddo
 !
-      do k = 1,km1
-        do i=1,im
-          xkzo(i,k) = frik(i) * xkzo(i,k)
-          xkzmo(i,k)= frik(i) * xkzmo(i,k)
-        enddo
-      enddo
+!     do k = 1,km1
+!       do i=1,im
+!         xkzo(i,k) = frik(i) * xkzo(i,k)
+!         xkzmo(i,k)= frik(i) * xkzmo(i,k)
+!       enddo
+!     enddo
 !
 ! The background vertical diffusivities in the inversion layers are limited 
 !    to be less than or equal to xkzminv
@@ -867,13 +867,14 @@
         do i = 1, im
           if(k == 1) then
             tem = ckz(i,1)
-            tem1 = xkzmo(i,1)
+            tem1 = 0.5 * xkzmo(i,1)
           else
             tem = 0.5 * (ckz(i,k-1) + ckz(i,k))
             tem1 = 0.5 * (xkzmo(i,k-1) + xkzmo(i,k))
           endif
           ptem = tem1 / (tem * elm(i,k))
           tkmnz(i,k) = ptem * ptem
+          tkmnz(i,k) = min(tkmnz(i,k), tkminx)
           tkmnz(i,k) = max(tkmnz(i,k), tkmin)
         enddo
       enddo

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -1119,15 +1119,10 @@ module FV3GFS_io_mod
           Sfcprop(nb)%zorll(ix) = Sfcprop(nb)%zorlo(ix)
           Sfcprop(nb)%zorl(ix)  = Sfcprop(nb)%zorlo(ix)
           Sfcprop(nb)%tsfc(ix)  = Sfcprop(nb)%tsfco(ix)
-          if (Sfcprop(nb)%slmsk(ix) < 0.1 .or. Sfcprop(nb)%slmsk(ix) > 1.9) then
+          if (Sfcprop(nb)%slmsk(ix) > 1.9) then
             Sfcprop(nb)%landfrac(ix) = 0.0
-            if (Sfcprop(nb)%oro_uf(ix) > 0.01) then
-              Sfcprop(nb)%lakefrac(ix) = 1.0        ! lake
-            else
-              Sfcprop(nb)%lakefrac(ix) = 0.0        ! ocean
-            endif
           else
-            Sfcprop(nb)%landfrac(ix) = 1.0          ! land
+            Sfcprop(nb)%landfrac(ix) = Sfcprop(nb)%slmsk(ix)
           endif
         enddo
       enddo

--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -22,7 +22,7 @@ module module_write_netcdf
   contains
 
 !----------------------------------------------------------------------------------------
-  subroutine write_netcdf(fieldbundle, wrtfb, filename, mpi_comm, mype, im, jm, rc)
+  subroutine write_netcdf(fieldbundle, wrtfb, filename, mpi_comm, mype, im, jm, idate, rc)
 !
     type(ESMF_FieldBundle), intent(in) :: fieldbundle
     type(ESMF_FieldBundle), intent(in) :: wrtfb
@@ -30,6 +30,7 @@ module module_write_netcdf
     integer, intent(in)                :: mpi_comm
     integer, intent(in)                :: mype
     integer, intent(in)                :: im, jm
+    integer, intent(in)                :: idate(7)
     integer, optional,intent(out)      :: rc
 !
 !** local vars
@@ -146,7 +147,7 @@ module module_write_netcdf
       call add_dim(ncid, "phalf", phalf_dimid, wrtgrid, rc)
     end if
 
-    call add_dim(ncid, "time", time_dimid, wrtgrid, rc)
+    call add_dim(ncid, "time", time_dimid, wrtgrid, rc, idate=idate)
 
     call get_global_attr(wrtfb, ncid, rc)
 
@@ -503,11 +504,12 @@ module module_write_netcdf
 
   end subroutine get_grid_attr
 
-  subroutine add_dim(ncid, dim_name, dimid, grid, rc)
+  subroutine add_dim(ncid, dim_name, dimid, grid, idate, rc)
     integer, intent(in)             :: ncid
     character(len=*), intent(in)    :: dim_name
-    integer, intent(inout) :: dimid
+    integer, intent(inout)          :: dimid
     type(ESMF_Grid), intent(in)     :: grid
+    integer, intent(in), optional   :: idate(7)
     integer, intent(out)            :: rc
 
 ! local variable
@@ -556,9 +558,38 @@ module module_write_netcdf
 
     call get_grid_attr(grid, dim_name, ncid, dim_varid, rc)
 
+    ! if write grid comp changes time units
+    if ( present (idate) ) then
+      if ( trim(dim_name) == "time") then
+        ncerr = nf90_get_att(ncid, dim_varid, 'units', time_units); NC_ERR_STOP(ncerr)
+        time_units  = get_time_units_from_idate(idate)
+        ncerr = nf90_put_att(ncid, dim_varid, 'units', trim(time_units)); NC_ERR_STOP(ncerr)
+      endif
+    endif
+
   end subroutine add_dim
 !
 !----------------------------------------------------------------------------------------
+  function get_time_units_from_idate(idate, time_measure) result(time_units)
+      ! create time units attribute of form 'hours since YYYY-MM-DD HH:MM:SS'
+      ! from integer array with year,month,day,hour,minute,second
+      ! optional argument 'time_measure' can be used to change 'hours' to
+      ! 'days', 'minutes', 'seconds' etc.
+      character(len=*), intent(in), optional :: time_measure
+      integer, intent(in) ::  idate(7)
+      character(len=12) :: timechar
+      character(len=nf90_max_name) :: time_units
+      if (present(time_measure)) then
+         timechar = trim(time_measure)
+      else
+         timechar = 'hours'
+      endif
+      write(time_units,101) idate(1:6)
+101   format(' since ',i4.4,'-',i2.2,'-',i2.2,' ',&
+      i2.2,':',i2.2,':',i2.2)
+      time_units = trim(adjustl(timechar))//time_units
+  end function get_time_units_from_idate
+!
   subroutine nccheck(status)
     use netcdf
     implicit none

--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -504,17 +504,18 @@ module module_write_netcdf
 
   end subroutine get_grid_attr
 
-  subroutine add_dim(ncid, dim_name, dimid, grid, idate, rc)
+  subroutine add_dim(ncid, dim_name, dimid, grid, rc, idate)
     integer, intent(in)             :: ncid
     character(len=*), intent(in)    :: dim_name
     integer, intent(inout)          :: dimid
     type(ESMF_Grid), intent(in)     :: grid
-    integer, intent(in), optional   :: idate(7)
     integer, intent(out)            :: rc
+    integer, intent(in), optional   :: idate(7)
 
 ! local variable
     integer :: i, attcount, n, dim_varid
     integer :: ncerr
+    character(255)             :: time_units
     character(len=ESMF_MAXSTR) :: attName
     type(ESMF_TypeKind_Flag)   :: typekind
 

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -71,6 +71,7 @@
       logical,save      :: first_init=.false.
       logical,save      :: first_run=.false.
       logical,save      :: first_getlatlon=.true.
+      logical,save      :: change_wrtidate=.false.
 !
 !-----------------------------------------------------------------------
 !
@@ -173,7 +174,8 @@
       real(ESMF_KIND_R4)                      :: valueR4
       real(ESMF_KIND_R8)                      :: valueR8
 
-      integer :: attCount, axeslen, jidx, noutfile
+      integer :: attCount, axeslen, jidx, idx, noutfile
+      character(19)  :: newdate
       character(128) :: FBlist_outfilename(100), outfile_name
       character(128),dimension(:,:), allocatable    :: outfilename
       real(8), dimension(:),         allocatable    :: slat
@@ -183,7 +185,6 @@
       real(ESMF_KIND_R8)                            :: geo_lon, geo_lat
       real(ESMF_KIND_R8)                            :: lon1_r8, lat1_r8
       real(ESMF_KIND_R8)                            :: x1, y1, x, y
-      type(ESMF_Time)                               :: IO_BASETIME_IAU
       type(ESMF_TimeInterval)                       :: IAU_offsetTI
       type(ESMF_DataCopy_Flag) :: copyflag=ESMF_DATACOPY_REFERENCE
 !     real(8),parameter :: PI=3.14159265358979d0
@@ -469,8 +470,31 @@
         call ESMF_Finalize(endflag=ESMF_END_ABORT)
 
       endif
+!
+!-----------------------------------------------------------------------
+!***  get write grid component initial time from clock
+!-----------------------------------------------------------------------
+!
+      call ESMF_ClockGet(clock    =CLOCK                                &  !<-- The ESMF Clock
+                        ,startTime=wrt_int_state%IO_BASETIME            &  !<-- The Clock's starting time
+                        ,rc       =RC)
 
-
+      call ESMF_TimeGet(time=wrt_int_state%IO_BASETIME,yy=idate(1),mm=idate(2),dd=idate(3),h=idate(4), &
+                        m=idate(5),s=idate(6),rc=rc)
+!     if (lprnt) write(0,*) 'in wrt initial, io_baseline time=',idate,'rc=',rc
+      idate(7) = 1
+      wrt_int_state%idate = idate
+      wrt_int_state%fdate = idate
+      if(iau_offset > 0 ) then
+        call ESMF_TimeIntervalSet(IAU_offsetTI, h=iau_offset, rc=rc)
+        wrt_int_state%IO_BASETIME = wrt_int_state%IO_BASETIME + IAU_offsetTI
+        call ESMF_TimeGet(time=wrt_int_state%IO_BASETIME,yy=idate(1),mm=idate(2),dd=idate(3),h=idate(4), &
+                          m=idate(5),s=idate(6),rc=rc)
+        wrt_int_state%idate = idate
+        change_wrtidate = .true.
+       if (mype == lead_write_task) print *,'in wrt initial, with iau, io_baseline time=',idate,'rc=',rc
+      endif
+!
 ! Create field bundle
 !-------------------------------------------------------------------
 !
@@ -867,6 +891,17 @@
 
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
+! add iau here
+        if ( index(trim(attNameList(i)),'time:units')>0) then
+          if ( change_wrtidate ) then
+            idx = index(trim(valueS),' since ')
+            if(mype == lead_write_task) print *,'in write grid comp, time:unit=',trim(valueS)
+            write(newdate,'(I4.4,a,I2.2,a,I2.2,a,I2.2,a,I2.2,a,I2.2)') idate(1),'-',   &
+              idate(2),'-',idate(3),' ',idate(4),':',idate(5),':',idate(6)
+            valueS = valueS(1:idx+6)//newdate
+            if(mype == lead_write_task) print *,'in write grid comp, new time:unit=',trim(valueS)
+          endif
+        endif
         call ESMF_AttributeSet(wrtgrid, convention="NetCDF", purpose="FV3", &
                                name=trim(attNameList(i)), value=valueS, rc=rc)
 
@@ -1034,28 +1069,6 @@
       call ESMF_FieldBundleAdd(gridFB, (/field/), rc=rc)
 
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-!
-!-----------------------------------------------------------------------
-!***  SET THE IO_BaseTime TO THE INITIAL CLOCK TIME.
-!-----------------------------------------------------------------------
-!
-      call ESMF_ClockGet(clock    =CLOCK                                &  !<-- The ESMF Clock
-                        ,startTime=wrt_int_state%IO_BASETIME            &  !<-- The Clock's starting time
-                        ,rc       =RC)
-
-      call ESMF_TimeGet(time=wrt_int_state%IO_BASETIME,yy=idate(1),mm=idate(2),dd=idate(3),h=idate(4), &
-                        m=idate(5),s=idate(6),rc=rc)
-!     if (lprnt) write(0,*) 'in wrt initial, io_baseline time=',idate,'rc=',rc
-      idate(7) = 1
-      wrt_int_state%idate = idate
-      wrt_int_state%fdate = idate
-      if(iau_offset > 0 ) then
-        call ESMF_TimeIntervalSet(IAU_offsetTI, h=iau_offset, rc=rc)
-        IO_BASETIME_IAU = wrt_int_state%IO_BASETIME + IAU_offsetTI
-        call ESMF_TimeGet(time=IO_BASETIME_IAU,yy=idate(1),mm=idate(2),dd=idate(3),h=idate(4), &
-                          m=idate(5),s=idate(6),rc=rc)
-!       if (lprnt) write(0,*) 'in wrt initial, with iau, io_baseline time=',idate,'rc=',rc
-      endif
 !
 !-----------------------------------------------------------------------
 !***  SET THE FIRST HISTORY FILE'S TIME INDEX.
@@ -1251,9 +1264,10 @@
 !
       nf_seconds = nf_hours*3600+nf_minuteS*60+nseconds+real(nseconds_num)/real(nseconds_den)
       ! shift forecast hour by iau_offset if iau is on.
-      nf_seconds = nf_seconds - iau_offset*3600
+      !nf_seconds = nf_seconds - iau_offset*3600
       wrt_int_state%nfhour = nf_seconds/3600.
       nf_hours   = int(nf_seconds/3600.)
+      if(mype == lead_write_task) print *,'in write grid comp, nf_hours=',nf_hours
       ! if iau_offset > nf_hours, don't write out anything
       if (nf_hours < 0) return
 
@@ -1386,7 +1400,7 @@
 
               wbeg = MPI_Wtime()
               call write_netcdf(file_bundle,wrt_int_state%wrtFB(nbdl),trim(filename), &
-                               wrt_mpi_comm,wrt_int_state%mype,imo,jmo,idate,rc)
+                               wrt_mpi_comm,wrt_int_state%mype,imo,jmo,rc)
               wend = MPI_Wtime()
               if (lprnt) then
                 write(*,'(A,F10.5,A,I4.2,A,I2.2)')' netcdf      Write Time is ',wend-wbeg  &
@@ -1431,7 +1445,7 @@
 
               wbeg = MPI_Wtime()
               call write_netcdf(file_bundle,wrt_int_state%wrtFB(nbdl),trim(filename), &
-                                wrt_mpi_comm,wrt_int_state%mype,imo,jmo,idate,rc)
+                                wrt_mpi_comm,wrt_int_state%mype,imo,jmo,rc)
               wend = MPI_Wtime()
               if (mype == lead_write_task) then
                 write(*,'(A,F10.5,A,I4.2,A,I2.2)')' netcdf      Write Time is ',wend-wbeg  &

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -1386,7 +1386,7 @@
 
               wbeg = MPI_Wtime()
               call write_netcdf(file_bundle,wrt_int_state%wrtFB(nbdl),trim(filename), &
-                               wrt_mpi_comm,wrt_int_state%mype,imo,jmo,rc)
+                               wrt_mpi_comm,wrt_int_state%mype,imo,jmo,idate,rc)
               wend = MPI_Wtime()
               if (lprnt) then
                 write(*,'(A,F10.5,A,I4.2,A,I2.2)')' netcdf      Write Time is ',wend-wbeg  &
@@ -1431,7 +1431,7 @@
 
               wbeg = MPI_Wtime()
               call write_netcdf(file_bundle,wrt_int_state%wrtFB(nbdl),trim(filename), &
-                                wrt_mpi_comm,wrt_int_state%mype,imo,jmo,rc)
+                                wrt_mpi_comm,wrt_int_state%mype,imo,jmo,idate,rc)
               wend = MPI_Wtime()
               if (mype == lead_write_task) then
                 write(*,'(A,F10.5,A,I4.2,A,I2.2)')' netcdf      Write Time is ',wend-wbeg  &

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -492,7 +492,7 @@
                           m=idate(5),s=idate(6),rc=rc)
         wrt_int_state%idate = idate
         change_wrtidate = .true.
-       if (mype == lead_write_task) print *,'in wrt initial, with iau, io_baseline time=',idate,'rc=',rc
+       if (lprnt) print *,'in wrt initial, with iau, io_baseline time=',idate,'rc=',rc
       endif
 !
 ! Create field bundle
@@ -895,11 +895,11 @@
         if ( index(trim(attNameList(i)),'time:units')>0) then
           if ( change_wrtidate ) then
             idx = index(trim(valueS),' since ')
-            if(mype == lead_write_task) print *,'in write grid comp, time:unit=',trim(valueS)
+            if(lprnt) print *,'in write grid comp, time:unit=',trim(valueS)
             write(newdate,'(I4.4,a,I2.2,a,I2.2,a,I2.2,a,I2.2,a,I2.2)') idate(1),'-',   &
               idate(2),'-',idate(3),' ',idate(4),':',idate(5),':',idate(6)
             valueS = valueS(1:idx+6)//newdate
-            if(mype == lead_write_task) print *,'in write grid comp, new time:unit=',trim(valueS)
+            if(lprnt) print *,'in write grid comp, new time:unit=',trim(valueS)
           endif
         endif
         call ESMF_AttributeSet(wrtgrid, convention="NetCDF", purpose="FV3", &

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -485,6 +485,7 @@
       idate(7) = 1
       wrt_int_state%idate = idate
       wrt_int_state%fdate = idate
+! update IO-BASETIME and idate on write grid comp when IAU is enabled
       if(iau_offset > 0 ) then
         call ESMF_TimeIntervalSet(IAU_offsetTI, h=iau_offset, rc=rc)
         wrt_int_state%IO_BASETIME = wrt_int_state%IO_BASETIME + IAU_offsetTI
@@ -891,7 +892,7 @@
 
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-! add iau here
+! update the time:units when idate on write grid component is changed 
         if ( index(trim(attNameList(i)),'time:units')>0) then
           if ( change_wrtidate ) then
             idx = index(trim(valueS),' since ')
@@ -1263,8 +1264,6 @@
 !         'nseconds_num=',nseconds_num,nseconds_den,'mype=',mype
 !
       nf_seconds = nf_hours*3600+nf_minuteS*60+nseconds+real(nseconds_num)/real(nseconds_den)
-      ! shift forecast hour by iau_offset if iau is on.
-      !nf_seconds = nf_seconds - iau_offset*3600
       wrt_int_state%nfhour = nf_seconds/3600.
       nf_hours   = int(nf_seconds/3600.)
       if(mype == lead_write_task) print *,'in write grid comp, nf_hours=',nf_hours

--- a/io/post_gfs.F90
+++ b/io/post_gfs.F90
@@ -451,8 +451,7 @@ module post_gfs
       end do
 !
 ! GFS does not output PD
-!      pt    = 10000.          ! this is for 100 hPa added by Moorthi
-      pt    = 0.
+      pt    = ak5(1)
 
 ! GFS may not have model derived radar ref.
 !                        TKE
@@ -1296,7 +1295,7 @@ module post_gfs
             endif
 
             ! inst incoming sfc longwave
-            if(trim(fieldname)=='dlwsf') then
+            if(trim(fieldname)=='dlwrf') then
               !$omp parallel do private(i,j)
               do j=jsta,jend
                 do i=ista, iend
@@ -1848,6 +1847,16 @@ module post_gfs
               !$omp parallel do private(i,j)
               do j=jsta,jend
                 do i=ista, iend
+                  alwoutc(i,j) = arrayr42d(i,j)
+                enddo
+              enddo
+            endif
+
+            ! time averaged TOA clear sky outgoing LW
+            if(trim(fieldname)=='csulftoa') then
+              !$omp parallel do private(i,j)
+              do j=jsta,jend
+                do i=ista, iend
                   alwtoac(i,j) = arrayr42d(i,j)
                 enddo
               enddo
@@ -1864,7 +1873,7 @@ module post_gfs
             endif
 
             ! time averaged TOA clear sky outgoing SW
-            if(trim(fieldname)=='csusf') then
+            if(trim(fieldname)=='csusftoa') then
               !$omp parallel do private(i,j)
               do j=jsta,jend
                 do i=ista, iend
@@ -2271,7 +2280,6 @@ module post_gfs
         enddo
       end do
 
-!??? reset pint(lev=1)
 !$omp parallel do private(i,j)
       do j=jsta,jend
         do i=1,im
@@ -2282,7 +2290,7 @@ module post_gfs
 !      print *,'in setvar, pt=',pt,'ak5(lp1)=', ak5(lp1),'ak5(1)=',ak5(1)
 
 ! compute alpint
-      do l=lp1,2,-1
+      do l=lp1,1,-1
 !$omp parallel do private(i,j)
         do j=jsta,jend
           do i=1,im
@@ -2320,6 +2328,18 @@ module post_gfs
           endif
         enddo
       enddo
+
+! compute cwm for gfdlmp
+      if(  imp_physics == 11 ) then
+        do l=1,lm
+!$omp parallel do private(i,j)
+          do j=jsta,jend
+            do i=ista,iend
+              cwm(i,j,l)=qqg(i,j,l)+qqs(i,j,l)+qqr(i,j,l)+qqi(i,j,l)+qqw(i,j,l)
+            enddo
+          enddo
+        enddo
+      endif
 
 ! estimate 2m pres and convert t2m to theta
 !$omp parallel do private(i,j)

--- a/io/post_gfs.F90
+++ b/io/post_gfs.F90
@@ -28,7 +28,7 @@ module post_gfs
 !
       use ctlblk_mod, only : komax,ifhr,ifmin,modelname,datapd,fld_info, &
                              npset,grib,gocart_on,icount_calmict, jsta,  &
-                             jend,im, nsoil, ihrst
+                             jend,im, nsoil
       use gridspec_mod, only : maptype, gridtype
       use grib2_module, only : gribit2,num_pset,nrecout,first_grbtbl
 !
@@ -342,7 +342,7 @@ module post_gfs
                              tprec, tclod, trdlw, trdsw, tsrfc, tmaxmin, theat, &
                              ardlw, ardsw, asrfc, avrain, avcnvc, iSF_SURFACE_PHYSICS,&
                              td3d, idat, sdat, ifhr, ifmin, dt, nphs, dtq2, pt_tbl, &
-                             alsl, spl 
+                             alsl, spl, ihrst 
       use params_mod,  only: erad, dtr, capa, p1000
       use gridspec_mod,only: latstart, latlast, lonstart, lonlast, cenlon, cenlat
       use lookup_mod,  only: thl, plq, ptbl, ttbl, rdq, rdth, rdp, rdthe, pl,   &
@@ -652,7 +652,7 @@ module post_gfs
       idat(4)  = wrt_int_state%fdate(4)
       idat(5)  = wrt_int_state%fdate(5)
 !
-!      if(mype==0) print *,'jdate=',jdate,'idate=',idate,'sdat=',sdat
+      if(mype==0) print *,'idat=',idat,'sdat=',sdat,'ihrst=',ihrst
 !      CALL W3DIFDAT(JDATE,IDATE,0,RINC)
 !
 !      if(mype==0)print *,' rinc=',rinc
@@ -690,7 +690,7 @@ module post_gfs
         call ESMF_FieldBundleGet(wrt_int_state%wrtFB(ibdl),fieldName='land',isPresent=found, rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, file=__FILE__)) return  ! bail out
-        if(mype==0) print *,'ibdl=',ibdl,'land, found=',found
+!        if(mype==0) print *,'ibdl=',ibdl,'land, found=',found
         if (found) then
           call ESMF_FieldBundleGet(wrt_int_state%wrtFB(ibdl),'land',field=theField, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -714,7 +714,7 @@ module post_gfs
         call ESMF_FieldBundleGet(wrt_int_state%wrtFB(ibdl),'icec',isPresent=found, rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, file=__FILE__)) return  ! bail out
-        if(mype==0) print *,'ibdl=',ibdl,'ice, found=',found
+!        if(mype==0) print *,'ibdl=',ibdl,'ice, found=',found
         if (found) then
           call ESMF_FieldBundleGet(wrt_int_state%wrtFB(ibdl),'icec',field=theField, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &

--- a/io/post_gfs.F90
+++ b/io/post_gfs.F90
@@ -28,7 +28,7 @@ module post_gfs
 !
       use ctlblk_mod, only : komax,ifhr,ifmin,modelname,datapd,fld_info, &
                              npset,grib,gocart_on,icount_calmict, jsta,  &
-                             jend,im, nsoil
+                             jend,im, nsoil, ihrst
       use gridspec_mod, only : maptype, gridtype
       use grib2_module, only : gribit2,num_pset,nrecout,first_grbtbl
 !
@@ -369,7 +369,7 @@ module post_gfs
 !
       integer i, ip1, j, l, k, n, iret, ibdl, rc, kstart, kend
       integer ista,iend,fieldDimCount,gridDimCount,ncount_field
-      integer idate(8), jdate(8)
+      integer jdate(8)
       logical foundland, foundice, found
       real(4) rinc(5)
       real    tlmh,RADI,TMP,ES,TV,RHOAIR,tem,tstart,dtp
@@ -641,26 +641,16 @@ module post_gfs
       enddo
 !
 ! get inital date
-      idate    = 0
-      idate(1) = wrt_int_state%idate(1)
-      idate(2) = wrt_int_state%idate(2)
-      idate(3) = wrt_int_state%idate(3)
-      idate(5) = wrt_int_state%idate(4)
-      idate(6) = wrt_int_state%idate(5)
       sdat(1)  = wrt_int_state%idate(2)   !month
       sdat(2)  = wrt_int_state%idate(3)   !day
       sdat(3)  = wrt_int_state%idate(1)   !year
-      jdate    = 0
-      jdate(1) = wrt_int_state%fdate(1)
-      jdate(2) = wrt_int_state%fdate(2)
-      jdate(3) = wrt_int_state%fdate(3)  !jdate(4): time zone
-      jdate(5) = wrt_int_state%fdate(4)
-      jdate(6) = wrt_int_state%fdate(5)
-      idat(1)  = wrt_int_state%idate(2)
-      idat(2)  = wrt_int_state%idate(3)
-      idat(3)  = wrt_int_state%idate(1)
-      idat(4)  = IFHR
-      idat(5)  = IFMIN
+      ihrst    = wrt_int_state%idate(4)   !hour
+
+      idat(1)  = wrt_int_state%fdate(2)
+      idat(2)  = wrt_int_state%fdate(3)
+      idat(3)  = wrt_int_state%fdate(1)
+      idat(4)  = wrt_int_state%fdate(4)
+      idat(5)  = wrt_int_state%fdate(5)
 !
 !      if(mype==0) print *,'jdate=',jdate,'idate=',idate,'sdat=',sdat
 !      CALL W3DIFDAT(JDATE,IDATE,0,RINC)


### PR DESCRIPTION
This pull request has several code changes:

1) vlab #69814: post fixes for mismatched field name, computinge level 1 alpint, computing cwm for gfdlmp and initialized ihrst. 
2) vlab #69735, update netcdf time units attribute when iau_offset on write grid component
3) ufs issue #4 , Add 3D reflectivity to restart file and fix the restart reproducibility for regional fv3,
4) ufs issue #5 , resolve land mask and tsfco issue when cplflx=true
5) ufs issue #6 , Update in scale-aware TKE-based moist eddy-diffusion mass-flux scheme satmedmfvdifq
6) ufs issue #7 , fixes in gfdl_cloud_microphys.F90 to reduce the cold bias in lower atmosphere layer 

Related PR:
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/8
https://github.com/NCAR/ccpp-physics/pull/351
