### PR TITLE
ufs_public_release: update version number for CCPP, bugfix for samfdeepcnv.f

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,9 @@
 	branch = ufs_public_release
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
-	branch = ufs_public_release
+	url = https://github.com/climbfuji/ccpp-framework
+	branch = update_version_number_and_authors
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = ufs_public_release
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = update_version_number_and_authors

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,9 @@
 	branch = ufs_public_release
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/climbfuji/ccpp-framework
-	branch = update_version_number_and_authors
+	url = https://github.com/NCAR/ccpp-framework
+	branch = ufs_public_release
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = update_version_number_and_authors
+	url = https://github.com/NCAR/ccpp-physics
+	branch = ufs_public_release

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15p2" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15p2" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v16beta.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16beta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v16beta" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v16beta" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/gfsphysics/physics/samfdeepcnv.f
+++ b/gfsphysics/physics/samfdeepcnv.f
@@ -1547,22 +1547,22 @@ c
       enddo
       enddo
       do i = 1, im
-        betamn = betas
-        if(islimsk(i) == 1) betamn = betal
-        if(ntk > 0) then
-          betamx = betamn + dbeta
-          if(tkemean(i) > tkemx) then
-            beta = betamn
-          else if(tkemean(i) < tkemn) then
-            beta = betamx
-          else
-            tem = (betamx - betamn) * (tkemean(i) - tkemn)
-            beta = betamx - tem  / dtke
-          endif
-        else
-          beta = betamn
-        endif
         if(cnvflg(i)) then
+          betamn = betas
+          if(islimsk(i) == 1) betamn = betal
+          if(ntk > 0) then
+            betamx = betamn + dbeta
+            if(tkemean(i) > tkemx) then
+              beta = betamn
+            else if(tkemean(i) < tkemn) then
+              beta = betamx
+            else
+              tem = (betamx - betamn) * (tkemean(i) - tkemn)
+              beta = betamx - tem  / dtke
+            endif
+          else
+            beta = betamn
+          endif
           dz  = (sumx(i)+zi(i,1))/float(kbcon(i))
           tem = 1./float(kbcon(i))
           xlamd(i) = (1.-beta**tem)/dz


### PR DESCRIPTION
- update version number of CCPP suites from 3.0.0 to 4.0.0
- bugfix for samfdeepcnv.f to prevent crash when regression tests are run in DEBUG mode (use of uninitialized variables)