### PR TITLE
make variables using filename_base consistant in length

### DIFF
--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -32,8 +32,7 @@ module fv3gfs_cap_mod
                                     cplprint_flag,output_1st_tstep_rst,      &
                                     first_kdt                            
 
-  use module_fv3_io_def,      only: max_filename_len,                        &
-                                    num_pes_fcst,write_groups,               &
+  use module_fv3_io_def,      only: num_pes_fcst,write_groups,               &
                                     num_files, filename_base,                &
                                     wrttasks_per_group, n_group,             &
                                     lead_wrttask, last_wrttask,              &
@@ -75,7 +74,7 @@ module fv3gfs_cap_mod
 
   type(ESMF_GridComp)                         :: fcstComp
   type(ESMF_State)                            :: fcstState
-  character(len=max_filename_len+14),allocatable :: fcstItemNameList(:)
+  character(len=esmf_maxstr),allocatable :: fcstItemNameList(:)
   type(ESMF_StateItem_Flag), allocatable      :: fcstItemTypeList(:)
   type(ESMF_FieldBundle),    allocatable      :: fcstFB(:)
   integer, save                               :: FBCount

--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -32,7 +32,8 @@ module fv3gfs_cap_mod
                                     cplprint_flag,output_1st_tstep_rst,      &
                                     first_kdt                            
 
-  use module_fv3_io_def,      only: num_pes_fcst,write_groups,               &
+  use module_fv3_io_def,      only: max_filename_len,                        &
+                                    num_pes_fcst,write_groups,               &
                                     num_files, filename_base,                &
                                     wrttasks_per_group, n_group,             &
                                     lead_wrttask, last_wrttask,              &
@@ -74,7 +75,7 @@ module fv3gfs_cap_mod
 
   type(ESMF_GridComp)                         :: fcstComp
   type(ESMF_State)                            :: fcstState
-  character(len=80),         allocatable      :: fcstItemNameList(:)
+  character(len=max_filename_len+14),allocatable :: fcstItemNameList(:)
   type(ESMF_StateItem_Flag), allocatable      :: fcstItemTypeList(:)
   type(ESMF_FieldBundle),    allocatable      :: fcstFB(:)
   integer, save                               :: FBCount

--- a/io/module_fv3_io_def.F90
+++ b/io/module_fv3_io_def.F90
@@ -7,7 +7,7 @@
 !
 !------------------------------------------------------------------------
 !
-  use esmf, only    :: esmf_maxstr
+  use esmf, only     : esmf_maxstr
   implicit none
 !
   integer           :: num_pes_fcst

--- a/io/module_fv3_io_def.F90
+++ b/io/module_fv3_io_def.F90
@@ -7,23 +7,23 @@
 !
 !------------------------------------------------------------------------
 !
+  use esmf, only    :: esmf_maxstr
   implicit none
 !
-  integer,parameter :: max_filename_len=255
   integer           :: num_pes_fcst
   integer           :: wrttasks_per_group, write_groups
   integer           :: n_group
   logical           :: write_nemsioflip
   logical           :: write_fsyncflag
   integer           :: num_files
-  character(len=max_filename_len)    :: output_grid
-  character(len=max_filename_len)    :: output_file
+  character(len=esmf_maxstr)    :: output_grid
+  character(len=esmf_maxstr)    :: output_file
   integer           :: imo,jmo
   integer           :: nbdlphys
   integer           :: nsout_io, iau_offset, ideflate, nbits
   real              :: cen_lon, cen_lat, lon1, lat1, lon2, lat2, dlon, dlat
   real              :: stdlat1, stdlat2, dx, dy
-  character(len=max_filename_len),dimension(:),allocatable :: filename_base
+  character(len=esmf_maxstr),dimension(:),allocatable :: filename_base
 !
   integer,dimension(:),allocatable     :: lead_wrttask, last_wrttask
 !

--- a/io/module_fv3_io_def.F90
+++ b/io/module_fv3_io_def.F90
@@ -9,20 +9,21 @@
 !
   implicit none
 !
+  integer,parameter :: max_filename_len=255
   integer           :: num_pes_fcst
   integer           :: wrttasks_per_group, write_groups
   integer           :: n_group
   logical           :: write_nemsioflip
   logical           :: write_fsyncflag
   integer           :: num_files
-  character(255)    :: output_grid
-  character(255)    :: output_file
+  character(len=max_filename_len)    :: output_grid
+  character(len=max_filename_len)    :: output_file
   integer           :: imo,jmo
   integer           :: nbdlphys
   integer           :: nsout_io, iau_offset, ideflate, nbits
   real              :: cen_lon, cen_lat, lon1, lat1, lon2, lat2, dlon, dlat
   real              :: stdlat1, stdlat2, dx, dy
-  character(255),dimension(:),allocatable :: filename_base
+  character(len=max_filename_len),dimension(:),allocatable :: filename_base
 !
   integer,dimension(:),allocatable     :: lead_wrttask, last_wrttask
 !

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -38,8 +38,7 @@
                                       nsout => nsout_io,                        &
                                       cen_lon, cen_lat,                         &
                                       lon1, lat1, lon2, lat2, dlon, dlat,       &
-                                      stdlat1, stdlat2, dx, dy, iau_offset,     &
-                                      max_filename_len
+                                      stdlat1, stdlat2, dx, dy, iau_offset
       use module_write_nemsio, only : nemsio_first_call, write_nemsio
       use module_write_netcdf, only : write_netcdf
       use physcons,            only : pi => con_pi
@@ -78,7 +77,7 @@
       type(wrt_internal_state),pointer :: wrt_int_state                 ! The internal state pointer.
       type(ESMF_FieldBundle)           :: gridFB
       integer                          :: FBcount
-      character(len=max_filename_len+14),allocatable    :: fcstItemNameList(:)
+      character(len=esmf_maxstr),allocatable    :: fcstItemNameList(:)
 !
 !-----------------------------------------------------------------------
       REAL(KIND=8)             :: btim,btim0
@@ -1156,7 +1155,7 @@
       logical,save                          :: first=.true.
       logical,save                          :: file_first=.true.
 !
-      character(max_filename_len)            :: filename,compname,bundle_name
+      character(esmf_maxstr)            :: filename,compname,bundle_name
       character(40)                         :: cfhour, cform
       character(10)                         :: stepString
       character(80)                         :: attrValueS

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -38,7 +38,8 @@
                                       nsout => nsout_io,                        &
                                       cen_lon, cen_lat,                         &
                                       lon1, lat1, lon2, lat2, dlon, dlat,       &
-                                      stdlat1, stdlat2, dx, dy, iau_offset
+                                      stdlat1, stdlat2, dx, dy, iau_offset,     &
+                                      max_filename_len
       use module_write_nemsio, only : nemsio_first_call, write_nemsio
       use module_write_netcdf, only : write_netcdf
       use physcons,            only : pi => con_pi
@@ -56,7 +57,7 @@
 !
 !-----------------------------------------------------------------------
 !
-      integer,parameter :: filename_maxstr=255
+
       real, parameter   :: rdgas=287.04, grav=9.80
       real, parameter   :: stndrd_atmos_ps = 101325.
       real, parameter   :: stndrd_atmos_lapse = 0.0065
@@ -77,7 +78,7 @@
       type(wrt_internal_state),pointer :: wrt_int_state                 ! The internal state pointer.
       type(ESMF_FieldBundle)           :: gridFB
       integer                          :: FBcount
-      character(len=80),allocatable    :: fcstItemNameList(:)
+      character(len=max_filename_len+14),allocatable    :: fcstItemNameList(:)
 !
 !-----------------------------------------------------------------------
       REAL(KIND=8)             :: btim,btim0
@@ -1155,7 +1156,7 @@
       logical,save                          :: first=.true.
       logical,save                          :: file_first=.true.
 !
-      character(filename_maxstr)            :: filename,compname,bundle_name
+      character(max_filename_len)            :: filename,compname,bundle_name
       character(40)                         :: cfhour, cform
       character(10)                         :: stepString
       character(80)                         :: attrValueS

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -67,7 +67,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
   use esmf
 !
   use module_fv3_io_def, only:  num_pes_fcst, num_files, filename_base, nbdlphys, &
-                                iau_offset, max_filename_len
+                                iau_offset
   use module_fv3_config, only:  dt_atmos, calendar, restart_interval,             &
                                 quilting, calendar_type, cpl,                     &
                                 cplprint_flag, force_date_from_configure
@@ -189,7 +189,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     character(3) cfhour
     character(4) dateSY
     character(2) dateSM,dateSD,dateSH,dateSN,dateSS
-    character(len=max_filename_len+14) name_FB, name_FB1
+    character(len=esmf_maxstr) name_FB, name_FB1
     character(len=80) :: dateS
     real,    allocatable, dimension(:,:) :: glon_bnd, glat_bnd
     

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -67,7 +67,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
   use esmf
 !
   use module_fv3_io_def, only:  num_pes_fcst, num_files, filename_base, nbdlphys, &
-                                iau_offset
+                                iau_offset, max_filename_len
   use module_fv3_config, only:  dt_atmos, calendar, restart_interval,             &
                                 quilting, calendar_type, cpl,                     &
                                 cplprint_flag, force_date_from_configure
@@ -189,7 +189,8 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     character(3) cfhour
     character(4) dateSY
     character(2) dateSM,dateSD,dateSH,dateSN,dateSS
-    character(128) name_FB, name_FB1, dateS
+    character(len=max_filename_len+14) name_FB, name_FB1
+    character(len=80) :: dateS
     real,    allocatable, dimension(:,:) :: glon_bnd, glat_bnd
     
     character(256)                         :: gridfile


### PR DESCRIPTION
filename_base was declared with length 255, however it was then used with variables of length 80 creating an error that was difficult to track down.  This makes the length of these variables consistant, it is needed for the proper naming of CIME testcase files.  See issue https://github.com/ufs-community/ufs-mrweather-app/issues/49