### PR TITLE
Fix dependencies for fv3cap library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(
 
 if(CCPP)
 target_include_directories(fv3cap PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/ccpp/driver/mod)
+add_dependencies(fv3cap ccppdriver ccppphys)
 endif()
 target_include_directories(fv3cap PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/stochastic_physics)
 target_compile_definitions(fv3cap PRIVATE -DESMF_VERSION_MAJOR=${ESMF_VERSION_MAJOR})


### PR DESCRIPTION
From @DusanJovic-NOAA: When CCPP is used, the fv3cap library depends on the ccppdriver and ccppphys libraries. Without this change, single-threaded cmake builds fail:
```
export BUILD_JOBS=1
./build.sh
```
Tested together with https://github.com/ufs-community/ufs-weather-model/pull/33, i.e. need to update the submodule pointer for fv3atm in the ufs-weather-model PR after the fv3atm PR is merged.