### PR TITLE
Update submodule pointer for ccpp/framework and revert change to .git…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
 	branch = ufs_public_release
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	#url = https://github.com/NCAR/ccpp-framework
-	#branch = release/public-v4
-	url = https://github.com/climbfuji/ccpp-framework
-	branch = remove_libxml2
+	url = https://github.com/NCAR/ccpp-framework
+	branch = release/public-v4
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	url = https://github.com/NCAR/ccpp-physics


### PR DESCRIPTION
Follow-up to https://github.com/NOAA-EMC/fv3atm/pull/55/files: revert .gitmodules, update submodule pointer for ccpp/framework following https://github.com/NCAR/ccpp-framework/pull/261. Will need to be merged before https://github.com/ufs-community/ufs-weather-model/pull/46 (update .gitmodules etc)