### PR TITLE
Change field names

### DIFF
--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -1740,7 +1740,7 @@ end subroutine atmos_data_type_chksum
 
 ! get upward LW flux:  for sea ice covered area
 !----------------------------------------------
-          fldname = 'mean_up_lw_flx'
+          fldname = 'mean_up_lw_flx_ice'
           if (trim(impfield_name) == trim(fldname)) then
             findex  = QueryFieldList(ImportFieldsList,fldname)
             if (importFieldsValid(findex)) then
@@ -1767,7 +1767,7 @@ end subroutine atmos_data_type_chksum
 
 ! get latent heat flux:  for sea ice covered area
 !------------------------------------------------
-          fldname = 'mean_laten_heat_flx'
+          fldname = 'mean_laten_heat_flx_atm_into_ice'
           if (trim(impfield_name) == trim(fldname)) then
             findex  = QueryFieldList(ImportFieldsList,fldname)
             if (importFieldsValid(findex)) then
@@ -1787,7 +1787,7 @@ end subroutine atmos_data_type_chksum
 
 ! get sensible heat flux:  for sea ice covered area
 !--------------------------------------------------
-          fldname = 'mean_sensi_heat_flx'
+          fldname = 'mean_sensi_heat_flx_atm_into_ice'
           if (trim(impfield_name) == trim(fldname)) then
             findex  = QueryFieldList(ImportFieldsList,fldname)
             if (importFieldsValid(findex)) then
@@ -1807,7 +1807,7 @@ end subroutine atmos_data_type_chksum
 
 ! get zonal compt of momentum flux:  for sea ice covered area
 !------------------------------------------------------------
-          fldname = 'mean_zonal_moment_flx'
+          fldname = 'stress_on_air_ice_zonal'
           if (trim(impfield_name) == trim(fldname)) then
             findex  = QueryFieldList(ImportFieldsList,fldname)
             if (importFieldsValid(findex)) then
@@ -1827,7 +1827,7 @@ end subroutine atmos_data_type_chksum
 
 ! get meridional compt of momentum flux:  for sea ice covered area
 !-----------------------------------------------------------------
-          fldname = 'mean_merid_moment_flx'
+          fldname = 'stress_on_air_ice_merid'
           if (trim(impfield_name) == trim(fldname)) then
             findex  = QueryFieldList(ImportFieldsList,fldname)
             if (importFieldsValid(findex)) then

--- a/cpl/module_cap_cpl.F90
+++ b/cpl/module_cap_cpl.F90
@@ -102,7 +102,7 @@ module module_cap_cpl
                                          numLevels, numSoilLayers, numTracers,             &
                                          num_diag_sfc_emis_flux, num_diag_down_flux,       &
                                          num_diag_type_down_flux, num_diag_burn_emis_flux, &
-                                         num_diag_cmass, fieldNames, fieldTypes, fieldList, rc)
+                                         num_diag_cmass, fieldNames, fieldTypes, fieldList, tag, rc)
 
       type(ESMF_State),            intent(inout)  :: state
       type(ESMF_Grid),                intent(in)  :: grid
@@ -117,6 +117,7 @@ module module_cap_cpl
       character(len=*), dimension(:), intent(in)  :: fieldNames
       character(len=*), dimension(:), intent(in)  :: fieldTypes
       type(ESMF_Field), dimension(:), intent(out) :: fieldList
+      character(len=*),               intent(in)  :: tag !< Import or export.
       integer,                        intent(out) :: rc
 
       ! local variables
@@ -196,10 +197,15 @@ module module_cap_cpl
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
           ! -- save field
           fieldList(item) = field
+          call ESMF_LogWrite('realizeConnectedCplFields '//trim(tag)//' Field '//trim(fieldNames(item))// ' is connected ', &
+                             ESMF_LOGMSG_INFO, line=__LINE__, file=__FILE__, rc=rc)
         else
           ! remove a not connected Field from State
           call ESMF_StateRemove(state, (/trim(fieldNames(item))/), rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+          call ESMF_LogWrite('realizeConnectedCplFields '//trim(tag)//' Field '//trim(fieldNames(item))// ' is not connected ', &
+                             ESMF_LOGMSG_INFO, line=__LINE__, file=__FILE__, rc=rc)
         end if
       end do
 

--- a/cpl/module_cplfields.F90
+++ b/cpl/module_cplfields.F90
@@ -152,12 +152,12 @@ module module_cplfields
 !      "inst_ice_ir_dir_albedo                 ", &
 !      "inst_ice_vis_dif_albedo                ", &
 !      "inst_ice_vis_dir_albedo                ", &
-       "mean_up_lw_flx                         ", &
-       "mean_laten_heat_flx                    ", &
-       "mean_sensi_heat_flx                    ", &
+       "mean_up_lw_flx_ice                     ", &
+       "mean_laten_heat_flx_atm_into_ice       ", &
+       "mean_sensi_heat_flx_atm_into_ice       ", &
 !      "mean_evap_rate                         ", &
-       "mean_zonal_moment_flx                  ", &
-       "mean_merid_moment_flx                  ", &
+       "stress_on_air_ice_zonal                ", &
+       "stress_on_air_ice_merid                ", &
        "mean_ice_volume                        ", &
        "mean_snow_volume                       ", &
        "inst_tracer_up_surface_flx             ", &

--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -880,14 +880,16 @@ module fv3gfs_cap_mod
         call realizeConnectedCplFields(exportState, fcstGrid,                                                &
                                        numLevels, numSoilLayers, numTracers, num_diag_sfc_emis_flux,         &
                                        num_diag_down_flux, num_diag_type_down_flux, num_diag_burn_emis_flux, &
-                                       num_diag_cmass, exportFieldsList, exportFieldTypes, exportFields, rc)
+                                       num_diag_cmass, exportFieldsList, exportFieldTypes, exportFields,     &
+                                       'FV3 Export',rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__,  file=__FILE__)) return
 
         ! -- realize connected fields in importState
         call realizeConnectedCplFields(importState, fcstGrid,                                                &
                                        numLevels, numSoilLayers, numTracers, num_diag_sfc_emis_flux,         &
                                        num_diag_down_flux, num_diag_type_down_flux, num_diag_burn_emis_flux, &
-                                       num_diag_cmass, importFieldsList, importFieldTypes, importFields, rc)
+                                       num_diag_cmass, importFieldsList, importFieldTypes, importFields,     &
+                                       'FV3 Import',rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__,  file=__FILE__)) return
       end if
     endif

--- a/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -2866,6 +2866,12 @@ module module_physics_driver
             Coupling%dtsfc_cpl (i) = Coupling%dtsfc_cpl(i) + Coupling%dtsfci_cpl(i) * dtf
             Coupling%dqsfc_cpl (i) = Coupling%dqsfc_cpl(i) + Coupling%dqsfci_cpl(i) * dtf
 !
+          else
+          !endif ! Ocean only, NO LAKES
+            Coupling%dusfc_cpl (i) = huge
+            Coupling%dvsfc_cpl (i) = huge
+            Coupling%dtsfc_cpl (i) = huge
+            Coupling%dqsfc_cpl (i) = huge
           endif ! Ocean only, NO LAKES
         enddo
       endif


### PR DESCRIPTION
This PR includes the following changes:
* fv3atm #54: field names imported from ice have same name as the ice export field
* PET log messages are written at the realize step to document connected and unconnected fields
* When Model%cplflx is true, land fluxes exported to the mediator for coupling to the ocean are set huge
* Adds tiled field dumping of coupled fields when statewrite_flag is true