### PR TITLE
Update for submodule GFDL_atmos_cubed_sphere

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-	branch = ufs_public_release
+	url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+	branch = ufs-release/public-v1
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
Update submodule GFDL_atmos_cubed_sphere to point to GFDL's repository, branch ufs-release/public-v1. I checked the code and it was identical between the old and the new fork/branch.

Associated PRs:
https://github.com/NOAA-EMC/fv3atm/pull/60
https://github.com/ufs-community/ufs-weather-model/pull/50

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/50