### PR TITLE
release/public-v1: bug fix for threading issue in stochastic physics

### DIFF
--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -301,7 +301,9 @@ subroutine update_atmos_radiation_physics (Atmos)
 
 !--- call stochastic physics pattern generation / cellular automata
     if (IPD_Control%do_sppt .OR. IPD_Control%do_shum .OR. IPD_Control%do_skeb .OR. IPD_Control%do_sfcperts) then
-       call run_stochastic_physics(IPD_Control, IPD_Data(:)%Grid, IPD_Data(:)%Coupling, nthrds)
+       ! Threading not working
+       !call run_stochastic_physics(IPD_Control, IPD_Data(:)%Grid, IPD_Data(:)%Coupling, nthrds)
+       call run_stochastic_physics(IPD_Control, IPD_Data(:)%Grid, IPD_Data(:)%Coupling, 1)
     end if
 
     if(IPD_Control%do_ca)then

--- a/stochastic_physics/CMakeLists.txt
+++ b/stochastic_physics/CMakeLists.txt
@@ -28,7 +28,6 @@ add_library(
     ../../stochastic_physics/glats_stochy.f
     ../../stochastic_physics/sumfln_stochy.f
     ../../stochastic_physics/gozrineo_stochy.f
-    ../../stochastic_physics/num_parthds_stochy.f
     ../../stochastic_physics/get_ls_node_stochy.f
     ../../stochastic_physics/get_lats_node_a_stochy.f
     ../../stochastic_physics/setlats_a_stochy.f


### PR DESCRIPTION
The stochastic physics code hangs indefinitely when called with more than two threads. This PR and associated PRs below fix/avoid this issue by
- correcting the stochastic_physics code to use the number of threads provided by the host model, and
- call stochastic_physics with only one thread

See issue https://github.com/ufs-community/ufs-weather-model/issues/51

Since these changes do not affect the physics or the regression test results (these are created with stochastic physics turned off), the PRs listed below can be merged anytime after the code review.

Associated PRs:
https://github.com/ufs-community/ufs-weather-model/pull/55
https://github.com/NOAA-EMC/fv3atm/pull/62
https://github.com/noaa-psd/stochastic_physics/pull/13
