### PR TITLE
release/public-v1: Python 3 compatibility for CCPP prebuild scripts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
 	branch = ufs-release/public-v1
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
-	branch = release/public-v4
+	#url = https://github.com/NCAR/ccpp-framework
+	#branch = release/public-v4
+	url = https://github.com/climbfuji/ccpp-framework
+	branch = ccpp_prebuild_python3
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	url = https://github.com/NCAR/ccpp-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
 	branch = ufs-release/public-v1
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	#url = https://github.com/NCAR/ccpp-framework
-	#branch = release/public-v4
-	url = https://github.com/climbfuji/ccpp-framework
-	branch = ccpp_prebuild_python3
+	url = https://github.com/NCAR/ccpp-framework
+	branch = release/public-v4
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	url = https://github.com/NCAR/ccpp-physics


### PR DESCRIPTION
This PR only updates the submodule pointer for ccpp-framework (and temporarily .gitmodules for code review and testing) for the changes described in https://github.com/NCAR/ccpp-framework/pull/271/files.

Associated PRs:
https://github.com/NCAR/ccpp-framework/pull/271/files
https://github.com/NOAA-EMC/fv3atm/pull/88
https://github.com/ufs-community/ufs-weather-model/pull/92

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/92