### PR TITLE
CCN-IN followup bugfix

### DIFF
--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -147,7 +147,7 @@ module GFS_typedefs
 
     character(len=32), pointer :: tracer_names(:) !< tracers names to dereference tracer id
                                                   !< based on name location in array
-    character(len=65) :: fn_nml                   !< namelist filename
+    character(len=64) :: fn_nml                   !< namelist filename
     character(len=256), pointer :: input_nml_file(:) !< character string containing full namelist
                                                      !< for use with internal file reads
   end type GFS_init_type
@@ -3330,6 +3330,7 @@ module GFS_typedefs
     Model%ialb             = ialb
     Model%iems             = iems
     Model%iaer             = iaer
+    Model%iaerclm          = iaerclm
     if (iaer/1000 == 1 .or. Model%iccn == 2) then
       Model%iaerclm = .true.
       ntrcaer = ntrcaerm

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -3663,7 +3663,11 @@ module GFS_typedefs
     Model%iau_filter_increments = iau_filter_increments
     Model%iau_drymassfixer = iau_drymassfixer
     if(Model%me==0) print *,' model init,iaufhrs=',Model%iaufhrs
-
+    
+    !--- debug flag
+    Model%debug            = debug
+    Model%pre_rad          = pre_rad
+    
 !--- tracer handling
     Model%ntrac            = size(tracer_names)
 #ifdef CCPP
@@ -3783,10 +3787,6 @@ module GFS_typedefs
     Model%ncnvcld3d        = ncnvcld3d
     Model%nctp             = nctp
 
-!--- debug flag
-    Model%debug            = debug
-    Model%pre_rad          = pre_rad
-
 !--- set initial values for time varying properties
     Model%ipt              = 1
     Model%lprnt            = .false.
@@ -3825,11 +3825,6 @@ module GFS_typedefs
     !--- ps is replaced with p0. The value of p0 uses that in http://www.emc.ncep.noaa.gov/officenotes/newernotes/on461.pdf
     !--- ak/bk have been flipped from their original FV3 orientation and are defined sfc -> toa
     Model%si = (ak + bk * con_p0 - ak(Model%levr+1)) / (con_p0 - ak(Model%levr+1))
-
-    if (Model%lsm == Model%lsm_noahmp) then
-      Model%yearlen        = 365
-      Model%julian         = -9999.
-    endif
 #endif
 
 #ifndef CCPP


### PR DESCRIPTION
The following bug was discovered when propagating the MG CCN/IN changes to the CCPP SCM.

The variable iaerclm in the Model DDT (GFS_control_type) was conditionally initialized in GFS_typedefs.F90, leading to segmentation faults when the condition was not met (if the uninitialized variable somehow gets set to true by the compiler or an antecedent memory value).

Also, the character length of the fn_nml variable in the GFS_init_type DDT was different than other instances of the variable in the file. Changed the character length to 64 from 65 to be consistent. Credit to @pjpegion for finding this one.

In addition, two other minor bugfixes are included:

Model%debug is now initialized before use in GFS_typedefs.F90 and a redundant code block initializing variables for NoahMP was deleted.

This PR was initiated on the request of @climbfuji following successful CCPP SCM testing.