### PR TITLE
Bugfix for Intel 18 on wcoss_cray, remove support for legacy Intel compilers in CCPP gmake build

### DIFF
--- a/ccpp/build_ccpp.sh
+++ b/ccpp/build_ccpp.sh
@@ -144,9 +144,6 @@ else
 fi
 if [[ "${MAKE_OPT}" == *"INTEL16=Y"* ]]; then
   CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -DLEGACY_INTEL=ON"
-elif [[ "${MACHINE_ID}" == "wcoss_cray" ]]; then
-  echo "In ccpp_build.sh: flag to cmake that wcoss_cray uses Intel 16"
-  CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -DLEGACY_INTEL=ON"
 else
   CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -DLEGACY_INTEL=OFF"
 fi

--- a/ccpp/build_ccpp.sh
+++ b/ccpp/build_ccpp.sh
@@ -29,7 +29,6 @@ function usage   {
   echo "                                   SUITES=ABC,XYZ  (comma-separated list of CCPP suites; "
   echo "                                                    corresponding filenames: suite_ABC.xml. ...)"
   echo "                                   MULTI_GASES=Y/N (default N)"
-  echo "                                   INTEL16=Y/N     (default N)"
   echo "           clean_before [optional] can be 'YES' (default) or 'NO'"
   echo "           clean_after  [optional] can be 'YES' (default) or 'NO'"
   exit 1
@@ -142,11 +141,9 @@ if [[ "${MAKE_OPT}" == *"MULTI_GASES=Y"* ]]; then
 else
   CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -DMULTI_GASES=OFF"
 fi
-if [[ "${MAKE_OPT}" == *"INTEL16=Y"* ]]; then
-  CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -DLEGACY_INTEL=ON"
-else
-  CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -DLEGACY_INTEL=OFF"
-fi
+
+# Flag to cmake that modern Intel compilers are used
+CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -DLEGACY_INTEL=OFF"
 
 # Generate additional CCPP cmake flags depending on machine / compiler
 if [[ "${MACHINE_ID}" == "macosx.gnu" ]]; then


### PR DESCRIPTION
This PR and https://github.com/ufs-community/ufs-weather-model/pull/104 address issue https://github.com/ufs-community/ufs-weather-model/issues/103. This PR:

- bugfix in `ccpp/build_ccpp.sh`: remove hardcoded flag for Intel 16 on wcoss_cray, remove support for legay Intel compiler switch (only ever used manually on gaea)
