### PR TITLE
Add a separate array for internal ice temperature

### DIFF
--- a/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -13,7 +13,7 @@ module GFS_diagnostics
                                 GFS_stateout_type, GFS_sfcprop_type,  &
                                 GFS_coupling_type, GFS_grid_type,     &
                                 GFS_tbd_type,      GFS_cldprop_type,  &
-                                GFS_radtend_type,  GFS_diag_type,  &
+                                GFS_radtend_type,  GFS_diag_type,     &
                                 GFS_init_type
   implicit none
   private
@@ -2777,6 +2777,22 @@ module GFS_diagnostics
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var2 => Sfcprop(nb)%tsfc(:)
     enddo
+
+    if (Model%frac_grid) then
+      do num = 1,Model%kice
+        write (xtra,'(i1)') num
+        idx = idx + 1
+        ExtDiag(idx)%axes = 2
+        ExtDiag(idx)%name = 'tiice'//trim(xtra)
+        ExtDiag(idx)%desc = 'internal ice temperature layer ' // trim(xtra)
+        ExtDiag(idx)%unit = 'K'
+        ExtDiag(idx)%mod_name = 'gfs_sfc'
+        allocate (ExtDiag(idx)%data(nblks))
+        do nb = 1,nblks
+          ExtDiag(idx)%data(nb)%var2 => sfcprop(nb)%tiice(:,num)
+        enddo
+      enddo
+    end if
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -3746,12 +3746,6 @@ module GFS_typedefs
     Model%frac_grid        = frac_grid
     Model%frac_grid_off    = frac_grid_off
     Model%ignore_lake      = ignore_lake
-#ifdef CCPP
-    if (Model%frac_grid) then
-      write(0,*) "ERROR: CCPP has not been tested with fractional landmask turned on"
-!     stop
-    end if
-#endif
     Model%min_lakeice      = min_lakeice
     Model%min_seaice       = min_seaice
     Model%min_lake_height  = min_lake_height

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -236,6 +236,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: tsfco  (:)   => null()  !< sst in K
     real (kind=kind_phys), pointer :: tsfcl  (:)   => null()  !< surface land temperature in K
     real (kind=kind_phys), pointer :: tisfc  (:)   => null()  !< surface temperature over ice fraction
+    real (kind=kind_phys), pointer :: tiice(:,:)   => null()  !< internal ice temperature
     real (kind=kind_phys), pointer :: snowd  (:)   => null()  !< snow depth water equivalent in mm ; same as snwdph
     real (kind=kind_phys), pointer :: zorl   (:)   => null()  !< composite surface roughness in cm
     real (kind=kind_phys), pointer :: zorlo  (:)   => null()  !< ocean surface roughness in cm
@@ -753,6 +754,7 @@ module GFS_typedefs
     integer              :: lsm_noahmp=2    !< flag for NOAH land surface model
     integer              :: lsm_ruc=3       !< flag for RUC land surface model
     integer              :: lsoil           !< number of soil layers
+    integer              :: kice=2          !< number of layers in sice
 #ifdef CCPP
     integer              :: lsoil_lsm       !< number of soil layers internal to land surface model
     integer              :: lsnow_lsm       !< maximum number of snow layers internal to land surface model
@@ -2151,6 +2153,7 @@ module GFS_typedefs
     allocate (Sfcprop%tsfco    (IM))
     allocate (Sfcprop%tsfcl    (IM))
     allocate (Sfcprop%tisfc    (IM))
+    allocate (Sfcprop%tiice    (IM,Model%kice))
     allocate (Sfcprop%snowd    (IM))
     allocate (Sfcprop%zorl     (IM))
     allocate (Sfcprop%zorlo    (IM))
@@ -2167,6 +2170,7 @@ module GFS_typedefs
     Sfcprop%tsfco     = clear_val
     Sfcprop%tsfcl     = clear_val
     Sfcprop%tisfc     = clear_val
+    Sfcprop%tiice     = clear_val
     Sfcprop%snowd     = clear_val
     Sfcprop%zorl      = clear_val
     Sfcprop%zorlo     = clear_val

--- a/gfsphysics/GFS_layer/GFS_typedefs.meta
+++ b/gfsphysics/GFS_layer/GFS_typedefs.meta
@@ -492,6 +492,13 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
+[tiice]
+  standard_name = internal_ice_temperature
+  long_name = sea ice internal temperature
+  units = K
+  dimensions = (horizontal_dimension,ice_vertical_dimension)
+  type = real
+  kind = kind_phys
 [snowd]
   standard_name = surface_snow_thickness_water_equivalent
   long_name = water equivalent snow depth
@@ -2764,6 +2771,12 @@
   standard_name = flag_for_ruc_land_surface_scheme
   long_name = flag for RUC land surface model
   units = flag
+  dimensions = ()
+  type = integer
+[kice]
+  standard_name = ice_vertical_dimension
+  long_name = vertical loop extent for ice levels, start at 1
+  units = count
   dimensions = ()
   type = integer
 [lsoil]

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -79,7 +79,7 @@ module FV3GFS_io_mod
  
   !--- GFDL FMS restart containers
   character(len=32),    allocatable,         dimension(:)       :: oro_name2, sfc_name2, sfc_name3
-  real(kind=kind_phys), allocatable, target, dimension(:,:,:)   :: oro_var2, sfc_var2, phy_var2
+  real(kind=kind_phys), allocatable, target, dimension(:,:,:)   :: oro_var2, sfc_var2, phy_var2, sfc_var3ice
   real(kind=kind_phys), allocatable, target, dimension(:,:,:,:) :: sfc_var3, phy_var3
   !--- Noah MP restart containers
   real(kind=kind_phys), allocatable, target, dimension(:,:,:,:) :: sfc_var3sn,sfc_var3eq,sfc_var3zn
@@ -89,7 +89,7 @@ module FV3GFS_io_mod
   integer :: tot_diag_idx = 0
   integer :: total_outputlevel = 0
   integer :: isco,ieco,jsco,jeco,levo,num_axes_phys
-  integer :: fhzero, ncld, nsoil, imp_physics
+  integer :: fhzero, ncld, nsoil, imp_physics, k
   real(4) :: dtp
   logical :: lprecip_accu
   character(len=64)  :: Sprecip_accu
@@ -192,9 +192,9 @@ module FV3GFS_io_mod
    ntr = size(IPD_Data(1)%Statein%qgrs,3)
 
    if(Model%lsm == Model%lsm_noahmp) then
-     nsfcprop2d = 149  
+     nsfcprop2d = 151  
    else
-     nsfcprop2d = 100
+     nsfcprop2d = 102
    endif
 
    allocate (temp2d(isc:iec,jsc:jec,nsfcprop2d+Model%ntot3d+Model%nctp))
@@ -318,8 +318,10 @@ module FV3GFS_io_mod
        temp2d(i,j,82) = IPD_Data(nb)%Radtend%sfcflw(ix)%upfx0
        temp2d(i,j,83) = IPD_Data(nb)%Radtend%sfcflw(ix)%dnfxc
        temp2d(i,j,84) = IPD_Data(nb)%Radtend%sfcflw(ix)%dnfx0
+       temp2d(i,j,85) = IPD_Data(nb)%Sfcprop%tiice(ix,1)
+       temp2d(i,j,86) = IPD_Data(nb)%Sfcprop%tiice(ix,2)
 
-        idx_opt = 85 
+       idx_opt = 87 
        if (Model%lsm == Model%lsm_noahmp) then
         temp2d(i,j,idx_opt) = IPD_Data(nb)%Sfcprop%snowxy(ix)
         temp2d(i,j,idx_opt+1) = IPD_Data(nb)%Sfcprop%tvxy(ix)
@@ -371,7 +373,7 @@ module FV3GFS_io_mod
         temp2d(i,j,idx_opt+46) = IPD_Data(nb)%Sfcprop%zsnsoxy(ix,2)
         temp2d(i,j,idx_opt+47) = IPD_Data(nb)%Sfcprop%zsnsoxy(ix,3)
         temp2d(i,j,idx_opt+48) = IPD_Data(nb)%Sfcprop%zsnsoxy(ix,4)
-        idx_opt = 134
+        idx_opt = 136
        endif
 
        if (Model%nstf_name(1) > 0) then
@@ -644,9 +646,9 @@ module FV3GFS_io_mod
       !--- allocate the various containers needed for restarts
 #ifdef CCPP
       allocate(sfc_name2(nvar_s2m+nvar_s2o+nvar_s2mp+nvar_s2r))
-      allocate(sfc_name3(nvar_s3+nvar_s3mp))
+      allocate(sfc_name3(0:nvar_s3+nvar_s3mp))
 
-      allocate(sfc_var2(nx,ny,nvar_s2m+nvar_s2o+nvar_s2mp+nvar_s2r))
+      allocate(sfc_var2(nx,ny,nvar_s2m+nvar_s2o+nvar_s2mp+nvar_s2r),sfc_var3ice(nx,ny,Model%kice))
       if (Model%lsm == Model%lsm_noah .or. Model%lsm == Model%lsm_noahmp .or. (.not.warm_start)) then
         allocate(sfc_var3(nx,ny,Model%lsoil,nvar_s3))
       else if (Model%lsm == Model%lsm_ruc) then
@@ -654,13 +656,14 @@ module FV3GFS_io_mod
       end if
 #else
       allocate(sfc_name2(nvar_s2m+nvar_s2o+nvar_s2mp))
-      allocate(sfc_name3(nvar_s3+nvar_s3mp))
+      allocate(sfc_name3(0:nvar_s3+nvar_s3mp))
 
       allocate(sfc_var2(nx,ny,nvar_s2m+nvar_s2o+nvar_s2mp))
       allocate(sfc_var3(nx,ny,Model%lsoil,nvar_s3))
 #endif
       sfc_var2   = -9999._kind_phys
       sfc_var3   = -9999._kind_phys
+      sfc_var3ice= -9999._kind_phys
 !
       if (Model%lsm == Model%lsm_noahmp) then
         allocate(sfc_var3sn(nx,ny,-2:0,4:6))
@@ -706,8 +709,8 @@ module FV3GFS_io_mod
       !--- variables below here are optional
       sfc_name2(32) = 'sncovr'
       if(Model%cplflx) then
-        sfc_name2(33) = 'tsfcl'   !temp on land portion of a cell
-        sfc_name2(34) = 'zorll'   !zorl on land portion of a cell
+        sfc_name2(33) = 'tsfcl' !temp on land portion of a cell
+        sfc_name2(34) = 'zorll' !zorl on land portion of a cell
       end if
 
       !--- NSSTM inputs only needed when (nstf_name(1) > 0) .and. (nstf_name(2)) == 0) 
@@ -854,6 +857,12 @@ module FV3GFS_io_mod
     endif
 #endif
       !--- register the 3D fields
+    if (Model%frac_grid) then
+      sfc_name3(0) = 'tiice'
+      var3_p => sfc_var3ice(:,:,:)
+      id_restart = register_restart_field(Sfc_restart, fn_srf, sfc_name3(0), var3_p, domain=fv_domain, mandatory=.false.)
+    end if
+ 
     do num = 1,nvar_s3
       var3_p => sfc_var3(:,:,:,num)
       id_restart = register_restart_field(Sfc_restart, fn_srf, sfc_name3(num), var3_p, domain=fv_domain)
@@ -1076,6 +1085,10 @@ module FV3GFS_io_mod
             Sfcprop(nb)%flag_frsoil(ix,lsoil) = sfc_var3(i,j,lsoil,5) !--- flag_frsoil
           enddo
         end if
+
+        do k = 1,Model%kice
+          Sfcprop(nb)%tiice(ix,k)= sfc_var3ice(i,j,k)   !--- internal ice temp
+        enddo
 #else
         !--- 3D variables
         do lsoil = 1,Model%lsoil
@@ -1144,7 +1157,7 @@ module FV3GFS_io_mod
       enddo
     endif
 
-    if(Model%cplflx .or. Model%frac_grid) then
+    if (Model%cplflx .or. Model%frac_grid) then
       if (nint(sfc_var2(1,1,33)) == -9999) then
         if (Model%me == Model%master ) call mpp_error(NOTE, 'gfs_driver::surface_props_input - computing tsfcl')
         do nb = 1, Atm_block%nblks
@@ -1162,6 +1175,16 @@ module FV3GFS_io_mod
           enddo
         enddo
       endif
+    endif
+
+    if (nint(sfc_var3ice(1,1,1)) == -9999) then
+      if (Model%me == Model%master ) call mpp_error(NOTE, 'gfs_driver::surface_props_input - computing tiice')
+      do nb = 1, Atm_block%nblks
+        do ix = 1, Atm_block%blksz(nb)
+          Sfcprop(nb)%tiice(ix,1) = Sfcprop(nb)%stc(ix,1) !--- initialize internal ice temp from soil temp at layer 1
+          Sfcprop(nb)%tiice(ix,2) = Sfcprop(nb)%stc(ix,2) !--- initialize internal ice temp from soil temp at layer 2
+        enddo
+      enddo
     endif
 
 !#endif
@@ -1550,7 +1573,7 @@ module FV3GFS_io_mod
       !--- allocate the various containers needed for restarts
 #ifdef CCPP
       allocate(sfc_name2(nvar2m+nvar2o+nvar2mp+nvar2r))
-      allocate(sfc_name3(nvar3+nvar3mp))
+      allocate(sfc_name3(0:nvar3+nvar3mp))
       allocate(sfc_var2(nx,ny,nvar2m+nvar2o+nvar2mp+nvar2r))
       if (Model%lsm == Model%lsm_noah .or. Model%lsm == Model%lsm_noahmp) then
         allocate(sfc_var3(nx,ny,Model%lsoil,nvar3))
@@ -1559,7 +1582,7 @@ module FV3GFS_io_mod
       endif
 #else
       allocate(sfc_name2(nvar2m+nvar2o+nvar2mp))
-      allocate(sfc_name3(nvar3+nvar3mp))
+      allocate(sfc_name3(0:nvar3+nvar3mp))
       allocate(sfc_var2(nx,ny,nvar2m+nvar2o+nvar2mp))
       allocate(sfc_var3(nx,ny,Model%lsoil,nvar3))
 #endif
@@ -1751,6 +1774,12 @@ module FV3GFS_io_mod
 #endif
 
       !--- register the 3D fields
+      if (Model%frac_grid) then
+        sfc_name3(0) = 'tiice'
+        var3_p => sfc_var3ice(:,:,:)
+        id_restart = register_restart_field(Sfc_restart, fn_srf, sfc_name3(0), var3_p, domain=fv_domain)
+      end if
+
       do num = 1,nvar3
         var3_p => sfc_var3(:,:,:,num)
         id_restart = register_restart_field(Sfc_restart, fn_srf, sfc_name3(num), var3_p, domain=fv_domain)
@@ -1890,6 +1919,10 @@ module FV3GFS_io_mod
         endif
 
 #ifdef CCPP
+        do k = 1,Model%kice
+          sfc_var3ice(i,j,k) = Sfcprop(nb)%tiice(ix,k) !--- internal ice temperature
+        end do
+
         if (Model%lsm == Model%lsm_noah .or. Model%lsm == Model%lsm_noahmp) then
           !--- 3D variables
           do lsoil = 1,Model%lsoil

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -593,7 +593,6 @@ module FV3GFS_io_mod
     call mpp_error(NOTE,'reading topographic/orographic information from INPUT/oro_data.tile*.nc')
     call restore_state(Oro_restart)
 
-    Model%frac_grid = .false.
     !--- copy data into GFS containers
     do nb = 1, Atm_block%nblks
       !--- 2D variables
@@ -631,8 +630,6 @@ module FV3GFS_io_mod
       Model%frac_grid = .false.
     elseif (Model%frac_grid_off) then
       Model%frac_grid = .false.
-    else
-      Model%frac_grid = .true.
     endif
 
     if (Model%me == Model%master ) write(0,*)' resetting Model%frac_grid=',Model%frac_grid


### PR DESCRIPTION
Sfcprop%stc is currently used to store temperatures for both soil and internal ice. In the case of fractional grid, both surface types can exist at a single grid point. Thus we introduced a separate array called "tiice" to store internal ice temperature. "tiice" will be added to phyf*nc output only when frac_grid=T. 