### PR TITLE
release/public-v1: bugfixes for no_nsst suites

### DIFF
--- a/ccpp/suites/suite_FV3_GFS_v15p2_no_nsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2_no_nsst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15p2_no_nsst" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15p2_no_nsst" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v16beta_no_nsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16beta_no_nsst.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v16beta_no_nsst" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v16beta_no_nsst" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">


### PR DESCRIPTION
Bugfixes for no_nsst suites: change line endings to unix, set correct version number

These bugfixes will be applied to the "develop" branch in forthcoming PRs.

Associated PRs:

https://github.com/NOAA-EMC/fv3atm/pull/110
https://github.com/ufs-community/ufs-weather-model/pull/118

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/118.