### PR TITLE
Remove cheyenne.pgi from CCPP config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
-	branch = master
+	#url = https://github.com/NCAR/ccpp-framework
+	#branch = master
+	url = https://github.com/climbfuji/ccpp-framework
+	branch = fix_decoding_errors_stampede
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	url = https://github.com/NCAR/ccpp-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	#url = https://github.com/NCAR/ccpp-framework
-	#branch = master
-	url = https://github.com/climbfuji/ccpp-framework
-	branch = fix_decoding_errors_stampede
+	url = https://github.com/NCAR/ccpp-framework
+	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	url = https://github.com/NCAR/ccpp-physics

--- a/ccpp/build_ccpp.sh
+++ b/ccpp/build_ccpp.sh
@@ -6,7 +6,7 @@ set -eu
 # List of valid/tested machines
 VALID_MACHINES=( wcoss_cray wcoss_dell_p3 gaea.intel jet.intel \
                  hera.intel hera.gnu orion.intel \
-                 cheyenne.intel cheyenne.intel-impi cheyenne.gnu cheyenne.pgi endeavor.intel \
+                 cheyenne.intel cheyenne.intel-impi cheyenne.gnu endeavor.intel \
                  stampede.intel supermuc_phase2.intel macosx.gnu \
                  linux.intel linux.gnu linux.pgi )
 

--- a/ccpp/set_compilers.sh
+++ b/ccpp/set_compilers.sh
@@ -74,14 +74,6 @@ case "$MACHINE_ID" in
             export F77=mpif77
             export F90=mpif90
             ;;
-        cheyenne.pgi)
-            export CPP="mpicc -E"
-            export CC=mpicc
-            export CXX=mpicxx
-            export FC=mpif90
-            export F77=mpif77
-            export F90=mpif90
-            ;;
         endeavor.intel)
             export CC=mpiicc
             export CXX=mpiicpc


### PR DESCRIPTION
This PR:
- remove `cheyenne.pgi` from CCPP config (`ccpp/set_compilers.sh`, `ccpp/build_ccpp.sh`)

Associated PRs:
https://github.com/NCAR/ccpp-framework/pull/295
https://github.com/NOAA-EMC/fv3atm/pull/117
https://github.com/NOAA-EMC/NEMS/pull/63
https://github.com/ufs-community/ufs-weather-model/pull/139

For regression testing information, see below https://github.com/ufs-community/ufs-weather-model/pull/139.