### PR TITLE
release/public-v1: ccpp-framework updates (Python 3 bugfix)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
 	branch = ufs-release/public-v1
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	#url = https://github.com/NCAR/ccpp-framework
-	#branch = release/public-v4
-	url = https://github.com/climbfuji/ccpp-framework
-	branch = ufs_public_release_v1_additional_python3_bugfixes
+	url = https://github.com/NCAR/ccpp-framework
+	branch = release/public-v4
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	url = https://github.com/NCAR/ccpp-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
 	branch = ufs-release/public-v1
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
-	branch = release/public-v4
+	#url = https://github.com/NCAR/ccpp-framework
+	#branch = release/public-v4
+	url = https://github.com/climbfuji/ccpp-framework
+	branch = ufs_public_release_v1_additional_python3_bugfixes
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	url = https://github.com/NCAR/ccpp-physics


### PR DESCRIPTION
This PR only changes the submodule pointer for ccpp-framework.

Associated PRs:
https://github.com/NCAR/ccpp-framework/pull/303
https://github.com/NOAA-EMC/fv3atm/pull/130
https://github.com/ufs-community/ufs-weather-model/pull/149

For regression testing information, see below https://github.com/ufs-community/ufs-weather-model/pull/149.