### PR TITLE
Update for GFDL_atmos_cubed_sphere (dycore GNU bugfix)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-	branch = dev/emc
+	#url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+	#branch = dev/emc
+	url = https://github.com/XiaqiongZhou-NOAA/GFDL_atmos_cubed_sphere
+	branch = emc_gnu
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	#url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-	#branch = dev/emc
-	url = https://github.com/XiaqiongZhou-NOAA/GFDL_atmos_cubed_sphere
-	branch = emc_gnu
+	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
This PR only updates the submodule pointer for GFDL_atmos_cubed_sphere.

Associated PRs:
https://github.com/ufs-community/ufs-weather-model/pull/151/files
https://github.com/NOAA-EMC/fv3atm/pull/131
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/22

For regression testing information, see below https://github.com/ufs-community/ufs-weather-model/pull/151/files.