### PR TITLE
Bugfix for regional runs when dycore is compiled in double precision

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	#url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-	#branch = dev/emc
-	url = https://github.com/climbfuji/GFDL_atmos_cubed_sphere
-	branch = regional_mpibugfix
+	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-	branch = dev/emc
+	#url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+	#branch = dev/emc
+	url = https://github.com/climbfuji/GFDL_atmos_cubed_sphere
+	branch = regional_mpibugfix
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
This PR only updates the submodule pointer for GFDL_atmos_cubed_sphere to fix issue https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/issues/24.

Associated PRs:
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/25
https://github.com/NOAA-EMC/fv3atm/pull/133
https://github.com/ufs-community/ufs-weather-model/pull/155

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/155.