### PR TITLE
Initialize ice fluxes to be huge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = master
+	url = https://github.com/shansun6/ccpp-physics
+	branch = iceflx_ini_20200710

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -2627,10 +2627,10 @@ module GFS_typedefs
       allocate (Coupling%hsnoin_cpl   (IM))
 
       Coupling%slimskin_cpl = clear_val
-      Coupling%dusfcin_cpl  = clear_val
-      Coupling%dvsfcin_cpl  = clear_val
-      Coupling%dtsfcin_cpl  = clear_val
-      Coupling%dqsfcin_cpl  = clear_val
+      Coupling%dusfcin_cpl  = huge
+      Coupling%dvsfcin_cpl  = huge
+      Coupling%dtsfcin_cpl  = huge
+      Coupling%dqsfcin_cpl  = huge
       Coupling%ulwsfcin_cpl = clear_val
       Coupling%tseain_cpl   = clear_val
       Coupling%tisfcin_cpl  = clear_val


### PR DESCRIPTION
When ice flux is huge (undefined in CICE yet) in the 1st time step cold run, use PBL-calculated ice fluxes instead. This will change results in the coupled model only. Passed regression tests for standalone FV3.

This refers to FV3 issue #142 and CCPP-physics issue #472.

@junwang-noaa @SMoorthi-emc  