### PR TITLE
Remove cheyenne.intel-impi and supermuc_phase2.intel build targets

### DIFF
--- a/ccpp/build_ccpp.sh
+++ b/ccpp/build_ccpp.sh
@@ -6,8 +6,9 @@ set -eu
 # List of valid/tested machines
 VALID_MACHINES=( wcoss_cray wcoss_dell_p3 gaea.intel jet.intel \
                  hera.intel hera.gnu orion.intel \
-                 cheyenne.intel cheyenne.intel-impi cheyenne.gnu endeavor.intel \
-                 stampede.intel supermuc_phase2.intel macosx.gnu \
+                 cheyenne.intel cheyenne.gnu \
+                 endeavor.intel stampede.intel \
+                 macosx.gnu \
                  linux.intel linux.gnu linux.pgi )
 
 ###################################################################################################

--- a/ccpp/set_compilers.sh
+++ b/ccpp/set_compilers.sh
@@ -60,13 +60,6 @@ case "$MACHINE_ID" in
             export F77=mpif77
             export F90=mpif90
             ;;
-        cheyenne.intel-impi)
-            export CC=mpiicc
-            export CXX=mpiicpc
-            export FC=mpiifort
-            export F77=mpiifort
-            export F90=mpiifort
-            ;;
         cheyenne.gnu)
             export CC=mpicc
             export CXX=mpicxx
@@ -87,13 +80,6 @@ case "$MACHINE_ID" in
             export FC=mpif90
             export F77=mpif77
             export F90=mpif90
-            ;;
-        supermuc_phase2.intel)
-            export CC=mpiicc
-            export CXX=mpiicpc
-            export FC=mpiifort
-            export F77=mpiifort
-            export F90=mpiifort
             ;;
         macosx.gnu)
             # set in generic modulefile


### PR DESCRIPTION
As the title says. Note that the affected files are for the gnumake build - if we had transitioned entirely to cmake, we wouldn't need to maintain these files any longer.

Associated PRs:
https://github.com/NOAA-EMC/fv3atm/pull/150
https://github.com/NOAA-EMC/NEMS/pull/74
https://github.com/ufs-community/ufs-weather-model/pull/177