### PR TITLE
Cldfra

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = master
+	url = https://github.com/ericaligo-NOAA/ccpp-physics.git 
+	branch = cldfra 

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/ericaligo-NOAA/ccpp-physics.git 
-	branch = cldfra 
+	url =  https://github.com/NCAR/ccpp-physics.git 
+	branch = master 

--- a/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -1939,6 +1939,17 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'cldfra'
+    ExtDiag(idx)%desc = 'Instantaneous 3D Cloud Fraction'
+    ExtDiag(idx)%unit = 'frac'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%cldfra(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'cnvw'
     ExtDiag(idx)%desc = 'subgrid scale convective cloud water'
     ExtDiag(idx)%unit = 'kg/kg'

--- a/gfsphysics/GFS_layer/GFS_restart.F90
+++ b/gfsphysics/GFS_layer/GFS_restart.F90
@@ -117,7 +117,6 @@ module GFS_restart
 #endif
 
     Restart%num3d = Model%ntot3d
-    print *,'aligo1 Restart%num3d,Model%ntot3d',Restart%num3d,Model%ntot3d
     if(Model%lrefres) then
        Restart%num3d = Model%ntot3d+1
     endif

--- a/gfsphysics/GFS_layer/GFS_restart.F90
+++ b/gfsphysics/GFS_layer/GFS_restart.F90
@@ -117,6 +117,7 @@ module GFS_restart
 #endif
 
     Restart%num3d = Model%ntot3d
+    print *,'aligo1 Restart%num3d,Model%ntot3d',Restart%num3d,Model%ntot3d
     if(Model%lrefres) then
        Restart%num3d = Model%ntot3d+1
     endif
@@ -263,8 +264,12 @@ module GFS_restart
       enddo
     endif
 #ifdef CCPP
+    if (Model%lrefres) then
+       num = Model%ntot3d+1
+    else
+       num = Model%ntot3d
+    endif
     !--- RAP/HRRR-specific variables, 3D
-
     ! GF
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
       num = num + 1

--- a/gfsphysics/GFS_layer/GFS_restart.F90
+++ b/gfsphysics/GFS_layer/GFS_restart.F90
@@ -264,7 +264,6 @@ module GFS_restart
     endif
 #ifdef CCPP
     !--- RAP/HRRR-specific variables, 3D
-    num = Model%ntot3d
 
     ! GF
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1549,7 +1549,9 @@ module GFS_typedefs
 #ifdef CCPP
     real (kind=kind_phys), pointer :: TRAIN  (:,:)   => null()  !< accumulated stratiform T tendency (K s-1)
 #endif
-
+#ifdef CCPP
+    real (kind=kind_phys), pointer :: cldfra  (:,:)   => null()  !< instantaneous 3D cloud fraction
+#endif
     !--- MP quantities for 3D diagnositics 
     real (kind=kind_phys), pointer :: refl_10cm(:,:) => null()  !< instantaneous refl_10cm 
 !
@@ -5593,6 +5595,10 @@ module GFS_typedefs
     end if
 #endif
 
+#ifdef CCPP
+    allocate (Diag%cldfra     (IM,Model%levs))
+#endif
+
     allocate (Diag%ca_deep  (IM))
     allocate (Diag%ca_turb  (IM))
     allocate (Diag%ca_shal  (IM))
@@ -5910,6 +5916,10 @@ module GFS_typedefs
        Diag%TRAIN      = zero
     end if
 #endif
+#ifdef CCPP
+    Diag%cldfra      = zero
+#endif
+
     Diag%totprcpb   = zero
     Diag%cnvprcpb   = zero
     Diag%toticeb    = zero

--- a/gfsphysics/GFS_layer/GFS_typedefs.meta
+++ b/gfsphysics/GFS_layer/GFS_typedefs.meta
@@ -5979,6 +5979,13 @@
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys
+[cldfra]
+  standard_name = instantaneous_3d_cloud_fraction
+  long_name = instantaneous 3D cloud fraction for all MPs
+  units = frac
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
 [ndust]
   standard_name = number_of_dust_bins_for_diagnostics
   long_name = number of dust bins for diagnostics


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Diagnostic cldfra array outputs 3D instantaneous cloud fractions.  Works with WSM6, Thompson and GFDL mp schemes.  No results changed.

UPDATE:  Provided a bug fix to GFS_restart.F90 with an if condition added in the ifdef CCPP block to test for reflectivity flag. RTs have been updated. Test run in 3-km FV3 LAM was successful and plots looked good.


### Issue(s) addressed

https://github.com/ufs-community/ufs-weather-model/issues/158
https://github.com/NOAA-EMC/fv3atm/pull/154
https://github.com/NCAR/ccpp-physics/pull/484

## Testing

How were these changes tested?  
Tested on hera with the SAR configuration.  Evaluated fields from run with Thompson microphyics and GFDL microphysics. 
Full RTs performed on hera.

## Dependencies
FV3
ccpp/physics
