### PR TITLE
Esmf810bs21

### DIFF
--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -682,8 +682,11 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
      diag_time = Time - real_to_time_type(mod(int((first_kdt - 1)*dt_phys/3600.),6)*3600.0)
    endif
    if (Atmos%iau_offset > zero) then
-     diag_time = Atmos%Time_init
-     diag_time_fhzero = Atmos%Time
+     call get_time (Atmos%Time - Atmos%Time_init, sec)
+     if (sec < Atmos%iau_offset*3600) then
+       diag_time = Atmos%Time_init
+       diag_time_fhzero = Atmos%Time
+     endif
    endif
 
    !---- print version number to logfile ----

--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -1147,7 +1147,7 @@ module fv3gfs_cap_mod
          enddo
          call ESMF_VMEpochExit(rc=rc)
          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
+         timerh = mpi_wtime()
          if (mype == 0 .or. mype == lead_wrttask(n_group)) print *,'aft fieldbundleregrid,na=',na,  &
            ' time=', timerh- timerhi
 

--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -247,7 +247,7 @@ module fv3gfs_cap_mod
     integer,dimension(:), allocatable      :: petList, originPetList, targetPetList
     character(20)                          :: cwrtcomp
     character(160)                         :: msg
-    integer                                :: isrctermprocessing
+    integer                                :: isrcTermProcessing
 
     character(len=*),parameter  :: subname='(fv3_cap:InitializeAdvertise)'
     integer nfmout, nfsout , nfmout_hf, nfsout_hf
@@ -344,8 +344,13 @@ module fv3gfs_cap_mod
                                    label ='app_domain:',rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
+      CALL ESMF_ConfigGetAttribute(config=CF,value=isrcTermProcessing, default=0, &
+                                   label ='isrcTermProcessing:',rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
       if(mype == 0) print *,'af nems config,quilting=',quilting,'write_groups=', &
-        write_groups,wrttasks_per_group,'calendar=',trim(calendar),'calendar_type=',calendar_type
+        write_groups,wrttasks_per_group,'calendar=',trim(calendar),'calendar_type=',calendar_type, &
+        'isrcTermProcessing=', isrcTermProcessing
 !
       CALL ESMF_ConfigGetAttribute(config=CF,value=num_files, &
                                    label ='num_files:',rc=rc)
@@ -733,11 +738,10 @@ module fv3gfs_cap_mod
 ! this is a Store() for the first wrtComp -> must do the Store()
             timewri = mpi_wtime()
 
-            isrctermprocessing = 1
             call ESMF_FieldBundleRegridStore(fcstFB(j), wrtFB(j,i),                                    &
                                              regridMethod=regridmethod, routehandle=routehandle(j,i),  &
                                              unmappedaction=ESMF_UNMAPPEDACTION_IGNORE,                &
-                                             srcTermProcessing=isrctermprocessing, rc=rc)
+                                             srcTermProcessing=isrcTermProcessing, rc=rc)
 
 !           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             if (rc /= ESMF_SUCCESS) then
@@ -799,6 +803,9 @@ module fv3gfs_cap_mod
           alarm_output_hf_ring = startTime + (nhf+1_ESMF_KIND_I4)*output_interval_hf
           if(iau_offset > 0) then
             alarm_output_hf_ring = startTime + IAU_offsetTI
+            if( currtime > alarm_output_hf_ring ) then
+              alarm_output_hf_ring = startTime + (nhf+1_ESMF_KIND_I4)*output_interval_hf
+            endif
           endif
           alarm_output_hf = ESMF_AlarmCreate(clock_fv3,name='ALARM_OUTPUT_HF',  &
                                              ringTime =alarm_output_hf_ring,    &
@@ -819,6 +826,9 @@ module fv3gfs_cap_mod
         alarm_output_ring = startTime + (nrg+1_ESMF_KIND_I4) * output_interval
         if(iau_offset > 0) then
           alarm_output_ring = startTime + IAU_offsetTI
+          if( currtime > alarm_output_ring ) then
+            alarm_output_ring = startTime + (nrg+1_ESMF_KIND_I4) * output_interval
+          endif
         endif
       endif
 
@@ -1120,6 +1130,10 @@ module fv3gfs_cap_mod
 
          timerhi = mpi_wtime()
 !         if (mype == 0 .or. mype == lead_wrttask(1)) print *,' aft fcst run alarm is on, na=',na,'mype=',mype
+         
+         call ESMF_VMEpochEnter(epoch=ESMF_VMEpoch_Buffer, rc=rc)
+         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
          do i=1, FBCount
 !
 ! get fcst fieldbundle
@@ -1127,13 +1141,15 @@ module fv3gfs_cap_mod
            call ESMF_FieldBundleRegrid(fcstFB(i), wrtFB(i,n_group),         &
                                        routehandle=routehandle(i, n_group), &
                                        termorderflag=(/ESMF_TERMORDER_SRCSEQ/), rc=rc)
-           timerh = mpi_wtime()
            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 !
 !end FBcount
-          enddo
-!       if (mype == 0 .or. mype == lead_wrttask(n_group)) print *,'aft fieldbundleregrid,na=',na,  &
-!       ' time=', timerh- timerhi
+         enddo
+         call ESMF_VMEpochExit(rc=rc)
+         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+         if (mype == 0 .or. mype == lead_wrttask(n_group)) print *,'aft fieldbundleregrid,na=',na,  &
+           ' time=', timerh- timerhi
 
 !      if(mype==0 .or. mype==lead_wrttask(1))  print *,'on wrt bf wrt run, na=',na
           call ESMF_LogWrite('Model Advance: before wrtcomp run ', ESMF_LOGMSG_INFO, rc=rc)
@@ -1410,17 +1426,20 @@ module fv3gfs_cap_mod
        output: IF(lalarm .or. na==first_kdt ) then
 
          timerhi = mpi_wtime()
+         call ESMF_VMEpochEnter(epoch=ESMF_VMEpoch_Buffer, rc=rc)
+         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
          do i=1, FBCount
 !
 ! get fcst fieldbundle
 !
            call ESMF_FieldBundleRegrid(fcstFB(i), wrtFB(i,n_group),    &
                                        routehandle=routehandle(i, n_group), rc=rc)
-           timerh = mpi_wtime()
            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 !
 !end FBcount
          enddo
+         call ESMF_VMEpochExit(rc=rc)
+         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
          if (mype == 0 .or. mype == lead_wrttask(n_group)) print *,'aft fieldbundleregrid,na=',na,  &
                                                                    ' time=', timerh- timerhi
 


### PR DESCRIPTION
## Description

Add GFSv16 performance tuning to fv3 develop branch 
The baseline results will change because the isrctermprocessing is changed from 1 to 0, this will allow a more balanced regridding between fcst grid and write grid.


### Issue(s) addressed

https://github.com/ufs-community/ufs-weather-model/issues/142

## Testing

How were these changes tested?  
The RT test has been run on dell, cray, orion, is now running on cray. 

What compilers / HPCs was it tested with?  
Intel compiler. 
Are the changes covered by regression tests?
Yes.


## Dependencies

[NEMS PR #76](https://github.com/NOAA-EMC/NEMS/pull/76) 
[ufs-weather-model #188 ](https://github.com/ufs-community/ufs-weather-model/pull/188)

[this fv3atm PR #160](https://github.com/NOAA-EMC/fv3atm/pull/160) needs to be committed before ufs-weather-model PR #188