### PR TITLE
Fix linker problem in gfsphysics/CMakeLists.txt by removing physics/physparam.f from IPD sources

### DIFF
--- a/gfsphysics/CMakeLists.txt
+++ b/gfsphysics/CMakeLists.txt
@@ -17,7 +17,6 @@ endif()
 set(CCPP_SOURCES
     physics/mersenne_twister.f
     physics/namelist_soilveg.f
-    physics/physparam.f
     physics/set_soilveg.f
 
     physics/noahmp_tables.f90


### PR DESCRIPTION
###  Description

For some reason, compiling `physparam.f` for both IPD and CCPP no longer works on macOS and leads to errors when linking the application (symbols declared twice). This used to work in the past, but is of course not recommended and also not necessary (it was necessary for the hybrid CCPP build that we maintained for some time).

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/191

## Dependencies

This PR is a dependency for https://github.com/ufs-community/ufs-weather-model/pull/191