### PR TITLE
release/public-v1: update ccpp-physics (fix unicode errors)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,5 @@
 	path = ccpp/physics
 	url = https://github.com/NCAR/ccpp-physics
 	branch = release/public-v4
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = fix_unicode_errors

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,5 +10,3 @@
 	path = ccpp/physics
 	url = https://github.com/NCAR/ccpp-physics
 	branch = release/public-v4
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = fix_unicode_errors


### PR DESCRIPTION
## Description

For a description of the problem and how it is solved, see https://github.com/NCAR/ccpp-physics/pull/499. This PR only updates the submodule pointer for ccpp-physics.

Note that we will need to retag fv3atm v1.1.0 after this PR is merged.

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/204

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/499
https://github.com/NOAA-EMC/fv3atm/pull/172
https://github.com/ufs-community/ufs-weather-model/pull/204