### PR TITLE
Updates required for ESMF 8.1bs30 and above

### DIFF
--- a/cpl/module_cap_cpl.F90
+++ b/cpl/module_cap_cpl.F90
@@ -13,7 +13,7 @@ module module_cap_cpl
   public clock_cplIntval
   public realizeConnectedInternCplField
   public realizeConnectedCplFields
-  public diagnose_cplFields
+  public Dump_cplFields
 !
   contains
 
@@ -139,50 +139,45 @@ module module_cap_cpl
         isConnected = NUOPC_IsConnected(state, fieldName=trim(fieldNames(item)), rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
         if (isConnected) then
+          call ESMF_StateGet(state, field=field, itemName=trim(fieldNames(item)), rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+          call ESMF_FieldEmptySet(field, grid=grid, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
           select case (fieldTypes(item))
             case ('l','layer')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/numLevels/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('i','interface')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/numLevels+1/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('t','tracer')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1, 1/), ungriddedUBound=(/numLevels, numTracers/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('u','tracer_up_flux')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/num_diag_sfc_emis_flux/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('d','tracer_down_flx')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1, 1/),        &
                                        ungriddedUBound=(/num_diag_down_flux, num_diag_type_down_flux/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('b','tracer_anth_biom_emission')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/num_diag_burn_emis_flux/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('c','tracer_column_mass_density')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/num_diag_cmass/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('s','surface')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)), rc=rc)
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('g','soil')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/numSoilLayers/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case default
@@ -193,11 +188,9 @@ module module_cap_cpl
           end select
           call NUOPC_Realize(state, field=field, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
           ! -- zero out field 
           call ESMF_FieldFill(field, dataFillScheme="const", const1=0._ESMF_KIND_R8, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
           ! -- save field
           fieldList(item) = field
           call ESMF_LogWrite('realizeConnectedCplFields '//trim(state_tag)//' Field '//trim(fieldNames(item))  &
@@ -215,14 +208,13 @@ module module_cap_cpl
 
   !-----------------------------------------------------------------------------
 
-    subroutine diagnose_cplFields(gcomp, importState, exportstate, clock_fv3,    &
-         statewrite_flag, stdiagnose_flag, state_tag, timestr)
+    subroutine Dump_cplFields(gcomp, importState, exportstate, clock_fv3,    &
+         statewrite_flag, state_tag, timestr)
 
       type(ESMF_GridComp), intent(in)       :: gcomp
       type(ESMF_State)                      :: importState, exportstate
       type(ESMF_Clock),intent(in)           :: clock_fv3
       logical, intent(in)                   :: statewrite_flag
-      integer, intent(in)                   :: stdiagnose_flag
       character(len=*),         intent(in)  :: state_tag                        !< Import or export.
       character(len=*),         intent(in)  :: timestr                          !< Import or export.
       integer                               :: timeslice = 1 
@@ -244,39 +236,32 @@ module module_cap_cpl
                            unit=nuopcMsg)
 !      call ESMF_LogWrite(nuopcMsg, ESMF_LOGMSG_INFO)
 
-      if(trim(state_tag) .eq. 'import')then 
-        call ESMF_GridCompGet(gcomp, importState=importState, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+      ! Dumping Fields out
+      if (statewrite_flag) then
 
-        if(stdiagnose_flag > 0)then
-         call state_diagnose(importState, ':IS', rc=rc)
-        end if
-
-        ! Dump Fields out
-        if (statewrite_flag) then
-          write(filename,'(A)') 'fv3_cap_import_'//trim(timestr)//'_'
+        if(trim(state_tag) .eq. 'import')then 
+          call ESMF_GridCompGet(gcomp, importState=importState, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+          ! replace with tiled field dumps
+          !call ESMFPP_RegridWriteState(importState, "fv3_cap_import_", timeslice, rc=rc)
+          write(filename,'(a,a,a)') 'fv3_cap_import_'//trim(timestr)//'_'
           call State_RWFields_tiles(importState,trim(filename), timeslice, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
         end if
-      end if
 
-      if(trim(state_tag) .eq. 'export')then
-        call ESMF_GridCompGet(gcomp, exportState=exportState, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-        if(stdiagnose_flag > 0)then
-         call state_diagnose(exportState, ':ES', rc=rc)
-        end if
-
-        ! Dump Fields out
-        if (statewrite_flag) then
-          write(filename,'(A)') 'fv3_cap_export_'//trim(timestr)//'_'
+        if(trim(state_tag) .eq. 'export')then
+          call ESMF_GridCompGet(gcomp, exportState=exportState, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+          ! replace with tiled field dumps
+          !call ESMFPP_RegridWriteState(exportState, "fv3_cap_export_", timeslice, rc=rc)
+          write(filename,'(a,a,a)') 'fv3_cap_export_'//trim(timestr)//'_'
           call State_RWFields_tiles(exportState,trim(filename), timeslice, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
         end if
-      end if
 
-    end subroutine diagnose_cplFields
+      endif
+!
+    end subroutine Dump_cplFields
 
   !-----------------------------------------------------------------------------
 
@@ -464,79 +449,6 @@ module module_cap_cpl
       !ESMF_LOGMSG_INFO, rc=rc)
 
     end subroutine State_RWFields_tiles
-
-  !-----------------------------------------------------------------------------
-
-  subroutine state_diagnose(State,string, rc)
-    ! ----------------------------------------------
-    ! Diagnose status of state
-    ! ----------------------------------------------
-    type(ESMF_State), intent(inout) :: State
-    character(len=*), intent(in), optional :: string
-    integer, intent(out), optional  :: rc
-
-    ! local variables
-    integer                       :: i,j,n
-    integer                       :: itemCount
-    character(len=64) ,pointer    :: itemNameList(:)
-    character(len=64)             :: lstring
-    character(len=256)            :: tmpstr
-
-    type(ESMF_Field)            :: lfield
-    type(ESMF_StateItem_Flag)   :: itemType
-    real(ESMF_KIND_R8), pointer :: dataPtr2d(:,:)
-    real(ESMF_KIND_R8), pointer :: dataPtr3d(:,:,:)
-    integer                     :: lrc, dimCount
-    character(len=*),parameter  :: subname='(FV3: state_diagnose)'
-
-    lstring = ''
-    if (present(string)) then
-       lstring = trim(string)
-    endif
-
-    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
-
-    call ESMF_StateGet(State, itemCount=itemCount, rc=lrc)
-    if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-    allocate(itemNameList(itemCount))
-   
-    call ESMF_StateGet(State, itemNameList=itemNameList, rc=lrc)
-    if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-   
-    do n = 1, itemCount
-       call ESMF_StateGet(State, itemName=trim(itemNameList(n)), itemType=itemType, rc=lrc)
-       if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-   
-     if(itemType == ESMF_STATEITEM_FIELD)then
-       call ESMF_StateGet(State, itemName=trim(itemNameList(n)), field=lfield, rc=lrc)
-       if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-  
-       call ESMF_FieldGet(lfield, dimCount=dimcount, rc=lrc)
-       if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-       
-       if(dimcount == 2)then
-         call ESMF_FieldGet(lfield, farrayPtr=dataPtr2d, rc=lrc)
-         if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-   
-         write(tmpstr,'(A,3g14.7)') trim(subname)//' '//trim(lstring)//':'//trim(itemNameList(n))//'  ', &
-           minval(dataPtr2d),maxval(dataPtr2d),sum(dataPtr2d)
-         call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=lrc)
-       else
-         call ESMF_FieldGet(lfield, farrayPtr=dataPtr3d, rc=lrc)
-         if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-  
-         write(tmpstr,'(A,3g14.7)') trim(subname)//' '//trim(lstring)//':'//trim(itemNameList(n))//'  ', &
-           minval(dataPtr3d),maxval(dataPtr3d),sum(dataPtr3d)
-         call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=lrc)
-       end if
-     end if
-    enddo
-     deallocate(itemNameList)
-
-    if (present(rc)) rc = lrc
-    call ESMF_LogWrite(subname//' exit', ESMF_LOGMSG_INFO)
-
-  end subroutine state_diagnose
 
   !-----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Minor updates to fv3 required for ESMF 8.1bs30 and above.  The changes are backward compatible to prior snapshots.  ESMF 8.1bs30 includes a major optimization to the ESMF_StateReconcile function and should improve coupled model initialization times.  This PR should enable a timing comparison of 8.1bs29 against 8.1bs30 for GFSv16 configuration as well as S2S configuration.

### Issue(s) addressed

No related issues.

## Testing

RT executed on Hera:
cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt

using modules
`esmf/8.1.0bs29` and
`esmf/8.1.0bs30`
from (`module use /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles`)

Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Yes

The ufs-weather-model regression tests were not run.  No baseline changes expected.


## Dependencies

None
