### PR TITLE
Updates required for ESMF 81bs30 including StateReconcile optimization

### DIFF
--- a/cpl/module_cap_cpl.F90
+++ b/cpl/module_cap_cpl.F90
@@ -139,50 +139,45 @@ module module_cap_cpl
         isConnected = NUOPC_IsConnected(state, fieldName=trim(fieldNames(item)), rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
         if (isConnected) then
+          call ESMF_StateGet(state, field=field, itemName=trim(fieldNames(item)), rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+          call ESMF_FieldEmptySet(field, grid=grid, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
           select case (fieldTypes(item))
             case ('l','layer')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/numLevels/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('i','interface')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/numLevels+1/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('t','tracer')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1, 1/), ungriddedUBound=(/numLevels, numTracers/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('u','tracer_up_flux')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/num_diag_sfc_emis_flux/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('d','tracer_down_flx')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1, 1/),        &
                                        ungriddedUBound=(/num_diag_down_flux, num_diag_type_down_flux/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('b','tracer_anth_biom_emission')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/num_diag_burn_emis_flux/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('c','tracer_column_mass_density')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/num_diag_cmass/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('s','surface')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)), rc=rc)
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case ('g','soil')
-              field = ESMF_FieldCreate(grid, typekind=ESMF_TYPEKIND_R8, &
-                                       name=trim(fieldNames(item)),     &
+              call ESMF_FieldEmptyComplete(field, typekind=ESMF_TYPEKIND_R8, &
                                        ungriddedLBound=(/1/), ungriddedUBound=(/numSoilLayers/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
             case default


### PR DESCRIPTION
## Description

Minor updates to fv3 required for ESMF 8.1bs30 and above.  The changes are backward compatible to prior snapshots.  ESMF 8.1bs30 includes a major optimization to the ESMF_StateReconcile function and should improve coupled model initialization times.  This PR should enable a timing comparison of 8.1bs29 against 8.1bs30 for GFSv16 configuration as well as S2S configuration.  This should at least partially address scaling issues seen in GFSv16.

### Issue(s) addressed

No related issues.

## Testing

RT executed on Hera:
cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt

using modules
`esmf/8.1.0bs29` and
`esmf/8.1.0bs30`
from (`module use /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles`)

Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Yes

The ufs-weather-model regression tests were not run.  No baseline changes expected.


## Dependencies

None