### PR TITLE
GFS.v16: using NCO installed upp lib on wcoss

### DIFF
--- a/io/makefile
+++ b/io/makefile
@@ -66,7 +66,7 @@ $(LIBRARY): $(OBJS)
 FV3GFS_io.o: FV3GFS_io.F90
 	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) $(ESMF_INC) -c FV3GFS_io.F90
 post_nems_routines.o: post_nems_routines.F90
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -I$(POST_INC) -c post_nems_routines.F90
+	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -I$(UPP_INC) -c post_nems_routines.F90
 module_write_nemsio.o: module_write_nemsio.F90
 	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) $(ESMF_INC) $(NEMSIOINC) -c module_write_nemsio.F90
 module_write_netcdf.o: module_write_netcdf.F90
@@ -78,7 +78,7 @@ module_write_internal_state.o: module_write_internal_state.F90
 module_wrt_grid_comp.o: module_wrt_grid_comp.F90
 	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) $(ESMF_INC) -c module_wrt_grid_comp.F90
 post_gfs.o: post_gfs.F90
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) $(ESMF_INC) -I$(POST_INC) -c post_gfs.F90
+	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) $(ESMF_INC) -I$(UPP_INC) -c post_gfs.F90
 post_gfs_stub.o: post_gfs_stub.F90
 	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) $(ESMF_INC) -c post_gfs_stub.F90
 


### PR DESCRIPTION
## Description

NCO changed post lib name to upp lib on wcoss for GFS.v16 implementation. Model needs to use UPP related lib name and module include path.


## Testing

Code has been tested with fv3_parallel test case.


## Dependencies

[ufs-weather-model PR#212](https://github.com/ufs-community/ufs-weather-model/pull/212)