### PR TITLE
jedi-ufs with ccpp-physics submodule update (contains #201)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = master
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = master
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = update_to_head_of_master_and_rrtmgp_update

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = master
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = update_to_head_of_master_and_rrtmgp_update
+	url = https://github.com/NCAR/ccpp-physics
+	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if(CCPP)
   add_dependencies(ccppphys ccpp)
   target_include_directories(fv3dycore PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/ccpp/framework/src
                                                ${CMAKE_CURRENT_BINARY_DIR}/ccpp/driver)
-  target_link_libraries(ccppphys PRIVATE sp::sp_d
+  target_link_libraries(ccppphys PUBLIC sp::sp_d
                                          w3nco::w3nco_d)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,8 @@ if(CCPP)
   add_dependencies(ccppphys ccpp)
   target_include_directories(fv3dycore PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/ccpp/framework/src
                                                ${CMAKE_CURRENT_BINARY_DIR}/ccpp/driver)
-  target_link_libraries(ccppphys PRIVATE sp::sp_d
-                                         w3nco::w3nco_d)
+  target_link_libraries(ccppphys PUBLIC sp::sp_d
+                                        w3nco::w3nco_d)
 endif()
 
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if(CCPP)
   add_dependencies(ccppphys ccpp)
   target_include_directories(fv3dycore PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/ccpp/framework/src
                                                ${CMAKE_CURRENT_BINARY_DIR}/ccpp/driver)
-  target_link_libraries(ccppphys PRIVATE sp::sp_d
+  target_link_libraries(ccppphys PUBLIC sp::sp_d
                                          w3nco::w3nco_d)
 endif()
 
@@ -189,7 +189,7 @@ target_link_libraries(fv3atm PUBLIC nemsio::nemsio
                                     esmf)
 
 if(INLINE_POST)
-  target_link_libraries(fv3atm PUBLIC upp::upp)
+  target_link_libraries(fv3atm PUBLIC nceppost::nceppost)
 endif()
 
 if(OpenMP_Fortran_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,7 @@ target_link_libraries(fv3atm PUBLIC nemsio::nemsio
                                     esmf)
 
 if(INLINE_POST)
-  target_link_libraries(fv3atm PUBLIC nceppost::nceppost)
+  target_link_libraries(fv3atm PUBLIC upp::upp)
 endif()
 
 if(OpenMP_Fortran_FOUND)


### PR DESCRIPTION
## Description

This PR contains #201 and a submodule pointer update for ccpp-physics (with no impact on fv3atm or the ufs-weather-model regression tests). The ccpp-physics submodule pointer update includes an update to a file used by the single column model only, and an update of the RRTMGP submodule pointer to allow running RRTMGP with 127 levels.

The commit history shows only the changes in this PR.

See #201 for more details on the Jedi UFS changes from @mark-a-potts .

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/295

## Dependencies

https://github.com/ufs-community/ufs-weather-model/pull/295
https://github.com/NOAA-EMC/fv3atm/pull/211 (includes #211)
https://github.com/NOAA-EMC/NEMS/pull/85
https://github.com/NCAR/ccpp-physics/pull/530 (includes https://github.com/NCAR/ccpp-physics/pull/523)
