### PR TITLE
Final-final GFS v16 updates / restart reproducibility bugfixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = master
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = final_gfsv16_changes
+	url = https://github.com/NCAR/ccpp-physics
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = master
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = master
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = final_gfsv16_changes

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -962,11 +962,11 @@ module FV3GFS_io_mod
     endif
 #endif
       !--- register the 3D fields
-    if (Model%frac_grid) then
+!   if (Model%frac_grid) then
       sfc_name3(0) = 'tiice'
       var3_p => sfc_var3ice(:,:,:)
       id_restart = register_restart_field(Sfc_restart, fn_srf, sfc_name3(0), var3_p, domain=fv_domain, mandatory=.false.)
-    end if
+!   end if
  
     do num = 1,nvar_s3
       var3_p => sfc_var3(:,:,:,num)
@@ -1994,11 +1994,11 @@ module FV3GFS_io_mod
 #endif
 
       !--- register the 3D fields
-      if (Model%frac_grid) then
+!     if (Model%frac_grid) then
         sfc_name3(0) = 'tiice'
         var3_p => sfc_var3ice(:,:,:)
         id_restart = register_restart_field(Sfc_restart, fn_srf, sfc_name3(0), var3_p, domain=fv_domain)
-      endif
+!     endif
 
       do num = 1,nvar3
         var3_p => sfc_var3(:,:,:,num)


### PR DESCRIPTION
## Description

This PR:
- updates the submodule pointer for ccpp-physics for the final-final (!) GFS v16 physics updates
- fixes a bug in `io/FV3GFS_io.F90` to obtain restart reproducibility for uncoupled and coupled runs - contributed by @SMoorthi-emc

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/325

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/531
https://github.com/NOAA-EMC/fv3atm/pull/212
https://github.com/ufs-community/ufs-weather-model/pull/325