### PR TITLE
Update submodule pointers for ccpp-framework (ccpp_prebuild bugfix) and ccpp-physics (RRTMGP GFDL-MP bugfix)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,13 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
-	branch = master
+	#url = https://github.com/NCAR/ccpp-framework
+	#branch = master
+	url = https://github.com/pjpegion/ccpp-framework
+	branch = prebuild_bugfix
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = master
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = master
+	url = https://github.com/dustinswales/ccpp-physics
+	branch = master-ncar-d1be22d

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,13 +4,9 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	#url = https://github.com/NCAR/ccpp-framework
-	#branch = master
-	url = https://github.com/pjpegion/ccpp-framework
-	branch = prebuild_bugfix
+	url = https://github.com/NCAR/ccpp-framework
+	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = master
-	url = https://github.com/dustinswales/ccpp-physics
-	branch = master-ncar-d1be22d
+	url = https://github.com/NCAR/ccpp-physics
+	branch = master


### PR DESCRIPTION
## Description

This PR only updates the submodule pointers for ccpp-framework and ccpp-physics for the changes described in
https://github.com/NCAR/ccpp-framework/pull/343 and https://github.com/NCAR/ccpp-physics/pull/536.

### Issue(s) addressed

n/a

## Testing

See MISSING (ufs-weather-model PR from Dusan, to come)

## Dependencies

https://github.com/NCAR/ccpp-framework/pull/343
https://github.com/NCAR/ccpp-physics/pull/536
MISSING ufs-weather-model PR from Dusan
