### PR TITLE
release/public-v2: bugfixes for GNU 10 crashes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = release/public-v5
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url =  https://github.com/NCAR/ccpp-physics
-	#branch = release/public-v5
-	url =  https://github.com/climbfuji/ccpp-physics
-	branch = release_public_v2_gnu10_crashes
+	url =  https://github.com/NCAR/ccpp-physics
+	branch = release/public-v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = release/public-v5
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url =  https://github.com/NCAR/ccpp-physics
-	branch = release/public-v5
+	#url =  https://github.com/NCAR/ccpp-physics
+	#branch = release/public-v5
+	url =  https://github.com/climbfuji/ccpp-physics
+	branch = release_public_v2_gnu10_crashes

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -2743,6 +2743,8 @@ module GFS_typedefs
    !-- cellular automata
     allocate (Coupling%condition(IM))
     allocate (Coupling%vfact_ca(Model%levs))
+    Coupling%condition = clear_val
+    Coupling%vfact_ca  = clear_val
     if (Model%do_ca) then
       allocate (Coupling%ca1      (IM))
       allocate (Coupling%ca2      (IM))
@@ -2752,7 +2754,6 @@ module GFS_typedefs
       allocate (Coupling%ca_shal  (IM))
       allocate (Coupling%ca_rad   (IM))
       allocate (Coupling%ca_micro (IM))
-      Coupling%vfact_ca = clear_val
       Coupling%ca1       = clear_val
       Coupling%ca2       = clear_val
       Coupling%ca3       = clear_val
@@ -2760,8 +2761,8 @@ module GFS_typedefs
       Coupling%ca_turb   = clear_val
       Coupling%ca_shal   = clear_val
       Coupling%ca_rad    = clear_val
-      Coupling%ca_micro  = clear_val   
-      Coupling%condition = clear_val
+      Coupling%ca_micro  = clear_val
+
     endif
 
     ! -- GSDCHEM coupling options


### PR DESCRIPTION
## Description

This PR updates the submodule pointer for ccpp-physics to fix crashes of the model run with GNU 10. It also contains a bugfix to properly initialize two arrays in `GFS_typedefs.F90`.

### Issue(s) addressed

n/a

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/355.

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/540
https://github.com/NOAA-EMC/fv3atm/pull/221
https://github.com/ufs-community/ufs-weather-model/pull/355