### PR TITLE
add radiation_clouds_thompson_dependency in ccpp physics 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = master
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = radiation_clouds_thompson_dependency

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = radiation_clouds_thompson_dependency
+	url = https://github.com/NCAR/ccpp-physics
+	branch = master


### PR DESCRIPTION
## Description

There is a ccpp physics fix to add the dependency of module_radiation_clouds on module_mp_thompson to metadata. 

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- ccpp physics issue [#545](https://github.com/NCAR/ccpp-physics/issues/545)

## Testing

So far test was done on hera. Will be done on all the supported platforms.

## Dependencies

Related PRs:
ccpp physics [PR#546](https://github.com/NCAR/ccpp-physics/pull/546)
ufs-weather-model PR [#345](https://github.com/ufs-community/ufs-weather-model/pull/345)