### PR TITLE
production/GFS.v16: reduce initialization time on atm wave connector

### DIFF
--- a/cpl/module_cplfields.F90
+++ b/cpl/module_cplfields.F90
@@ -16,85 +16,8 @@ module module_cplfields
   integer,          public, parameter :: NexportFields = 71
   type(ESMF_Field), target, public    :: exportFields(NexportFields)
   character(len=*), public, parameter :: exportFieldsList(NexportFields) = (/ &
-       "inst_pres_interface                      ", &
-       "inst_pres_levels                         ", &
-       "inst_geop_interface                      ", &
-       "inst_geop_levels                         ", &
-       "inst_temp_levels                         ", &
-       "inst_zonal_wind_levels                   ", &
-       "inst_merid_wind_levels                   ", &
-       "inst_omega_levels                        ", &
-       "inst_tracer_mass_frac                    ", &
-       "soil_type                                ", &
-       "inst_pbl_height                          ", &
-       "surface_cell_area                        ", &
-       "inst_convective_rainfall_amount          ", &
-       "inst_exchange_coefficient_heat_levels    ", &
-       "inst_spec_humid_conv_tendency_levels     ", &
-       "inst_friction_velocity                   ", &
-       "inst_rainfall_amount                     ", &
-       "inst_soil_moisture_content               ", &
-       "inst_up_sensi_heat_flx                   ", &
-       "inst_lwe_snow_thickness                  ", &
-       "vegetation_type                          ", &
-       "inst_vegetation_area_frac                ", &
-       "inst_surface_roughness                   ", &
-       "mean_zonal_moment_flx                    ", &
-       "mean_merid_moment_flx                    ", &
-       "mean_sensi_heat_flx                      ", &
-       "mean_laten_heat_flx                      ", &
-       "mean_down_lw_flx                         ", &
-       "mean_down_sw_flx                         ", &
-       "mean_prec_rate                           ", &
-       "inst_zonal_moment_flx                    ", &
-       "inst_merid_moment_flx                    ", &
-       "inst_sensi_heat_flx                      ", &
-       "inst_laten_heat_flx                      ", &
-       "inst_down_lw_flx                         ", &
-       "inst_down_sw_flx                         ", &
-       "inst_temp_height2m                       ", &
-       "inst_spec_humid_height2m                 ", &
        "inst_zonal_wind_height10m                ", &
-       "inst_merid_wind_height10m                ", &
-       "inst_temp_height_surface                 ", &
-       "inst_pres_height_surface                 ", &
-       "inst_surface_height                      ", &
-       "mean_net_lw_flx                          ", &
-       "mean_net_sw_flx                          ", &
-       "inst_net_lw_flx                          ", &
-       "inst_net_sw_flx                          ", &
-       "mean_down_sw_ir_dir_flx                  ", &
-       "mean_down_sw_ir_dif_flx                  ", &
-       "mean_down_sw_vis_dir_flx                 ", &
-       "mean_down_sw_vis_dif_flx                 ", &
-       "inst_down_sw_ir_dir_flx                  ", &
-       "inst_down_sw_ir_dif_flx                  ", &
-       "inst_down_sw_vis_dir_flx                 ", &
-       "inst_down_sw_vis_dif_flx                 ", &
-       "mean_net_sw_ir_dir_flx                   ", &
-       "mean_net_sw_ir_dif_flx                   ", &
-       "mean_net_sw_vis_dir_flx                  ", &
-       "mean_net_sw_vis_dif_flx                  ", &
-       "inst_net_sw_ir_dir_flx                   ", &
-       "inst_net_sw_ir_dif_flx                   ", &
-       "inst_net_sw_vis_dir_flx                  ", &
-       "inst_net_sw_vis_dif_flx                  ", &
-       "inst_land_sea_mask                       ", &
-       "inst_temp_height_lowest                  ", &
-       "inst_spec_humid_height_lowest            ", &
-       "inst_zonal_wind_height_lowest            ", &
-       "inst_merid_wind_height_lowest            ", &
-       "inst_pres_height_lowest                  ", &
-       "inst_height_lowest                       ", &
-       "mean_fprec_rate                          " &
-!      "northward_wind_neutral                   ", &
-!      "eastward_wind_neutral                    ", &
-!      "upward_wind_neutral                      ", &
-!      "temp_neutral                             ", &
-!      "O_Density                                ", &
-!      "O2_Density                               ", &
-!      "N2_Density                               ", &
-!      "height                                   "  &
+       "inst_merid_wind_height10m                "
   /)
   ! Field types should be provided for proper handling
   ! according to the table below:
@@ -104,37 +27,12 @@ module module_cplfields
   !  s : surface (2D)
   !  t : tracers (4D)
   character(len=*), public, parameter :: exportFieldTypes(NexportFields) = (/ &
-       "i","l","i","l","l","l","l","l","t", &
-       "s","s","s","s","l","l","s","s","g", &
-       "s","s","s","s","s","s","s","s",     &
-       "s","s","s","s","s","s","s","s",     &
-       "s","s","s","s","s","s","s","s",     &
-       "s","s","s","s","s","s","s","s",     &
-       "s","s","s","s","s","s","s","s",     &
-       "s","s","s","s","s","s","s","s",     &
-       "s","s","s","s","s"                  &
-!      "l","l","l","l","l","l","l","s",     &
+       "s","s"
   /)
   ! Set exportFieldShare to .true. if field is provided as memory reference
   ! to coupled components
   logical, public, parameter :: exportFieldShare(NexportFields) = (/ &
-       .true. ,.true. ,.true. ,.true. ,.true. , &
-       .true. ,.true. ,.true. ,.true. ,.true. , &
-       .true. ,.true. ,.true. ,.true. ,.true. , &
-       .true. ,.true. ,.true. ,.true. ,.true. , &
-       .true. ,.true. ,.true. ,.false.,.false., &
-       .false.,.false.,.false.,.false.,.false., &
-       .false.,.false.,.false.,.false.,.false. , &
-       .true. ,.false.,.false.,.false.,.false. , &
-       .true. ,.false.,.false.,.false.,.false., &
-       .false.,.false.,.false.,.false.,.false., &
-       .false.,.false.,.false.,.false.,.false., &
-       .false.,.false.,.false.,.false.,.false., &
-       .false.,.false.,.false.,.true. ,.false., &
-       .false.,.false.,.false.,.false.,.false., &
-       .false.                                  &
-!      .false.,.false.,.false.,.false.,.false., &
-!      .false.,.false.,.false.                  &
+       .false.,.false.
   /)
   real(kind=8), allocatable, public :: exportData(:,:,:)
 
@@ -143,41 +41,15 @@ module module_cplfields
   logical,          public            :: importFieldsValid(NimportFields)
   type(ESMF_Field), target, public    :: importFields(NimportFields)
   character(len=*), public, parameter :: importFieldsList(NimportFields) = (/ &
-       "inst_tracer_mass_frac                  ", &
-       "land_mask                              ", &
-       "sea_ice_surface_temperature            ", &
-       "sea_surface_temperature                ", &
-       "ice_fraction                           ", &
-!      "inst_ice_ir_dif_albedo                 ", &
-!      "inst_ice_ir_dir_albedo                 ", &
-!      "inst_ice_vis_dif_albedo                ", &
-!      "inst_ice_vis_dir_albedo                ", &
-       "mean_up_lw_flx_ice                     ", &
-       "mean_laten_heat_flx_atm_into_ice       ", &
-       "mean_sensi_heat_flx_atm_into_ice       ", &
-!      "mean_evap_rate                         ", &
-       "stress_on_air_ice_zonal                ", &
-       "stress_on_air_ice_merid                ", &
-       "mean_ice_volume                        ", &
-       "mean_snow_volume                       ", &
-       "inst_tracer_up_surface_flx             ", &
-       "inst_tracer_down_surface_flx           ", &
-       "inst_tracer_clmn_mass_dens             ", &
-       "inst_tracer_anth_biom_flx              "  &
+       "land_mask                              "
   /)
   character(len=*), public, parameter :: importFieldTypes(NimportFields) = (/ &
-       "t",                                 &
-       "s","s","s","s","s",                 &
-       "s","s","s","s","s",                 &
-       "s","u","d","c","b"                  &
+       "s"                                  &
   /)
   ! Set importFieldShare to .true. if field is provided as memory reference
   ! from coupled components
   logical, public, parameter :: importFieldShare(NimportFields) = (/ &
-       .true. ,                                 &
-       .false.,.false.,.false.,.false.,.false., &
-       .false.,.false.,.false.,.false.,.false., &
-       .false.,.true. ,.true. ,.true. ,.true.   &
+       .false.                                  &
   /)
 
   ! Methods

--- a/cpl/module_cplfields.F90
+++ b/cpl/module_cplfields.F90
@@ -17,7 +17,7 @@ module module_cplfields
   type(ESMF_Field), target, public    :: exportFields(NexportFields)
   character(len=*), public, parameter :: exportFieldsList(NexportFields) = (/ &
        "inst_zonal_wind_height10m                ", &
-       "inst_merid_wind_height10m                "
+       "inst_merid_wind_height10m                "  &
   /)
   ! Field types should be provided for proper handling
   ! according to the table below:
@@ -27,12 +27,12 @@ module module_cplfields
   !  s : surface (2D)
   !  t : tracers (4D)
   character(len=*), public, parameter :: exportFieldTypes(NexportFields) = (/ &
-       "s","s"
+       "s","s"                                      &
   /)
   ! Set exportFieldShare to .true. if field is provided as memory reference
   ! to coupled components
   logical, public, parameter :: exportFieldShare(NexportFields) = (/ &
-       .false.,.false.
+       .false.,.false.                              &
   /)
   real(kind=8), allocatable, public :: exportData(:,:,:)
 
@@ -41,7 +41,7 @@ module module_cplfields
   logical,          public            :: importFieldsValid(NimportFields)
   type(ESMF_Field), target, public    :: importFields(NimportFields)
   character(len=*), public, parameter :: importFieldsList(NimportFields) = (/ &
-       "land_mask                              "
+       "land_mask                              "    &
   /)
   character(len=*), public, parameter :: importFieldTypes(NimportFields) = (/ &
        "s"                                  &

--- a/cpl/module_cplfields.F90
+++ b/cpl/module_cplfields.F90
@@ -13,7 +13,7 @@ module module_cplfields
   private
 
 ! Export Fields ----------------------------------------
-  integer,          public, parameter :: NexportFields = 71
+  integer,          public, parameter :: NexportFields = 2
   type(ESMF_Field), target, public    :: exportFields(NexportFields)
   character(len=*), public, parameter :: exportFieldsList(NexportFields) = (/ &
        "inst_zonal_wind_height10m                ", &
@@ -37,7 +37,7 @@ module module_cplfields
   real(kind=8), allocatable, public :: exportData(:,:,:)
 
 ! Import Fields ----------------------------------------
-  integer,          public, parameter :: NimportFields = 16
+  integer,          public, parameter :: NimportFields = 1
   logical,          public            :: importFieldsValid(NimportFields)
   type(ESMF_Field), target, public    :: importFields(NimportFields)
   character(len=*), public, parameter :: importFieldsList(NimportFields) = (/ &


### PR DESCRIPTION
## Description

There is a request to further reduce the time taken in the model initialization for GFS.v16 implementation. Following the suggestion from ESMF group,  the number of export fields in fv3 has been reduced to 2 coupled fields for atm->ww3 coupling and the import fields have been removed. The initialization time on atm-wave connector becomes longer when larger number of nodes are used.

## Testing

Tests have been done on hera and wcoss. On hera, the tests were done with 152 nodes, 3s improvement is seen. On wcoss, Fanglin's test shows 20s improves with 220 nodes.

## Dependencies

Similar changes have been made in ww3. [WW3 PR#295](WW3/pull/295).
ufs-weather-model [PR#363](https://github.com/ufs-community/ufs-weather-model/pull/363). 
