### PR TITLE
release/public-v2: noahmp_bugfix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = release/public-v5
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url =  https://github.com/HelinWei-NOAA/ccpp-physics
-	branch = public_release_v5_noahmp_bugfix
+	url =  https://github.com/NCAR/ccpp-physics
+	branch = release/public-v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = release/public-v5
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url =  https://github.com/NCAR/ccpp-physics
-	branch = release/public-v5
+	url =  https://github.com/HelinWei-NOAA/ccpp-physics
+	branch = public_release_v5_noahmp_bugfix


### PR DESCRIPTION
## Description

(1) Some updates to prevent the model from crashing. 
(2) Include opt_stc=3 bug fix in both noahmp land and glacier code (no initialization for some parameters)
(3) The wrong downward longwave forcing to Noah MP. Noah MP expects the
downward longwave before surface emission, however the current driver passed the
one after emission. Inside Noah MP it is multiplied by surface emissivity
again. So generally Noah MP is getting less downward longwave.


### Issue(s) addressed

https://github.com/NCAR/ccpp-physics/issues/556

## Testing

See details at: https://github.com/ufs-weather-model/pull/393

## Dependencies

- waiting on https://github.com/NCAR/ccpp-physics/pull/557
