### PR TITLE
Changes to CMakeLists.txt for FMS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,11 +109,11 @@ target_include_directories(fv3dycore INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT
                                                $<INSTALL_INTERFACE:mod>)
 
 if(32BIT)
-   target_link_libraries(fv3dycore PUBLIC fms_r4
+   target_link_libraries(fv3dycore PUBLIC FMS::fms_r4
                                           gfsphysics
                                           esmf)
 else()
-   target_link_libraries(fv3dycore PUBLIC fms_r8
+   target_link_libraries(fv3dycore PUBLIC FMS::fms_r8
                                           gfsphysics
                                           esmf)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,9 +108,16 @@ target_include_directories(fv3dycore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/atmos_c
 target_include_directories(fv3dycore INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
                                                $<INSTALL_INTERFACE:mod>)
 
-target_link_libraries(fv3dycore PUBLIC fms
-                                       gfsphysics
-                                       esmf)
+if(32BIT)
+   target_link_libraries(fv3dycore PUBLIC fms_r4
+                                          gfsphysics
+                                          esmf)
+else()
+   target_link_libraries(fv3dycore PUBLIC fms_r8
+                                          gfsphysics
+                                          esmf)
+endif()
+
 if(OpenMP_Fortran_FOUND)
   target_link_libraries(fv3dycore PUBLIC OpenMP::OpenMP_Fortran)
 endif()

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -31,9 +31,15 @@ set_target_properties(io PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BIN
 target_compile_definitions(io PRIVATE "${_io_defs_private}")
 target_include_directories(io PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>)
 
-target_link_libraries(io PRIVATE fms
-                                 gfsphysics
-                                 ccppdriver)
+if(32BIT)
+   target_link_libraries(io PRIVATE fms_r4
+                                    gfsphysics
+                                    ccppdriver)
+else()
+   target_link_libraries(io PRIVATE fms_r8
+                                    gfsphysics
+                                    ccppdriver)
+endif()
 
 if(INLINE_POST)
   target_link_libraries(io PRIVATE upp::upp)

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -32,11 +32,11 @@ target_compile_definitions(io PRIVATE "${_io_defs_private}")
 target_include_directories(io PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>)
 
 if(32BIT)
-   target_link_libraries(io PRIVATE fms_r4
+   target_link_libraries(io PRIVATE FMS::fms_r4
                                     gfsphysics
                                     ccppdriver)
 else()
-   target_link_libraries(io PRIVATE fms_r8
+   target_link_libraries(io PRIVATE FMS::fms_r8
                                     gfsphysics
                                     ccppdriver)
 endif()

--- a/stochastic_physics/CMakeLists.txt
+++ b/stochastic_physics/CMakeLists.txt
@@ -4,10 +4,17 @@ target_include_directories(stochastic_physics_wrapper PRIVATE ${CMAKE_BINARY_DIR
 target_include_directories(stochastic_physics_wrapper PRIVATE ${CMAKE_BINARY_DIR}/FV3/ccpp/framework/src
                                                               ${CMAKE_BINARY_DIR}/FV3/ccpp/physics)
 target_include_directories(stochastic_physics_wrapper PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>)
-target_link_libraries(stochastic_physics_wrapper PUBLIC fms
-                                                        stochastic_physics
-                                                        gfsphysics
-                                                        fv3dycore)
+if(32BIT)
+   target_link_libraries(stochastic_physics_wrapper PUBLIC fms_r4
+                                                           stochastic_physics
+                                                           gfsphysics
+                                                           fv3dycore)
+else()
+   target_link_libraries(stochastic_physics_wrapper PUBLIC fms_r8
+                                                           stochastic_physics
+                                                           gfsphysics
+                                                           fv3dycore)
+endif()
 
 if(OpenMP_Fortran_FOUND)
   target_link_libraries(stochastic_physics_wrapper PUBLIC OpenMP::OpenMP_Fortran)

--- a/stochastic_physics/CMakeLists.txt
+++ b/stochastic_physics/CMakeLists.txt
@@ -5,12 +5,12 @@ target_include_directories(stochastic_physics_wrapper PRIVATE ${CMAKE_BINARY_DIR
                                                               ${CMAKE_BINARY_DIR}/FV3/ccpp/physics)
 target_include_directories(stochastic_physics_wrapper PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>)
 if(32BIT)
-   target_link_libraries(stochastic_physics_wrapper PUBLIC fms_r4
+   target_link_libraries(stochastic_physics_wrapper PUBLIC FMS::fms_r4
                                                            stochastic_physics
                                                            gfsphysics
                                                            fv3dycore)
 else()
-   target_link_libraries(stochastic_physics_wrapper PUBLIC fms_r8
+   target_link_libraries(stochastic_physics_wrapper PUBLIC FMS::fms_r8
                                                            stochastic_physics
                                                            gfsphysics
                                                            fv3dycore)


### PR DESCRIPTION
## Description
This PR updates `CMakeLists.txt`, `io/CMakeLists.txt`, and `stochastic_physics/CMakeLists.txt` to be compatible with the FMS CMakeLists.txt. The fms target has been changed to FMS::fms_r4 for 32BIT or FMS::fms_r8 for a 64BIT compilation. This change is necessary for the UFS Weather Model to use the FMS CMakeLists.txt file.  Answer changes are not expected.

### Issue(s) addressed
- fixes #242 

## Testing
Regression tests are currently running after making last minute minor changes.  

## Dependencies
