### PR TITLE
release/public-v2: bit-for-bit reproducibility for regional runs when changing MPI decomposition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	#url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-	#branch = ufs-release/public-v2
-	url = https://github.com/climbfuji/GFDL_atmos_cubed_sphere
-	branch = regional_decomp_b4b
+	url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+	branch = ufs-release/public-v2
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-	branch = ufs-release/public-v2
+	#url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+	#branch = ufs-release/public-v2
+	url = https://github.com/climbfuji/GFDL_atmos_cubed_sphere
+	branch = regional_decomp_b4b
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description

This PR only updates the submodule pointer for GFDL_atmos_cubed_sphere for the changes in https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/68.

### Issue(s) addressed

These PRs solve the "b4b reproducibility for regional runs on the ESG grid when changing the MPI decomposition" of issue https://github.com/ufs-community/ufs-weather-model/issues/288.

## Testing

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/409.

## Dependencies

https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/68
https://github.com/NOAA-EMC/fv3atm/pull/245
https://github.com/ufs-community/ufs-weather-model/pull/409
