### PR TITLE
release/public-v2: b4b reproducibility for restart runs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = release/public-v5
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url =  https://github.com/NCAR/ccpp-physics
-	branch = release/public-v5
+	#url =  https://github.com/NCAR/ccpp-physics
+	#branch = release/public-v5
+	url =  https://github.com/mzhangw/ccpp-physics
+	branch = release_public_v5_scidoc

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = release/public-v5
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url =  https://github.com/NCAR/ccpp-physics
-	#branch = release/public-v5
-	url =  https://github.com/mzhangw/ccpp-physics
-	branch = release_public_v5_scidoc
+	url =  https://github.com/NCAR/ccpp-physics
+	branch = release/public-v5

--- a/gfsphysics/GFS_layer/GFS_restart.F90
+++ b/gfsphysics/GFS_layer/GFS_restart.F90
@@ -102,7 +102,11 @@ module GFS_restart
     if (Model%imfdeepcnv == 3) then
       Restart%num2d = Restart%num2d + 1
     endif
-    ! RUC 
+    ! NoahMP
+    if (Model%lsm == Model%lsm_noahmp) then
+      Restart%num2d = Restart%num2d + 10
+    endif
+    ! RUC
     if (Model%lsm == Model%lsm_ruc) then
       Restart%num2d = Restart%num2d + 5
     endif
@@ -195,7 +199,60 @@ module GFS_restart
         Restart%data(nb,num)%var2p => Sfcprop(nb)%conv_act(:)
       enddo
     endif
-    ! RUC 
+    ! NoahMP
+    if (Model%lsm == Model%lsm_noahmp) then
+      num = num + 1
+      Restart%name2d(num) = 'noahmp_2d_raincprv'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var2p => Sfcprop(nb)%raincprv(:)
+      enddo
+      num = num + 1
+      Restart%name2d(num) = 'noahmp_2d_rainncprv'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var2p => Sfcprop(nb)%rainncprv(:)
+      enddo
+      num = num + 1
+      Restart%name2d(num) = 'noahmp_2d_iceprv'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var2p => Sfcprop(nb)%iceprv(:)
+      enddo
+      num = num + 1
+      Restart%name2d(num) = 'noahmp_2d_snowprv'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var2p => Sfcprop(nb)%snowprv(:)
+      enddo
+      num = num + 1
+      Restart%name2d(num) = 'noahmp_2d_graupelprv'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var2p => Sfcprop(nb)%graupelprv(:)
+      enddo
+      num = num + 1
+      Restart%name2d(num) = 'noahmp_2d_draincprv'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var2p => Sfcprop(nb)%draincprv(:)
+      enddo
+      num = num + 1
+      Restart%name2d(num) = 'noahmp_2d_drainncprv'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var2p => Sfcprop(nb)%drainncprv(:)
+      enddo
+      num = num + 1
+      Restart%name2d(num) = 'noahmp_2d_diceprv'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var2p => Sfcprop(nb)%diceprv(:)
+      enddo
+      num = num + 1
+      Restart%name2d(num) = 'noahmp_2d_dsnowprv'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var2p => Sfcprop(nb)%dsnowprv(:)
+      enddo
+      num = num + 1
+      Restart%name2d(num) = 'noahmp_2d_dgraupelprv'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var2p => Sfcprop(nb)%dgraupelprv(:)
+      enddo
+    endif
+    ! RUC
     if (Model%lsm == Model%lsm_ruc) then
       num = num + 1
       Restart%name2d(num) = 'ruc_2d_raincprv'


### PR DESCRIPTION
## Description

This PR and associated PRs below fix the b4b reproducibility issues for the release/public-v2 branches. With these changes, restart runs are b4b identical to continues runs for regional and global applications with both GFS v15p2 and RRFS v1 alpha physics.

Changes: 
- copied over from develop (and originally contributed by @SMoorthi-emc): bugfixes in io/FV3GFS_io.F90 to achieve restart reproducibility for global runs using the GFS v15p2 suite; see original PRs for develop https://github.com/NOAA-EMC/fv3atm/pull/178 and https://github.com/NOAA-EMC/fv3atm/pull/212
- add necessary variables for NoahMP restart reproducibility to gfsphysics/GFS_layer/GFS_restart.F90 (as described in https://github.com/NCAR/ccpp-physics/issues/367)
- update submodule pointer for ccpp-physics to include PR https://github.com/NCAR/ccpp-physics/pull/519 (release/public-v5: scientific documentation)

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/417

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/519
https://github.com/NOAA-EMC/fv3atm/pull/246
https://github.com/ufs-community/ufs-weather-model/pull/417
