### PR TITLE
Hotfix for RRTMGP using multiple threads

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = master
+	url = https://github.com/dustinswales/ccpp-physics
+	branch = hotfix_GPthreadsafe

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/dustinswales/ccpp-physics
-	branch = hotfix_GPthreadsafe
+	url = https://github.com/NCAR/ccpp-physics
+	branch = master

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1998,6 +1998,7 @@ module GFS_typedefs
 
     ! RRTMGP
     real (kind=kind_phys)               :: minGPpres                            !< Minimum pressure allowed by RRTMGP.
+    real (kind=kind_phys)               :: minGPtemp                            !< Minimum temperature allowed by RRTMGP. 
     integer                             :: ipsdlw0                              !<
     integer                             :: ipsdsw0                              !<
     real (kind=kind_phys), pointer      :: p_lay(:,:)                => null()  !<

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1997,6 +1997,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: dudt_tms(:,:)      => null()  !< daily aver u-wind tend due to TMS
 
     ! RRTMGP
+    real (kind=kind_phys)               :: minGPpres                            !< Minimum pressure allowed by RRTMGP.
     integer                             :: ipsdlw0                              !<
     integer                             :: ipsdsw0                              !<
     real (kind=kind_phys), pointer      :: p_lay(:,:)                => null()  !<
@@ -2046,10 +2047,6 @@ module GFS_typedefs
     integer, pointer                    :: icseed_sw(:)              => null()  !< RRTMGP seed for RNG for shortwave radiation
     type(proflw_type), pointer          :: flxprf_lw(:,:)            => null()  !< DDT containing RRTMGP longwave fluxes
     type(profsw_type), pointer          :: flxprf_sw(:,:)            => null()  !< DDT containing RRTMGP shortwave fluxes
-    type(ty_gas_optics_rrtmgp)          :: lw_gas_props                         !< RRTMGP DDT
-    type(ty_gas_optics_rrtmgp)          :: sw_gas_props                         !< RRTMGP DDT
-    type(ty_cloud_optics)               :: lw_cloud_props                       !< RRTMGP DDT
-    type(ty_cloud_optics)               :: sw_cloud_props                       !< RRTMGP DDT
     type(ty_optical_props_2str)         :: lw_optical_props_cloudsByBand        !< RRTMGP DDT
     type(ty_optical_props_2str)         :: lw_optical_props_clouds              !< RRTMGP DDT
     type(ty_optical_props_2str)         :: lw_optical_props_precipByBand        !< RRTMGP DDT
@@ -6138,6 +6135,7 @@ module GFS_typedefs
     class(GFS_interstitial_type)       :: Interstitial
     integer,                intent(in) :: IM
     type(GFS_control_type), intent(in) :: Model
+    integer                            :: iGas
     !
     allocate (Interstitial%otspt      (Model%ntracp1,2))
     ! Set up numbers of tracers for PBL, convection, etc: sets
@@ -6421,6 +6419,14 @@ module GFS_typedefs
        allocate (Interstitial%toa_src_sw           (IM,Model%rrtmgp_nGptsSW))
        allocate (Interstitial%toa_src_lw           (IM,Model%rrtmgp_nGptsLW))
        allocate (Interstitial%active_gases_array   (Model%nGases))
+       ! ty_gas_concs
+       Interstitial%gas_concentrations%ncol = IM
+       Interstitial%gas_concentrations%nlay = Model%levs
+       allocate(Interstitial%gas_concentrations%gas_name(Model%nGases))
+       allocate(Interstitial%gas_concentrations%concs(Model%nGases))
+       do iGas=1,Model%nGases
+          allocate(Interstitial%gas_concentrations%concs(iGas)%conc(IM, Model%levs))
+       enddo
     end if
 ! CIRES UGWP v0
     allocate (Interstitial%gw_dudt         (IM,Model%levs))

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -10064,6 +10064,13 @@
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
+[minGPpres]
+  standard_name = minimum_pressure_in_RRTMGP
+  long_name = minimum pressure allowed in RRTMGP
+  units = Pa
+  dimensions = ()
+  type = real
+  kind = kind_phys
 [ipsdsw0]
   standard_name = initial_permutation_seed_sw
   long_name = initial seed for McICA SW 

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -10071,6 +10071,13 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[minGPtemp]
+  standard_name = minimum_temperature_in_RRTMGP
+  long_name = minimum temperature allowed in RRTMGP
+  units = K
+  dimensions = ()
+  type = real
+  kind = kind_phys
 [ipsdsw0]
   standard_name = initial_permutation_seed_sw
   long_name = initial seed for McICA SW 


### PR DESCRIPTION
This PR contains several changes to the initialization and setup of the RRTMGP radiation scheme to allow for use across multiple openMP threads.
*) Moved Interstitial RRTMGP DDTs (ty_rrtmgp_gas_optics, ty_cloud_optics) to static fields defined during initialization in module memory.
*) Add "$omp critical" statements around the calling type-bound procedures during initialization.
*) Move allocation of ty_gas_conc from Interstitial to GFS_typedefs. Initialize ty_gas_concs for all blocks during initialization.

This issue was brought to our attention by @yangfanglin and Qingfu Liu at EMC while testing RRTMGP in high-resolution cases, which require multiple threads.

The GP regression tests on hera using Intel were successful. 
There are no changes to the baselines

Waiting on https://github.com/NCAR/ccpp-physics/pull/568