### PR TITLE
release/public-v2: Update submodule pointer for ccpp-physics for release v5 SCM only mods

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = release/public-v5
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url =  https://github.com/NCAR/ccpp-physics
-	branch = release/public-v5
+	#url =  https://github.com/NCAR/ccpp-physics
+	#branch = release/public-v5
+	url =  https://github.com/grantfirl/ccpp-physics
+	branch = v5_scm_mods

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = release/public-v5
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url =  https://github.com/NCAR/ccpp-physics
-	#branch = release/public-v5
-	url =  https://github.com/grantfirl/ccpp-physics
-	branch = v5_scm_mods
+	url =  https://github.com/NCAR/ccpp-physics
+	branch = release/public-v5


### PR DESCRIPTION
## Description

Update submodule pointer for ccpp-physics for SCM-only changes in https://github.com/NCAR/ccpp-physics/pull/572.

## Testing

No testing required, these two files are not used by the ufs-weather-model (they are in fact completely ignored, because they are not in fv3atm's `ccpp/config/ccpp_prebuild_config.py`).

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/572
https://github.com/NOAA-EMC/fv3atm/pull/248
https://github.com/ufs-community/ufs-weather-model/pull/423
