### PR TITLE
Fix model slowness when using threading

### DIFF
--- a/ccpp/data/CMakeLists.txt
+++ b/ccpp/data/CMakeLists.txt
@@ -32,8 +32,12 @@ add_library(
     CCPP_data.F90
 )
 
-target_link_libraries(ccppdata ccpp)
-target_link_libraries(ccppdata ccppphys)
+target_link_libraries(ccppdata PUBLIC ccpp)
+target_link_libraries(ccppdata PUBLIC ccppphys)
+
+if(OpenMP_Fortran_FOUND)
+  target_link_libraries(ccppdata PUBLIC OpenMP::OpenMP_Fortran)
+endif()
 
 target_include_directories(ccppdata PRIVATE ${CMAKE_BINARY_DIR}/FV3/ccpp/framework/src
                                             ${CMAKE_BINARY_DIR}/FV3/ccpp/physics)

--- a/ccpp/driver/CMakeLists.txt
+++ b/ccpp/driver/CMakeLists.txt
@@ -38,13 +38,17 @@ add_library(
 # Compile GFS_diagnostics.F90 without optimization, this leads to out of memory errors on wcoss_dell_p3
 set_property(SOURCE GFS_diagnostics.F90 APPEND_STRING PROPERTY COMPILE_FLAGS "-O0")
 
-target_link_libraries(ccppdriver ccpp)
-target_link_libraries(ccppdriver ccppphys)
-target_link_libraries(ccppdriver ccppdata)
+target_link_libraries(ccppdriver PUBLIC ccpp)
+target_link_libraries(ccppdriver PUBLIC ccppphys)
+target_link_libraries(ccppdriver PUBLIC ccppdata)
+
+if(OpenMP_Fortran_FOUND)
+  target_link_libraries(ccppdriver PUBLIC OpenMP::OpenMP_Fortran)
+endif()
 
 target_include_directories(ccppdriver PRIVATE ${CMAKE_BINARY_DIR}/FV3/ccpp/framework/src
                                               ${CMAKE_BINARY_DIR}/FV3/ccpp/physics)
 
 set_target_properties(ccppdriver PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
-target_compile_definitions(ccppdata PRIVATE "${_ccppdata_defs_private}")
+target_compile_definitions(ccppdriver PRIVATE "${_ccppdriver_defs_private}")
 target_include_directories(ccppdriver PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>)


### PR DESCRIPTION
## Description

This PR fixes the model slowness that we started to see after PR https://github.com/NOAA-EMC/fv3atm/pull/249 was merged. The reason are missing OpenMP dependencies in `ccpp/data/CMakeLists.txt` and `ccpp/driver/CMakeLists.txt`.

These dependencies were missing since the two folders `ccpp/data` and `ccpp/driver` were created. However, OpenMP was added implicitly through a dependency on target `gfsphysics`, which was removed in PR #249.

### Issue(s) addressed

ufs-weather-model issue [#474](https://github.com/ufs-community/ufs-weather-model/issues/474)
## Testing

Tested manually with Intel and GNU on Cheyenne and Hera for the regression test `fv3_ccpp_2threads` for 240h long integration times. With these changes the performance of the pre-#249 code is regained (and at the same time the memory footprint is reduced due to the changes in #249).

## Dependencies

n/a