### PR TITLE
fix lam post uninitialied fields

### DIFF
--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
@@ -39,7 +39,7 @@
     </subcycle>
     <!-- Surface iteration loop -->
     <subcycle loop="2">
-      <scheme>sfc_diff</scheme>
+      <scheme>mynnsfc_wrapper</scheme>
       <scheme>GFS_surface_loop_control_part1</scheme>
       <scheme>sfc_nst_pre</scheme>
       <scheme>sfc_nst</scheme>

--- a/io/post_regional.F90
+++ b/io/post_regional.F90
@@ -448,7 +448,7 @@ module post_regional
       use vrbls3d,     only: t, q, uh, vh, wh, alpint, dpres, zint, zmid, o3,  &
                              qqr, qqs, cwm, qqi, qqw, qqg, omga, cfr, pmid,    &
                              q2, rlwtt, rswtt, tcucn, tcucns, train, el_pbl,   &
-                             pint, exch_h, ref_10cm
+                             pint, exch_h, ref_10cm, extcof55, aextc55, u, v
       use vrbls2d,     only: f, pd, sigt4, fis, pblh, ustar, z0, ths, qs, twbs,&
                              qwbs, avgcprate, cprate, avgprec, prec, lspa, sno,&
                              cldefi, th10, q10, tshltr, pshltr, tshltr, albase,&
@@ -477,7 +477,8 @@ module post_regional
                              up_heli_max03,up_heli_min03,rel_vort_max01,       &
                              rel_vort_max, rel_vort_maxhy1, refd_max,          &
                              refdm10c_max, u10max, v10max, wspd10max, sfcuxi,  &
-                             sfcvxi, t10m, t10avg, psfcavg, akhsavg, akmsavg
+                             sfcvxi, t10m, t10avg, psfcavg, akhsavg, akmsavg,  &
+                             albedo, tg
       use soil,        only: sldpth, sh2o, smc, stc
       use masks,       only: lmv, lmh, htm, vtm, gdlat, gdlon, dx, dy, hbm2, sm, sice
       use ctlblk_mod,  only: im, jm, lm, lp1, jsta, jend, jsta_2l, jend_2u, jsta_m,jend_m, &
@@ -641,7 +642,7 @@ module post_regional
           lspa(i,j) = SPVAL
           th10(i,j) = SPVAL
           q10(i,j) = SPVAL
-          albase(i,j) = SPVAL
+          albase(i,j) = 0.
         enddo
       enddo
 
@@ -829,9 +830,10 @@ module post_regional
         enddo
       enddo
 !
-!** temporary fix: initialize t10m, t10avg, psfcavg, akhsavg, akmsavg
+!** temporary fix: initialize t10m, t10avg, psfcavg, akhsavg, akmsavg,
+!** albedo, tg
 !$omp parallel do default(none),private(i,j),shared(jsta_2l,jend_2u,im), &
-!$omp& shared(t10m,t10avg,psfcavg,akhsavg, akmsavg)
+!$omp& shared(t10m,t10avg,psfcavg,akhsavg,akmsavg,albedo,tg)
       do j=jsta_2l,jend_2u
         do i=1,im
           t10m(i,j) = 0.
@@ -839,6 +841,20 @@ module post_regional
           psfcavg(i,j) = 0.
           akhsavg(i,j) = 0.
           akmsavg(i,j) = 0.
+          albedo(i,j) = 0.
+          tg(i,j) = 0.
+        enddo
+      enddo
+!$omp parallel do default(none),private(i,j,k),shared(jsta_2l,jend_2u,im,lm), &
+!$omp& shared(extcof55,aextc55,u,v)
+      do k=1,lm
+        do j=jsta_2l,jend_2u
+        do i=1,im
+          extcof55(i,j,k) = 0.
+          aextc55(i,j,k) = 0.
+          u(i,j,k) = 0.
+          v(i,j,k) = 0.
+        enddo
         enddo
       enddo
 !
@@ -1312,9 +1328,6 @@ module post_regional
                 do i=ista, iend
                   mxsnal(i,j) = arrayr42d(i,j)
                   if (abs(arrayr42d(i,j)-fillValue) < small) mxsnal(i,j) = spval
-                  if (mxsnal(i,j) /= spval) then
-                    mxsnal(i,j) = mxsnal(i,j) * 0.01
-                  endif
                 enddo
               enddo
             endif

--- a/io/post_regional.F90
+++ b/io/post_regional.F90
@@ -830,7 +830,7 @@ module post_regional
       enddo
 !
 !** temporary fix: initialize t10m, t10avg, psfcavg, akhsavg, akmsavg
-!$omp parallel do default(none),private(i,j),shared(jsta_2l,jend_2u,im,spval), &
+!$omp parallel do default(none),private(i,j),shared(jsta_2l,jend_2u,im), &
 !$omp& shared(t10m,t10avg,psfcavg,akhsavg, akmsavg)
       do j=jsta_2l,jend_2u
         do i=1,im

--- a/io/post_regional.F90
+++ b/io/post_regional.F90
@@ -477,7 +477,7 @@ module post_regional
                              up_heli_max03,up_heli_min03,rel_vort_max01,       &
                              rel_vort_max, rel_vort_maxhy1, refd_max,          &
                              refdm10c_max, u10max, v10max, wspd10max, sfcuxi,  &
-                             sfcvxi
+                             sfcvxi, t10m, t10avg, psfcavg, akhsavg, akmsavg
       use soil,        only: sldpth, sh2o, smc, stc
       use masks,       only: lmv, lmh, htm, vtm, gdlat, gdlon, dx, dy, hbm2, sm, sice
       use ctlblk_mod,  only: im, jm, lm, lp1, jsta, jend, jsta_2l, jend_2u, jsta_m,jend_m, &
@@ -826,6 +826,19 @@ module post_regional
             qqs(i,j,l) = 0.
             qqi(i,j,l) = 0.
           enddo
+        enddo
+      enddo
+!
+!** temporary fix: initialize t10m, t10avg, psfcavg, akhsavg, akmsavg
+!$omp parallel do default(none),private(i,j),shared(jsta_2l,jend_2u,im,spval), &
+!$omp& shared(t10m,t10avg,psfcavg,akhsavg, akmsavg)
+      do j=jsta_2l,jend_2u
+        do i=1,im
+          t10m(i,j) = 0.
+          t10avg(i,j) = 0.
+          psfcavg(i,j) = 0.
+          akhsavg(i,j) = 0.
+          akmsavg(i,j) = 0.
         enddo
       enddo
 !
@@ -1372,7 +1385,7 @@ module post_regional
                   else
                     islope(i,j) = 0
                   endif
-                  if (abs(arrayr42d(i,j)-fillValue) < small) islope(i,j) = spval
+                  if (abs(arrayr42d(i,j)-fillValue) < small) islope(i,j) = 0
                 enddo
               enddo
             endif
@@ -1925,7 +1938,7 @@ module post_regional
                 do i=ista, iend
                   if (arrayr42d(i,j) < spval) then
                     ivgtyp(i,j) = nint(arrayr42d(i,j))
-                    if( abs(arrayr42d(i,j)-fillValue) < small)  ivgtyp(i,j) = spval
+                    if( abs(arrayr42d(i,j)-fillValue) < small)  ivgtyp(i,j) = 0
                   else
                     ivgtyp(i,j) = 0
                   endif
@@ -1940,7 +1953,7 @@ module post_regional
                 do i=ista, iend
                   if (arrayr42d(i,j) < spval) then
                     isltyp(i,j) = nint(arrayr42d(i,j))
-                    if( abs(arrayr42d(i,j)-fillValue) < small)  isltyp(i,j) = spval
+                    if( abs(arrayr42d(i,j)-fillValue) < small)  isltyp(i,j) = 0
                   else
                     isltyp(i,j) = 0
                   endif


### PR DESCRIPTION
## Description

This is to fix the uninitialized fields in lam post products, and the assignment of integer fields. The uninitialized fields cause run-ro-run reproducibility issue in LAM post test. 

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes issue [ufs-weather-model #504](https://github.com/ufs-community/ufs-weather-model/issues/504) 
- fixes issue [ufs-weather-model #519](https://github.com/ufs-community/ufs-weather-model/issues/519) 

## Testing

How were these changes tested?  
The code has been tested on hera and orion. The run-to-run reproducibility issue is fixed. A final solution will be initializing all the allocated fields and  removing those fields in LAM post control file, which will be delivered from post group.


## Dependencies

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
-  ufs-weather-model PR 

