### PR TITLE
Various CCPP PRs: change vertical dimension and long name of dku/dkt, UGWP bugfixes, LTP bugfixes, sfcsub update, framework update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,13 +4,9 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	#url = https://github.com/NCAR/ccpp-framework
-	#branch = main
-	url = https://github.com/climbfuji/ccpp-framework
-	branch = always_copy_data_in
+	url = https://github.com/NCAR/ccpp-framework
+	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = main
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = collect_various_prs_20210422
+	url = https://github.com/NCAR/ccpp-physics
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = master
+	url = https://github.com/mdtoy/ccpp-physics
+	branch = ugwpv1_gsldrag_bugfixes_etc

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,13 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
-	branch = master
+	#url = https://github.com/NCAR/ccpp-framework
+	#branch = main
+	url = https://github.com/climbfuji/ccpp-framework
+	branch = always_copy_data_in
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = master
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = main
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = collect_various_prs_20210422

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -5805,8 +5805,8 @@ module GFS_typedefs
     allocate (Diag%refl_10cm(IM,Model%levs))
 
     !--- New PBL Diagnostics
-    allocate (Diag%dkt(IM,Model%levs-1))
-    allocate (Diag%dku(IM,Model%levs-1))
+    allocate (Diag%dkt(IM,Model%levs))
+    allocate (Diag%dku(IM,Model%levs))
 
     !--  New max hourly diag.
     allocate (Diag%refdmax(IM))

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -5775,8 +5775,7 @@ module GFS_typedefs
       allocate (Diag%tav_ugwp  (IM,Model%levs) )
     endif
 
-    if (Model%do_ugwp_v1 .or. Model%gwd_opt==33 .or. Model%gwd_opt==22 &
-                         .or. Model%gwd_opt==3  .or. Model%gwd_opt==2) then
+    if (Model%do_ugwp_v1 .or. Model%gwd_opt==33 .or. Model%gwd_opt==22) then
       allocate (Diag%dudt_ogw  (IM,Model%levs))
       allocate (Diag%dvdt_ogw  (IM,Model%levs))
       allocate (Diag%dudt_obl  (IM,Model%levs))
@@ -6043,8 +6042,7 @@ module GFS_typedefs
     Diag%dtdt_gw     = zero
     Diag%kdis_gw     = zero
 
-    if (Model%do_ugwp_v1 .or. Model%gwd_opt==33 .or. Model%gwd_opt==22 &
-                         .or. Model%gwd_opt==3  .or. Model%gwd_opt==2) then
+    if (Model%do_ugwp_v1 .or. Model%gwd_opt==33 .or. Model%gwd_opt==22) then
       Diag%dudt_ogw    = zero
       Diag%dvdt_ogw    = zero
       Diag%dudt_obl    = zero
@@ -6528,8 +6526,7 @@ module GFS_typedefs
     allocate (Interstitial%zngw            (IM)           )
 
 ! CIRES UGWP v1
-    if (Model%do_ugwp_v1 .or. Model%gwd_opt==33 .or. Model%gwd_opt==22 &
-                         .or. Model%gwd_opt==3  .or. Model%gwd_opt==2) then
+    if (Model%do_ugwp_v1) then
       allocate (Interstitial%dudt_ngw        (IM,Model%levs))
       allocate (Interstitial%dvdt_ngw        (IM,Model%levs))
       allocate (Interstitial%dtdt_ngw        (IM,Model%levs))
@@ -7139,8 +7136,7 @@ module GFS_typedefs
     Interstitial%zngw            = clear_val
 
 ! CIRES UGWP v1
-    if (Model%do_ugwp_v1 .or. Model%gwd_opt==33 .or. Model%gwd_opt==22 &
-                         .or. Model%gwd_opt==3  .or. Model%gwd_opt==2) then
+    if (Model%do_ugwp_v1) then
       Interstitial%dudt_ngw        = clear_val
       Interstitial%dvdt_ngw        = clear_val
       Interstitial%dtdt_ngw        = clear_val

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -6940,16 +6940,16 @@
   kind = kind_phys
 [dkt]
   standard_name = atmosphere_heat_diffusivity
-  long_name = diffusivity for heat
+  long_name = atmospheric heat diffusivity
   units = m2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension_minus_one)
+  dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
 [dku]
   standard_name = atmosphere_momentum_diffusivity
-  long_name = diffusivity for momentum
+  long_name = atmospheric momentum diffusivity
   units = m2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension_minus_one)
+  dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
 [cldfra]

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -1936,7 +1936,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'dkt'
-    ExtDiag(idx)%desc = 'Eddy diffusivity for heat'
+    ExtDiag(idx)%desc = 'Atmospheric heat diffusivity'
     ExtDiag(idx)%unit = 'm2s-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))
@@ -1947,7 +1947,7 @@ module GFS_diagnostics
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'dku'
-    ExtDiag(idx)%desc = 'Eddy diffusivity for momentum'
+    ExtDiag(idx)%desc = 'Atmospheric momentum diffusivity'
     ExtDiag(idx)%unit = 'm2s-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     allocate (ExtDiag(idx)%data(nblks))


### PR DESCRIPTION
## Description

This PR:
- contains #288, ugwpv1_gsldrag bug fixes, and GFS_typdefs updates associated with diag flags for ugwpv1_gsldrag.F90 and GFS_DCNV_generic.F90)
- changes the standard name and vertical dimension for arrays `dkt` and `dku` 
- updates submodule pointers for ccpp-framework and ccpp-physics for the changes in the associated PRs listed below.

### Issue(s) addressed

See https://github.com/NCAR/ccpp-physics/pull/641.

## Testing

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/541

The changes in https://github.com/NCAR/ccpp-physics/pull/635/files modify the answers of all regression tests involving Thompson MP.

The changes in https://github.com/NCAR/ccpp-physics/pull/634/files modify the answers of all regression tests involving UGWP v1.

## Dependencies

https://github.com/NCAR/ccpp-framework/pull/368
https://github.com/NCAR/ccpp-physics/pull/641
https://github.com/NOAA-EMC/fv3atm/pull/291
https://github.com/ufs-community/ufs-weather-model/pull/541
