### PR TITLE
inline post restart issue with gnu compiler

### DIFF
--- a/io/post_gfs.F90
+++ b/io/post_gfs.F90
@@ -158,9 +158,11 @@ module post_gfs
             filenameflat = 'postxconfig-NT.txt'
             if(size(paramset)>0) then
               do i=1,size(paramset)
-                if (size(paramset(i)%param)>0) then
-                  deallocate(paramset(i)%param)
-                  nullify(paramset(i)%param)
+                if (associated(paramset(i)%param)) then
+                  if (size(paramset(i)%param)>0) then
+                    deallocate(paramset(i)%param)
+                    nullify(paramset(i)%param)
+                  endif
                 endif
               enddo
               deallocate(paramset)

--- a/io/post_gfs.F90
+++ b/io/post_gfs.F90
@@ -156,7 +156,7 @@ module post_gfs
             if(mype==0) print *,'af read_xml at fh00,name=',trim(filenameflat)
           else if(ifhr > 0) then
             filenameflat = 'postxconfig-NT.txt'
-            if(size(paramset)>0) then
+            if(associated(paramset) .and. size(paramset)>0) then
               do i=1,size(paramset)
                 if (associated(paramset(i)%param)) then
                   if (size(paramset(i)%param)>0) then

--- a/io/post_gfs.F90
+++ b/io/post_gfs.F90
@@ -156,17 +156,19 @@ module post_gfs
             if(mype==0) print *,'af read_xml at fh00,name=',trim(filenameflat)
           else if(ifhr > 0) then
             filenameflat = 'postxconfig-NT.txt'
-            if(associated(paramset) .and. size(paramset)>0) then
-              do i=1,size(paramset)
-                if (associated(paramset(i)%param)) then
-                  if (size(paramset(i)%param)>0) then
-                    deallocate(paramset(i)%param)
-                    nullify(paramset(i)%param)
+            if(associated(paramset)) then
+              if( size(paramset)>0) then
+                do i=1,size(paramset)
+                  if (associated(paramset(i)%param)) then
+                    if (size(paramset(i)%param)>0) then
+                      deallocate(paramset(i)%param)
+                      nullify(paramset(i)%param)
+                    endif
                   endif
-                endif
-              enddo
-              deallocate(paramset)
-              nullify(paramset)
+                enddo
+                deallocate(paramset)
+                nullify(paramset)
+              endif
             endif
             num_pset = 0
             call read_xml()

--- a/io/post_regional.F90
+++ b/io/post_regional.F90
@@ -160,15 +160,17 @@ module post_regional
             if(mype==0) print *,'af read_xml at fh00,name=',trim(filenameflat)
           else if(ifhr > 0) then
             filenameflat = 'postxconfig-NT.txt'
-            if(associated(paramset) .and. size(paramset)>0) then
-              do i=1,size(paramset)
-                if (associated(paramset(i)%param)) then
-                  if (size(paramset(i)%param)>0) then
-                    deallocate(paramset(i)%param)
-                    nullify(paramset(i)%param)
+            if(associated(paramset)) then
+              if(size(paramset)>0) then
+                do i=1,size(paramset)
+                  if (associated(paramset(i)%param)) then
+                    if (size(paramset(i)%param)>0) then
+                      deallocate(paramset(i)%param)
+                      nullify(paramset(i)%param)
+                    endif
                   endif
-                endif
-              enddo
+                enddo
+              endif
               deallocate(paramset)
               nullify(paramset)
             endif

--- a/io/post_regional.F90
+++ b/io/post_regional.F90
@@ -162,9 +162,11 @@ module post_regional
             filenameflat = 'postxconfig-NT.txt'
             if(size(paramset)>0) then
               do i=1,size(paramset)
-                if (size(paramset(i)%param)>0) then
-                  deallocate(paramset(i)%param)
-                  nullify(paramset(i)%param)
+                if (associated(paramset(i)%param)) then
+                  if (size(paramset(i)%param)>0) then
+                    deallocate(paramset(i)%param)
+                    nullify(paramset(i)%param)
+                  endif
                 endif
               enddo
               deallocate(paramset)

--- a/io/post_regional.F90
+++ b/io/post_regional.F90
@@ -160,7 +160,7 @@ module post_regional
             if(mype==0) print *,'af read_xml at fh00,name=',trim(filenameflat)
           else if(ifhr > 0) then
             filenameflat = 'postxconfig-NT.txt'
-            if(size(paramset)>0) then
+            if(associated(paramset) .and. size(paramset)>0) then
               do i=1,size(paramset)
                 if (associated(paramset(i)%param)) then
                   if (size(paramset(i)%param)>0) then


### PR DESCRIPTION
## Description

This PR is to fix the issue with inline post in restart runs with gnu compiler. 
Is a change of answers expected from this PR?  The fix does not changes results. 



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)

- fixes noaa-emc/fv3atm/issues/<320>

## Testing

How were these changes tested?  
Run the control restart test with gnu compiler 

What compilers / HPCs was it tested with?  GNU
Are the changes covered by regression tests? 
NO, the current control restart does not have inline post. The global tests update (ufs-weather-model PR#561) has inline post turned on in the control and restart.
Have the ufs-weather-model regression test been run? On what platform? 
Tested on hera. Will test on other tier-1 platforms 
- Will the code updates change regression test baseline? 
This change does not change results, but the ufs-weather-model PR#561 does require new baseline.

- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- [ ufs-weather-model/pull/<561>](https://github.com/ufs-community/ufs-weather-model/pull/561)
-  [noaa-emc/fv3atm/pull/<321>](https://github.com/NOAA-EMC/fv3atm/pull/321)
