### PR TITLE
P7a: update ccpp physics to point to the release/P7a branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	branch = release/P7a


### PR DESCRIPTION
## Description

This PR points to ccpp/physics P7a branch, which has the gcycle fix. 
