### PR TITLE
Remove legacy print statements from io/FV3GFS_io.F90

### DIFF
--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -1064,7 +1064,6 @@ module FV3GFS_io_mod
           Sfcprop(nb)%oceanfrac(ix) = zero ! lake & ocean don't coexist in a cell
           if (Sfcprop(nb)%slmsk(ix) /= one) then
             if (Sfcprop(nb)%fice(ix) >= Model%min_lakeice) then
-              if (Sfcprop(nb)%slmsk(ix) < 1.9_r8)      &
                 Sfcprop(nb)%slmsk(ix) = 2.
             else if (Sfcprop(nb)%slmsk(ix) > 1.e-7) then
                 Sfcprop(nb)%slmsk(ix) = zero
@@ -1074,7 +1073,6 @@ module FV3GFS_io_mod
           Sfcprop(nb)%oceanfrac(ix) = one - Sfcprop(nb)%landfrac(ix)
           if (Sfcprop(nb)%slmsk(ix) /= one) then
             if (Sfcprop(nb)%fice(ix) >= Model%min_seaice) then
-              if (Sfcprop(nb)%slmsk(ix) < 1.9_r8)      &
                 Sfcprop(nb)%slmsk(ix) = 2.
             else if (Sfcprop(nb)%slmsk(ix) > 1.e-7) then
                 Sfcprop(nb)%slmsk(ix) = zero

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -1065,12 +1065,8 @@ module FV3GFS_io_mod
           if (Sfcprop(nb)%slmsk(ix) /= one) then
             if (Sfcprop(nb)%fice(ix) >= Model%min_lakeice) then
               if (Sfcprop(nb)%slmsk(ix) < 1.9_r8)      &
-                write(*,'(a,2i3,3f6.2)') 'reset lake slmsk=2 at nb,ix=' &
-               ,nb,ix,Sfcprop(nb)%fice(ix),Sfcprop(nb)%slmsk(ix),Sfcprop(nb)%lakefrac(ix)
                 Sfcprop(nb)%slmsk(ix) = 2.
             else if (Sfcprop(nb)%slmsk(ix) > 1.e-7) then
-                write(*,'(a,2i3,3f6.2)') 'reset lake slmsk=0 at nb,ix=' &
-               ,nb,ix,Sfcprop(nb)%fice(ix),Sfcprop(nb)%slmsk(ix),Sfcprop(nb)%lakefrac(ix)
                 Sfcprop(nb)%slmsk(ix) = zero
             end if
           end if
@@ -1079,12 +1075,8 @@ module FV3GFS_io_mod
           if (Sfcprop(nb)%slmsk(ix) /= one) then
             if (Sfcprop(nb)%fice(ix) >= Model%min_seaice) then
               if (Sfcprop(nb)%slmsk(ix) < 1.9_r8)      &
-                write(*,'(a,2i3,3f6.2)') 'reset sea slmsk=2 at nb,ix=' &
-               ,nb,ix,Sfcprop(nb)%fice(ix),Sfcprop(nb)%slmsk(ix),Sfcprop(nb)%landfrac(ix)
                 Sfcprop(nb)%slmsk(ix) = 2.
             else if (Sfcprop(nb)%slmsk(ix) > 1.e-7) then
-                write(*,'(a,2i3,4f6.2)') 'reset sea slmsk=0 at nb,ix=' &
-               ,nb,ix,Sfcprop(nb)%fice(ix),Sfcprop(nb)%slmsk(ix),Sfcprop(nb)%landfrac(ix)
                 Sfcprop(nb)%slmsk(ix) = zero
             end if
           end if


### PR DESCRIPTION
## Description

As the title says. Remove print statements used during the development phase, no longer needed.

### Issue(s) addressed

Fixes https://github.com/NOAA-EMC/fv3atm/issues/226.

## Testing

This PR will be pullet into the Thompson subcycling PR and merged as part of it.