### PR TITLE
Remove snet from noah lsm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = main
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	url = https://github.com/HelinWei-NOAA/ccpp-physics
+	branch = remove_snet_from_noah_lsm

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -2298,6 +2298,10 @@ module GFS_typedefs
     allocate (Sfcprop%fice     (IM))
 !   allocate (Sfcprop%hprim    (IM))
     allocate (Sfcprop%hprime   (IM,Model%nmtvr))
+    allocate(Sfcprop%albdvis_lnd (IM))
+    allocate(Sfcprop%albdnir_lnd (IM))
+    allocate(Sfcprop%albivis_lnd (IM))
+    allocate(Sfcprop%albinir_lnd (IM))
     allocate (Sfcprop%emis_lnd (IM))
 
     Sfcprop%slmsk     = clear_val
@@ -2319,6 +2323,10 @@ module GFS_typedefs
     Sfcprop%fice      = clear_val
 !   Sfcprop%hprim     = clear_val
     Sfcprop%hprime    = clear_val
+    Sfcprop%albdvis_lnd = clear_val
+    Sfcprop%albdnir_lnd = clear_val
+    Sfcprop%albivis_lnd = clear_val
+    Sfcprop%albinir_lnd = clear_val
     Sfcprop%emis_lnd  = clear_val
 
 !--- In (radiation only)
@@ -2473,20 +2481,12 @@ module GFS_typedefs
       allocate(Sfcprop%iceprv    (IM))
       allocate(Sfcprop%snowprv   (IM))
       allocate(Sfcprop%graupelprv(IM))
-      allocate(Sfcprop%albdvis_lnd (IM))
-      allocate(Sfcprop%albdnir_lnd (IM))
-      allocate(Sfcprop%albivis_lnd (IM))
-      allocate(Sfcprop%albinir_lnd (IM))
 
       Sfcprop%raincprv   = clear_val
       Sfcprop%rainncprv  = clear_val
       Sfcprop%iceprv     = clear_val
       Sfcprop%snowprv    = clear_val
       Sfcprop%graupelprv = clear_val
-      Sfcprop%albdvis_lnd = clear_val
-      Sfcprop%albdnir_lnd = clear_val
-      Sfcprop%albivis_lnd = clear_val
-      Sfcprop%albinir_lnd = clear_val
     end if
 ! Noah MP allocate and init when used
 !

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -1714,6 +1714,11 @@ module FV3GFS_io_mod
           sfc_var2(i,j,36) = Sfcprop(nb)%tsfc(ix)  !--- tsfc composite
           sfc_var2(i,j,37) = Sfcprop(nb)%zorl(ix)  !--- zorl composite
 !       endif
+          sfc_var2(i,j,38) = Sfcprop(nb)%albdvis_lnd(ix)
+          sfc_var2(i,j,39) = Sfcprop(nb)%albdnir_lnd(ix)
+          sfc_var2(i,j,40) = Sfcprop(nb)%albivis_lnd(ix)
+          sfc_var2(i,j,41) = Sfcprop(nb)%albinir_lnd(ix)
+          sfc_var2(i,j,42) = Sfcprop(nb)%emis_lnd(ix)
         if (Model%cplwav) then
           sfc_var2(i,j,nvar2m) = Sfcprop(nb)%zorlwav(ix) !--- zorlwav (zorl from wav)
         endif
@@ -1751,21 +1756,16 @@ module FV3GFS_io_mod
           sfc_var2(i,j,nvar2m+26) = Sfcprop(nb)%snowfallac_land(ix)
           sfc_var2(i,j,nvar2m+27) = Sfcprop(nb)%snowfallac_ice(ix)
           sfc_var2(i,j,nvar2m+28) = Sfcprop(nb)%sncovr_ice(ix)
-          sfc_var2(i,j,nvar2m+29) = Sfcprop(nb)%albdvis_lnd(ix)
-          sfc_var2(i,j,nvar2m+30) = Sfcprop(nb)%albdnir_lnd(ix)
-          sfc_var2(i,j,nvar2m+31) = Sfcprop(nb)%albivis_lnd(ix)
-          sfc_var2(i,j,nvar2m+32) = Sfcprop(nb)%albinir_lnd(ix)
-          sfc_var2(i,j,nvar2m+33) = Sfcprop(nb)%sfalb_lnd(ix)
-          sfc_var2(i,j,nvar2m+34) = Sfcprop(nb)%sfalb_lnd_bck(ix)
-          sfc_var2(i,j,nvar2m+35) = Sfcprop(nb)%albdvis_ice(ix)
-          sfc_var2(i,j,nvar2m+36) = Sfcprop(nb)%albdnir_ice(ix)
-          sfc_var2(i,j,nvar2m+37) = Sfcprop(nb)%albivis_ice(ix)
-          sfc_var2(i,j,nvar2m+38) = Sfcprop(nb)%albinir_ice(ix)
-          sfc_var2(i,j,nvar2m+39) = Sfcprop(nb)%sfalb_ice(ix)
-          sfc_var2(i,j,nvar2m+40) = Sfcprop(nb)%emis_lnd(ix)
-          sfc_var2(i,j,nvar2m+41) = Sfcprop(nb)%emis_ice(ix)
+          sfc_var2(i,j,nvar2m+29) = Sfcprop(nb)%sfalb_lnd(ix)
+          sfc_var2(i,j,nvar2m+30) = Sfcprop(nb)%sfalb_lnd_bck(ix)
+          sfc_var2(i,j,nvar2m+31) = Sfcprop(nb)%albdvis_ice(ix)
+          sfc_var2(i,j,nvar2m+32) = Sfcprop(nb)%albdnir_ice(ix)
+          sfc_var2(i,j,nvar2m+33) = Sfcprop(nb)%albivis_ice(ix)
+          sfc_var2(i,j,nvar2m+34) = Sfcprop(nb)%albinir_ice(ix)
+          sfc_var2(i,j,nvar2m+35) = Sfcprop(nb)%sfalb_ice(ix)
+          sfc_var2(i,j,nvar2m+36) = Sfcprop(nb)%emis_ice(ix)
           if (Model%rdlai) then
-            sfc_var2(i,j,nvar2m+42) = Sfcprop(nb)%xlaixy(ix)
+            sfc_var2(i,j,nvar2m+37) = Sfcprop(nb)%xlaixy(ix)
           endif
         else if (Model%lsm == Model%lsm_noahmp) then
           !--- Extra Noah MP variables

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -178,7 +178,7 @@ module FV3GFS_io_mod
        nsfcprop2d = nsfcprop2d + 1
      endif
    else
-     nsfcprop2d = 102
+     nsfcprop2d = 107
    endif
 
    allocate (temp2d(isc:iec,jsc:jec,nsfcprop2d+Model%ntot3d+Model%nctp))
@@ -303,8 +303,13 @@ module FV3GFS_io_mod
        temp2d(i,j,84) = GFS_Data(nb)%Radtend%sfcflw(ix)%dnfx0
        temp2d(i,j,85) = GFS_Data(nb)%Sfcprop%tiice(ix,1)
        temp2d(i,j,86) = GFS_Data(nb)%Sfcprop%tiice(ix,2)
+       temp2d(i,j,87) = GFS_Data(nb)%Sfcprop%albdvis_lnd(ix)
+       temp2d(i,j,88) = GFS_Data(nb)%Sfcprop%albdnir_lnd(ix)
+       temp2d(i,j,89) = GFS_Data(nb)%Sfcprop%albivis_lnd(ix)
+       temp2d(i,j,90) = GFS_Data(nb)%Sfcprop%albinir_lnd(ix)
+       temp2d(i,j,91) = GFS_Data(nb)%Sfcprop%emis_lnd(ix)
 
-       idx_opt = 87 
+       idx_opt = 92 
        if (Model%lsm == Model%lsm_noahmp) then
         temp2d(i,j,idx_opt)    = GFS_Data(nb)%Sfcprop%snowxy(ix)
         temp2d(i,j,idx_opt+1)  = GFS_Data(nb)%Sfcprop%tvxy(ix)
@@ -356,11 +361,6 @@ module FV3GFS_io_mod
         temp2d(i,j,idx_opt+46) = GFS_Data(nb)%Sfcprop%zsnsoxy(ix,2)
         temp2d(i,j,idx_opt+47) = GFS_Data(nb)%Sfcprop%zsnsoxy(ix,3)
         temp2d(i,j,idx_opt+48) = GFS_Data(nb)%Sfcprop%zsnsoxy(ix,4)
-        temp2d(i,j,idx_opt+49) = GFS_Data(nb)%Sfcprop%albdvis_lnd(ix)
-        temp2d(i,j,idx_opt+50) = GFS_Data(nb)%Sfcprop%albdnir_lnd(ix)
-        temp2d(i,j,idx_opt+51) = GFS_Data(nb)%Sfcprop%albivis_lnd(ix)
-        temp2d(i,j,idx_opt+52) = GFS_Data(nb)%Sfcprop%albinir_lnd(ix)
-        temp2d(i,j,idx_opt+53) = GFS_Data(nb)%Sfcprop%emis_lnd(ix)
         idx_opt = 141
        elseif (Model%lsm == Model%lsm_ruc) then
         temp2d(i,j,idx_opt)    = GFS_Data(nb)%Sfcprop%wetness(ix)
@@ -373,19 +373,14 @@ module FV3GFS_io_mod
         temp2d(i,j,idx_opt+7)  = GFS_Data(nb)%Sfcprop%snowfallac_land(ix)
         temp2d(i,j,idx_opt+8)  = GFS_Data(nb)%Sfcprop%snowfallac_ice(ix)
         temp2d(i,j,idx_opt+9)  = GFS_Data(nb)%Sfcprop%sncovr_ice(ix)
-        temp2d(i,j,idx_opt+10) = GFS_Data(nb)%Sfcprop%albdvis_lnd(ix)
-        temp2d(i,j,idx_opt+11) = GFS_Data(nb)%Sfcprop%albdnir_lnd(ix)
-        temp2d(i,j,idx_opt+12) = GFS_Data(nb)%Sfcprop%albivis_lnd(ix)
-        temp2d(i,j,idx_opt+13) = GFS_Data(nb)%Sfcprop%albinir_lnd(ix)
-        temp2d(i,j,idx_opt+14) = GFS_Data(nb)%Sfcprop%sfalb_lnd(ix)
-        temp2d(i,j,idx_opt+15) = GFS_Data(nb)%Sfcprop%sfalb_lnd_bck(ix)
-        temp2d(i,j,idx_opt+16) = GFS_Data(nb)%Sfcprop%albdvis_ice(ix)
-        temp2d(i,j,idx_opt+17) = GFS_Data(nb)%Sfcprop%albdnir_ice(ix)
-        temp2d(i,j,idx_opt+18) = GFS_Data(nb)%Sfcprop%albivis_ice(ix)
-        temp2d(i,j,idx_opt+19) = GFS_Data(nb)%Sfcprop%albinir_ice(ix)
-        temp2d(i,j,idx_opt+20) = GFS_Data(nb)%Sfcprop%sfalb_ice(ix)
-        temp2d(i,j,idx_opt+21) = GFS_Data(nb)%Sfcprop%emis_lnd(ix)
-        temp2d(i,j,idx_opt+22) = GFS_Data(nb)%Sfcprop%emis_ice(ix)
+        temp2d(i,j,idx_opt+10) = GFS_Data(nb)%Sfcprop%sfalb_lnd(ix)
+        temp2d(i,j,idx_opt+11) = GFS_Data(nb)%Sfcprop%sfalb_lnd_bck(ix)
+        temp2d(i,j,idx_opt+12) = GFS_Data(nb)%Sfcprop%albdvis_ice(ix)
+        temp2d(i,j,idx_opt+13) = GFS_Data(nb)%Sfcprop%albdnir_ice(ix)
+        temp2d(i,j,idx_opt+14) = GFS_Data(nb)%Sfcprop%albivis_ice(ix)
+        temp2d(i,j,idx_opt+15) = GFS_Data(nb)%Sfcprop%albinir_ice(ix)
+        temp2d(i,j,idx_opt+16) = GFS_Data(nb)%Sfcprop%sfalb_ice(ix)
+        temp2d(i,j,idx_opt+17) = GFS_Data(nb)%Sfcprop%emis_ice(ix)
         idx_opt = 110
         if (Model%rdlai) then
           temp2d(i,j,idx_opt+23) = GFS_Data(nb)%Sfcprop%xlaixy(ix)
@@ -517,9 +512,9 @@ module FV3GFS_io_mod
 
     if (Model%lsm == Model%lsm_ruc .and. warm_start) then
       if(Model%rdlai) then
-        nvar_s2r = 24
+        nvar_s2r = 19
       else
-        nvar_s2r = 23
+        nvar_s2r = 18
       end if
       nvar_s3  = 5
     else
@@ -532,7 +527,7 @@ module FV3GFS_io_mod
     endif
 
     if (Model%lsm == Model%lsm_noahmp) then
-      nvar_s2mp = 34       !mp 2D
+      nvar_s2mp = 29       !mp 2D
       nvar_s3mp = 5        !mp 3D
     else
       nvar_s2mp = 0        !mp 2D
@@ -628,7 +623,7 @@ module FV3GFS_io_mod
     enddo
  
 !   if (Model%frac_grid) then  ! needs more variables
-      nvar_s2m = 37
+      nvar_s2m = 42
 !   else
 !     nvar_s2m = 32
 !   endif
@@ -789,6 +784,11 @@ module FV3GFS_io_mod
         sfc_name2(36) = 'tsfc'  !tsfc composite
         sfc_name2(37) = 'zorl'  !zorl composite
 !     endif
+      sfc_name2(38) = 'albdvis_lnd'
+      sfc_name2(39) = 'albdnir_lnd'
+      sfc_name2(40) = 'albivis_lnd'
+      sfc_name2(41) = 'albinir_lnd'
+      sfc_name2(42) = 'emis_lnd'
       if(Model%cplwav) then
         sfc_name2(nvar_s2m) = 'zorlwav' !zorl on land portion of a cell
       endif
@@ -813,7 +813,7 @@ module FV3GFS_io_mod
       sfc_name2(nvar_s2m+17) = 'dt_cool'
       sfc_name2(nvar_s2m+18) = 'qrain'
 !
-! Only needed when Noah MP LSM is used - 34 2D
+! Only needed when Noah MP LSM is used - 29 2D
 !
       if (Model%lsm == Model%lsm_noahmp) then
         sfc_name2(nvar_s2m+19) = 'snowxy'
@@ -845,11 +845,6 @@ module FV3GFS_io_mod
         sfc_name2(nvar_s2m+45) = 'smcwtdxy'
         sfc_name2(nvar_s2m+46) = 'deeprechxy'
         sfc_name2(nvar_s2m+47) = 'rechxy'
-        sfc_name2(nvar_s2m+48) = 'albdvis_lnd'
-        sfc_name2(nvar_s2m+49) = 'albdnir_lnd'
-        sfc_name2(nvar_s2m+50) = 'albivis_lnd'
-        sfc_name2(nvar_s2m+51) = 'albinir_lnd'
-        sfc_name2(nvar_s2m+52) = 'emis_lnd'
       else if (Model%lsm == Model%lsm_ruc .and. warm_start) then
         sfc_name2(nvar_s2m+19) = 'wetness'
         sfc_name2(nvar_s2m+20) = 'clw_surf_land'
@@ -861,21 +856,16 @@ module FV3GFS_io_mod
         sfc_name2(nvar_s2m+26) = 'snowfall_acc_land'
         sfc_name2(nvar_s2m+27) = 'snowfall_acc_ice'
         sfc_name2(nvar_s2m+28) = 'sncovr_ice'
-        sfc_name2(nvar_s2m+29) = 'albdvis_lnd'
-        sfc_name2(nvar_s2m+30) = 'albdnir_lnd'
-        sfc_name2(nvar_s2m+31) = 'albivis_lnd'
-        sfc_name2(nvar_s2m+32) = 'albinir_lnd'
-        sfc_name2(nvar_s2m+33) = 'sfalb_lnd'
-        sfc_name2(nvar_s2m+34) = 'sfalb_lnd_bck'
-        sfc_name2(nvar_s2m+35) = 'albdvis_ice'
-        sfc_name2(nvar_s2m+36) = 'albdnir_ice'
-        sfc_name2(nvar_s2m+37) = 'albivis_ice'
-        sfc_name2(nvar_s2m+38) = 'albinir_ice'
-        sfc_name2(nvar_s2m+39) = 'sfalb_ice'
-        sfc_name2(nvar_s2m+40) = 'emis_lnd'
-        sfc_name2(nvar_s2m+41) = 'emis_ice'
+        sfc_name2(nvar_s2m+29) = 'sfalb_lnd'
+        sfc_name2(nvar_s2m+30) = 'sfalb_lnd_bck'
+        sfc_name2(nvar_s2m+31) = 'albdvis_ice'
+        sfc_name2(nvar_s2m+32) = 'albdnir_ice'
+        sfc_name2(nvar_s2m+33) = 'albivis_ice'
+        sfc_name2(nvar_s2m+34) = 'albinir_ice'
+        sfc_name2(nvar_s2m+35) = 'sfalb_ice'
+        sfc_name2(nvar_s2m+36) = 'emis_ice'
         if (Model%rdlai) then
-          sfc_name2(nvar_s2m+42) = 'lai'
+          sfc_name2(nvar_s2m+37) = 'lai'
         endif
       else if (Model%lsm == Model%lsm_ruc .and. Model%rdlai) then
         sfc_name2(nvar_s2m+19) = 'lai'
@@ -886,7 +876,10 @@ module FV3GFS_io_mod
         var2_p => sfc_var2(:,:,num)
         if (trim(sfc_name2(num)) == 'sncovr'.or. trim(sfc_name2(num)) == 'tsfcl' .or. trim(sfc_name2(num)) == 'zorll' &
                                             .or. trim(sfc_name2(num)) == 'zorli' .or. trim(sfc_name2(num)) == 'zorlwav' &
-                                            .or. trim(sfc_name2(num)) == 'tsfc'  .or. trim(sfc_name2(num)) ==  'zorl') then
+                                            .or. trim(sfc_name2(num)) == 'tsfc'  .or. trim(sfc_name2(num)) ==  'zorl' &
+                                .or.trim(sfc_name2(num)) == 'albdvis_lnd' .or.  trim(sfc_name2(num)) == 'albdnir_lnd' &
+                                .or.trim(sfc_name2(num)) == 'albivis_lnd' .or.  trim(sfc_name2(num)) == 'albinir_lnd' &
+                                .or.trim(sfc_name2(num)) == 'emis_lnd' ) then
           id_restart = register_restart_field(Sfc_restart, fn_srf, sfc_name2(num), var2_p, domain=fv_domain, mandatory=.false.)
         else
           id_restart = register_restart_field(Sfc_restart, fn_srf, sfc_name2(num), var2_p, domain=fv_domain)
@@ -1044,6 +1037,11 @@ module FV3GFS_io_mod
 !         Sfcprop(nb)%zorll(ix)  = Sfcprop(nb)%zorlw(ix)
 !         Sfcprop(nb)%zorli(ix)  = Sfcprop(nb)%zorlw(ix)
 !       endif
+          Sfcprop(nb)%albdvis_lnd(ix)= sfc_var2(i,j,37)
+          Sfcprop(nb)%albdnir_lnd(ix)= sfc_var2(i,j,38)
+          Sfcprop(nb)%albivis_lnd(ix)= sfc_var2(i,j,39)
+          Sfcprop(nb)%albinir_lnd(ix)= sfc_var2(i,j,40)
+          Sfcprop(nb)%emis_lnd(ix)   = sfc_var2(i,j,41)
         if(Model%cplwav) then
           Sfcprop(nb)%zorlwav(ix)  = sfc_var2(i,j,nvar_s2m) !--- (zorw  from wave model)
         else
@@ -1146,21 +1144,16 @@ module FV3GFS_io_mod
           Sfcprop(nb)%snowfallac_land(ix) = sfc_var2(i,j,nvar_s2m+26)
           Sfcprop(nb)%snowfallac_ice(ix)  = sfc_var2(i,j,nvar_s2m+27)
           Sfcprop(nb)%sncovr_ice(ix)      = sfc_var2(i,j,nvar_s2m+28)
-          Sfcprop(nb)%albdvis_lnd(ix)     = sfc_var2(i,j,nvar_s2m+29)
-          Sfcprop(nb)%albdnir_lnd(ix)     = sfc_var2(i,j,nvar_s2m+30)
-          Sfcprop(nb)%albivis_lnd(ix)     = sfc_var2(i,j,nvar_s2m+31)
-          Sfcprop(nb)%albinir_lnd(ix)     = sfc_var2(i,j,nvar_s2m+32)
-          Sfcprop(nb)%sfalb_lnd(ix)       = sfc_var2(i,j,nvar_s2m+33)
-          Sfcprop(nb)%sfalb_lnd_bck(ix)   = sfc_var2(i,j,nvar_s2m+34)
-          Sfcprop(nb)%albdvis_ice(ix)     = sfc_var2(i,j,nvar_s2m+35)
-          Sfcprop(nb)%albdnir_ice(ix)     = sfc_var2(i,j,nvar_s2m+36)
-          Sfcprop(nb)%albivis_ice(ix)     = sfc_var2(i,j,nvar_s2m+37)
-          Sfcprop(nb)%albinir_ice(ix)     = sfc_var2(i,j,nvar_s2m+38)
-          Sfcprop(nb)%sfalb_ice(ix)       = sfc_var2(i,j,nvar_s2m+39)
-          Sfcprop(nb)%emis_lnd(ix)        = sfc_var2(i,j,nvar_s2m+40)
-          Sfcprop(nb)%emis_ice(ix)        = sfc_var2(i,j,nvar_s2m+41)
+          Sfcprop(nb)%sfalb_lnd(ix)       = sfc_var2(i,j,nvar_s2m+29)
+          Sfcprop(nb)%sfalb_lnd_bck(ix)   = sfc_var2(i,j,nvar_s2m+30)
+          Sfcprop(nb)%albdvis_ice(ix)     = sfc_var2(i,j,nvar_s2m+31)
+          Sfcprop(nb)%albdnir_ice(ix)     = sfc_var2(i,j,nvar_s2m+32)
+          Sfcprop(nb)%albivis_ice(ix)     = sfc_var2(i,j,nvar_s2m+33)
+          Sfcprop(nb)%albinir_ice(ix)     = sfc_var2(i,j,nvar_s2m+34)
+          Sfcprop(nb)%sfalb_ice(ix)       = sfc_var2(i,j,nvar_s2m+35)
+          Sfcprop(nb)%emis_ice(ix)        = sfc_var2(i,j,nvar_s2m+36)
           if (Model%rdlai) then
-            Sfcprop(nb)%xlaixy(ix)        = sfc_var2(i,j,nvar_s2m+42)
+            Sfcprop(nb)%xlaixy(ix)        = sfc_var2(i,j,nvar_s2m+37)
           endif
         else if (Model%lsm == Model%lsm_ruc) then
           ! Initialize RUC snow cover on ice from snow cover
@@ -1199,11 +1192,6 @@ module FV3GFS_io_mod
           Sfcprop(nb)%smcwtdxy(ix)   = sfc_var2(i,j,nvar_s2m+45)
           Sfcprop(nb)%deeprechxy(ix) = sfc_var2(i,j,nvar_s2m+46)
           Sfcprop(nb)%rechxy(ix)     = sfc_var2(i,j,nvar_s2m+47)
-          Sfcprop(nb)%albdvis_lnd(ix)= sfc_var2(i,j,nvar_s2m+48)
-          Sfcprop(nb)%albdnir_lnd(ix)= sfc_var2(i,j,nvar_s2m+49)
-          Sfcprop(nb)%albivis_lnd(ix)= sfc_var2(i,j,nvar_s2m+50)
-          Sfcprop(nb)%albinir_lnd(ix)= sfc_var2(i,j,nvar_s2m+51)
-          Sfcprop(nb)%emis_lnd(ix)   = sfc_var2(i,j,nvar_s2m+52)
         endif
 
         if (Model%lsm == Model%lsm_noah .or. Model%lsm == Model%lsm_noahmp .or. Model%lsm == Model%lsm_noah_wrfv4 .or. (.not.warm_start)) then
@@ -1390,7 +1378,7 @@ module FV3GFS_io_mod
     real(kind=kind_phys), pointer, dimension(:,:,:) :: var3_p3 => NULL()
 
 !   if (Model%frac_grid) then ! needs more variables
-      nvar2m = 37
+      nvar2m = 42
 !   else
 !     nvar2m = 32
 !   endif
@@ -1398,9 +1386,9 @@ module FV3GFS_io_mod
     nvar2o = 18
     if (Model%lsm == Model%lsm_ruc) then
       if (Model%rdlai) then
-        nvar2r = 24
+        nvar2r = 19
       else
-        nvar2r = 23
+        nvar2r = 18
       endif
       nvar3  = 5
     else
@@ -1502,6 +1490,11 @@ module FV3GFS_io_mod
         sfc_name2(36) = 'tsfc'    !tsfc composite
         sfc_name2(37) = 'zorl'    !zorl composite
 !     endif
+      sfc_name2(38) = 'albdvis_lnd'
+      sfc_name2(39) = 'albdnir_lnd'
+      sfc_name2(40) = 'albivis_lnd'
+      sfc_name2(41) = 'albinir_lnd'
+      sfc_name2(42) = 'emis_lnd'
       if (Model%cplwav) then
         sfc_name2(nvar2m) = 'zorlwav'   !zorl on land portion of a cell
       endif
@@ -1535,21 +1528,16 @@ module FV3GFS_io_mod
         sfc_name2(nvar2m+26) = 'snowfall_acc_land'
         sfc_name2(nvar2m+27) = 'snowfall_acc_ice'
         sfc_name2(nvar2m+28) = 'sncovr_ice'
-        sfc_name2(nvar2m+29) = 'albdvis_lnd'
-        sfc_name2(nvar2m+30) = 'albdnir_lnd'
-        sfc_name2(nvar2m+31) = 'albivis_lnd'
-        sfc_name2(nvar2m+32) = 'albinir_lnd'
-        sfc_name2(nvar2m+33) = 'sfalb_lnd'
-        sfc_name2(nvar2m+34) = 'sfalb_lnd_bck'
-        sfc_name2(nvar2m+35) = 'albdvis_ice'
-        sfc_name2(nvar2m+36) = 'albdnir_ice'
-        sfc_name2(nvar2m+37) = 'albivis_ice'
-        sfc_name2(nvar2m+38) = 'albinir_ice'
-        sfc_name2(nvar2m+39) = 'sfalb_ice'
-        sfc_name2(nvar2m+40) = 'emis_lnd'
-        sfc_name2(nvar2m+41) = 'emis_ice'
+        sfc_name2(nvar2m+29) = 'sfalb_lnd'
+        sfc_name2(nvar2m+30) = 'sfalb_lnd_bck'
+        sfc_name2(nvar2m+31) = 'albdvis_ice'
+        sfc_name2(nvar2m+32) = 'albdnir_ice'
+        sfc_name2(nvar2m+33) = 'albivis_ice'
+        sfc_name2(nvar2m+34) = 'albinir_ice'
+        sfc_name2(nvar2m+35) = 'sfalb_ice'
+        sfc_name2(nvar2m+36) = 'emis_ice'
         if (Model%rdlai) then
-          sfc_name2(nvar2m+42) = 'lai'
+          sfc_name2(nvar2m+37) = 'lai'
         endif
       else if(Model%lsm == Model%lsm_noahmp) then
         ! Only needed when Noah MP LSM is used - 29 2D
@@ -1588,7 +1576,11 @@ module FV3GFS_io_mod
       do num = 1,nvar2m
         var2_p => sfc_var2(:,:,num)
         if (trim(sfc_name2(num)) == 'sncovr'.or.trim(sfc_name2(num)) == 'tsfcl'.or.trim(sfc_name2(num)) == 'zorll' &
-                                            .or.trim(sfc_name2(num)) == 'zorli' .or.trim(sfc_name2(num)) == 'zorlwav') then
+                                            .or.trim(sfc_name2(num)) == 'zorli' .or.trim(sfc_name2(num)) == 'zorlwav' &
+                               .or.trim(sfc_name2(num)) == 'albdvis_lnd' .or.  trim(sfc_name2(num)) == 'albdnir_lnd' &
+                               .or.trim(sfc_name2(num)) == 'albivis_lnd' .or.  trim(sfc_name2(num)) == 'albinir_lnd' &
+                               .or.trim(sfc_name2(num)) == 'emis_lnd' ) then
+
           id_restart = register_restart_field(Sfc_restart, fn_srf, sfc_name2(num), var2_p, domain=fv_domain, mandatory=.false.)
         else
           id_restart = register_restart_field(Sfc_restart, fn_srf, sfc_name2(num), var2_p, domain=fv_domain)


### PR DESCRIPTION
This PR contains the fix to the net surface shortwave radiation (snet) to the Noah LSM when fraction grid is turned on. The current snet is computed using the composited albedo and is improperly treated as the snet over land only as a forcing to the Noah LSM. The fix will use 4 components of both surface downward shortwave and albedo to calculate the snet over land.

[#669](https://github.com/NCAR/ccpp-physics/issues/669)



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
