### PR TITLE
release/P7b: update ccpp physics to with gcycle fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = main
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = release/P7b
+	url = https://github.com/junwang-noaa/ccpp-physics
+	branch = gcycle_fix_p7b

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = main
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/junwang-noaa/ccpp-physics
-	branch = gcycle_fix_p7b
+	url = https://github.com/NCAR/ccpp-physics
+	branch = release/P7b


### PR DESCRIPTION
## Description

The PR is adding the fix for tile fixed file in ccpp physics gcycle.F90


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- ncar/ccpp-physics [PR#674](https://github.com/NCAR/ccpp-physics/pull/674)
- noaa-emc/fv3atm [PR#326](https://github.com/noaa-emc/fv3atm/pull/326)
- ufs-weather-model [PR#629](https://github.com/ufs-community/ufs-weather-model/pull/629)
