### PR TITLE
Thompson subcycling for develop, remove legacy print statements from io/FV3GFS_io.F90

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,13 +4,9 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	#url = https://github.com/NCAR/ccpp-framework
-	#branch = main
-	url = https://github.com/climbfuji/ccpp-framework
-	branch = thompson_subcycling_v2_tutorial
+	url = https://github.com/NCAR/ccpp-framework
+	branch = main
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = main
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = thompson_subcycling_v2_tutorial
+	url = https://github.com/NCAR/ccpp-physics
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,13 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
-	branch = main
+	#url = https://github.com/NCAR/ccpp-framework
+	#branch = main
+	url = https://github.com/climbfuji/ccpp-framework
+	branch = thompson_subcycling_v2_tutorial
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = main
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = thompson_subcycling_v2_tutorial

--- a/ccpp/suites/suite_FV3_GFS_v16_thompson.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_thompson.xml
@@ -76,7 +76,11 @@
       <scheme>cnvc90</scheme>
       <scheme>GFS_MP_generic_pre</scheme>
       <scheme>mp_thompson_pre</scheme>
+    </subcycle>
+    <subcycle loop="2">
       <scheme>mp_thompson</scheme>
+    </subcycle>
+    <subcycle loop="1">
       <scheme>mp_thompson_post</scheme>
       <scheme>GFS_MP_generic_post</scheme>
       <scheme>maximum_hourly_diagnostics</scheme>

--- a/ccpp/suites/suite_FV3_GSD_noah.xml
+++ b/ccpp/suites/suite_FV3_GSD_noah.xml
@@ -76,7 +76,11 @@
       <scheme>cnvc90</scheme>
       <scheme>GFS_MP_generic_pre</scheme>
       <scheme>mp_thompson_pre</scheme>
+    </subcycle>
+    <subcycle loop="4">
       <scheme>mp_thompson</scheme>
+    </subcycle>
+    <subcycle loop="1">
       <scheme>mp_thompson_post</scheme>
       <scheme>GFS_MP_generic_post</scheme>
       <scheme>cu_gf_driver_post</scheme>

--- a/ccpp/suites/suite_FV3_GSD_v0.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0.xml
@@ -75,7 +75,11 @@
       <scheme>cnvc90</scheme>
       <scheme>GFS_MP_generic_pre</scheme>
       <scheme>mp_thompson_pre</scheme>
+    </subcycle>
+    <subcycle loop="1">
       <scheme>mp_thompson</scheme>
+    </subcycle>
+    <subcycle loop="1">
       <scheme>mp_thompson_post</scheme>
       <scheme>GFS_MP_generic_post</scheme>
       <scheme>cu_gf_driver_post</scheme>

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -1064,7 +1064,6 @@ module FV3GFS_io_mod
           Sfcprop(nb)%oceanfrac(ix) = zero ! lake & ocean don't coexist in a cell
           if (Sfcprop(nb)%slmsk(ix) /= one) then
             if (Sfcprop(nb)%fice(ix) >= Model%min_lakeice) then
-              if (Sfcprop(nb)%slmsk(ix) < 1.9_r8)      &
                 Sfcprop(nb)%slmsk(ix) = 2.
             else if (Sfcprop(nb)%slmsk(ix) > 1.e-7) then
                 Sfcprop(nb)%slmsk(ix) = zero
@@ -1074,7 +1073,6 @@ module FV3GFS_io_mod
           Sfcprop(nb)%oceanfrac(ix) = one - Sfcprop(nb)%landfrac(ix)
           if (Sfcprop(nb)%slmsk(ix) /= one) then
             if (Sfcprop(nb)%fice(ix) >= Model%min_seaice) then
-              if (Sfcprop(nb)%slmsk(ix) < 1.9_r8)      &
                 Sfcprop(nb)%slmsk(ix) = 2.
             else if (Sfcprop(nb)%slmsk(ix) > 1.e-7) then
                 Sfcprop(nb)%slmsk(ix) = zero

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -1065,12 +1065,8 @@ module FV3GFS_io_mod
           if (Sfcprop(nb)%slmsk(ix) /= one) then
             if (Sfcprop(nb)%fice(ix) >= Model%min_lakeice) then
               if (Sfcprop(nb)%slmsk(ix) < 1.9_r8)      &
-                write(*,'(a,2i3,3f6.2)') 'reset lake slmsk=2 at nb,ix=' &
-               ,nb,ix,Sfcprop(nb)%fice(ix),Sfcprop(nb)%slmsk(ix),Sfcprop(nb)%lakefrac(ix)
                 Sfcprop(nb)%slmsk(ix) = 2.
             else if (Sfcprop(nb)%slmsk(ix) > 1.e-7) then
-                write(*,'(a,2i3,3f6.2)') 'reset lake slmsk=0 at nb,ix=' &
-               ,nb,ix,Sfcprop(nb)%fice(ix),Sfcprop(nb)%slmsk(ix),Sfcprop(nb)%lakefrac(ix)
                 Sfcprop(nb)%slmsk(ix) = zero
             end if
           end if
@@ -1079,12 +1075,8 @@ module FV3GFS_io_mod
           if (Sfcprop(nb)%slmsk(ix) /= one) then
             if (Sfcprop(nb)%fice(ix) >= Model%min_seaice) then
               if (Sfcprop(nb)%slmsk(ix) < 1.9_r8)      &
-                write(*,'(a,2i3,3f6.2)') 'reset sea slmsk=2 at nb,ix=' &
-               ,nb,ix,Sfcprop(nb)%fice(ix),Sfcprop(nb)%slmsk(ix),Sfcprop(nb)%landfrac(ix)
                 Sfcprop(nb)%slmsk(ix) = 2.
             else if (Sfcprop(nb)%slmsk(ix) > 1.e-7) then
-                write(*,'(a,2i3,4f6.2)') 'reset sea slmsk=0 at nb,ix=' &
-               ,nb,ix,Sfcprop(nb)%fice(ix),Sfcprop(nb)%slmsk(ix),Sfcprop(nb)%landfrac(ix)
                 Sfcprop(nb)%slmsk(ix) = zero
             end if
           end if


### PR DESCRIPTION
## Note

This PR **replaces** https://github.com/NOAA-EMC/fv3atm/pull/316. It contains exactly the same changes, but as new commits due to the "UFS code commit process" tutorial held June 9/10, 2021. For discussion and approval of the original code changes, see https://github.com/NOAA-EMC/fv3atm/pull/316.

## Description

This PR does the following:
- Set number of subcycles for Thompson MP to 4/2 in suites FV3_GSD_noah and FV3_GFS_v16_thompson

This PR also contains the changes in https://github.com/NOAA-EMC/fv3atm/pull/324 (remove legacy print statements from io/FV3GFS_io.F90).

### Issue(s) addressed

Fixes https://github.com/NOAA-EMC/fv3atm/issues/226

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/632

## Dependencies

https://github.com/NCAR/ccpp-framework/pull/379
https://github.com/NCAR/ccpp-physics/pull/676
https://github.com/NOAA-EMC/fv3atm/pull/328
https://github.com/ufs-community/ufs-weather-model/pull/632
