### PR TITLE
update CCPP standard names for consistency

### DIFF
--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -272,27 +272,27 @@ OPTIONAL_ARGUMENTS = {
         },
     'mp_thompson' : {
         'mp_thompson_init' : [
-            'cloud_droplet_number_concentration',
-            'water_friendly_aerosol_number_concentration',
-            'ice_friendly_aerosol_number_concentration',
-            'tendency_of_water_friendly_aerosols_at_surface',
-            'tendency_of_ice_friendly_aerosols_at_surface',
+            'mass_number_concentration_of_cloud_liquid_water_particles_in_air',
+            'mass_number_concentration_of_hygroscopic_aerosols',
+            'mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols',
+            'tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer',
+            'tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer',
             # DH* 2020-06-01: turn off calculation of effective radii, now done in GFS_rrtmg_pre
-            #'effective_radius_of_stratiform_cloud_liquid_water_particle_in_um',
-            #'effective_radius_of_stratiform_cloud_ice_particle_in_um',
-            #'effective_radius_of_stratiform_cloud_snow_particle_in_um',
+            #'effective_radius_of_stratiform_cloud_liquid_water_particle',
+            #'effective_radius_of_stratiform_cloud_ice_particle',
+            #'effective_radius_of_stratiform_cloud_snow_particle',
             # *DH 2020-06-01
             ],
         'mp_thompson_run' : [
-            'cloud_droplet_number_concentration_updated_by_physics',
-            'water_friendly_aerosol_number_concentration_updated_by_physics',
-            'ice_friendly_aerosol_number_concentration_updated_by_physics',
-            'tendency_of_water_friendly_aerosols_at_surface',
-            'tendency_of_ice_friendly_aerosols_at_surface',
+            'mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state',
+            'mass_number_concentration_of_hygroscopic_aerosols_of_new_state',
+            'mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_of_new_state',
+            'tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer',
+            'tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer',
             # DH* 2020-06-01: turn off calculation of effective radii, now done in GFS_rrtmg_pre
-            #'effective_radius_of_stratiform_cloud_liquid_water_particle_in_um',
-            #'effective_radius_of_stratiform_cloud_ice_particle_in_um',
-            #'effective_radius_of_stratiform_cloud_snow_particle_in_um',
+            #'effective_radius_of_stratiform_cloud_liquid_water_particle',
+            #'effective_radius_of_stratiform_cloud_ice_particle',
+            #'effective_radius_of_stratiform_cloud_snow_particle',
             # *DH 2020-06-01
             ],
         },
@@ -303,13 +303,13 @@ OPTIONAL_ARGUMENTS = {
          },
     'GFS_rrtmgp_sw_post' : {
          'GFS_rrtmgp_sw_post_run' : [
-             'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step',
+             'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_timestep',
              'components_of_surface_downward_shortwave_fluxes',
              ],
          },
     'GFS_rrtmgp_lw_post' : {
          'GFS_rrtmgp_lw_post_run' : [
-             'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step',
+             'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_timestep',
              ],
          },
     #'subroutine_name_1' : 'all',

--- a/ccpp/data/CCPP_data.meta
+++ b/ccpp/data/CCPP_data.meta
@@ -46,5 +46,5 @@
   standard_name = GFS_interstitial_type_instance_all_threads
   long_name = instance of derived type GFS_interstitial_type
   units = DDT
-  dimensions = (omp_threads)
+  dimensions = (number_of_openmp_threads)
   type = GFS_interstitial_type

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -10,14 +10,14 @@
   standard_name = geopotential_at_interface
   long_name = geopotential at model layer interfaces
   units = m2 s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
 [prsi]
   standard_name = air_pressure_at_interface
   long_name = air pressure at model layer interfaces
   units = Pa
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
 [prsi(:,1)]
@@ -28,14 +28,14 @@
   type = real
   kind = kind_phys
 [prsik]
-  standard_name = dimensionless_exner_function_at_model_interfaces
+  standard_name = dimensionless_exner_function_at_interface
   long_name = dimensionless Exner function at model layer interfaces
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
 [prsik(:,1)]
-  standard_name = dimensionless_exner_function_at_lowest_model_interface
+  standard_name = surface_dimensionless_exner_function
   long_name = dimensionless Exner function at lowest model interface
   units = none
   dimensions = (horizontal_loop_extent)
@@ -45,32 +45,32 @@
   standard_name = geopotential
   long_name = geopotential at model layer centers
   units = m2 s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [prsl]
   standard_name = air_pressure
   long_name = mean layer pressure
   units = Pa
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [prsl(:,1)]
-  standard_name = air_pressure_at_lowest_model_layer
+  standard_name = air_pressure_at_surface_adjacent_layer
   long_name = mean pressure at lowest model layer
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [prslk]
-  standard_name = dimensionless_exner_function_at_model_layers
+  standard_name = dimensionless_exner_function
   long_name = dimensionless Exner function at model layer centers
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [prslk(:,1)]
-  standard_name = dimensionless_exner_function_at_lowest_model_layer
+  standard_name = dimensionless_exner_function_at_surface_adjacent_layer
   long_name = dimensionless Exner function at lowest model layer
   units = none
   dimensions = (horizontal_loop_extent)
@@ -87,11 +87,11 @@
   standard_name = x_wind
   long_name = zonal wind
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [ugrs(:,1)]
-  standard_name = x_wind_at_lowest_model_layer
+  standard_name = x_wind_at_surface_adjacent_layer
   long_name = zonal wind at lowest model layer
   units = m s-1
   dimensions = (horizontal_loop_extent)
@@ -101,32 +101,32 @@
   standard_name = y_wind
   long_name = meridional wind
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [vgrs(:,1)]
-  standard_name = y_wind_at_lowest_model_layer
+  standard_name = y_wind_at_surface_adjacent_layer
   long_name = meridional wind at lowest model layer
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [vvl]
-  standard_name = omega
+  standard_name = lagrangian_tendency_of_air_pressure
   long_name = layer mean vertical velocity
   units = Pa s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [tgrs]
   standard_name = air_temperature
   long_name = model layer mean temperature
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [tgrs(:,1)]
-  standard_name = air_temperature_at_lowest_model_layer
+  standard_name = air_temperature_at_surface_adjacent_layer
   long_name = mean temperature at lowest model layer
   units = K
   dimensions = (horizontal_loop_extent)
@@ -136,136 +136,136 @@
   standard_name = tracer_concentration
   long_name = model layer mean tracer concentration
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_water_vapor)]
-  standard_name = water_vapor_specific_humidity
+[qgrs(:,:,index_of_specific_humidity_in_tracer_concentration_array)]
+  standard_name = specific_humidity
   long_name = water vapor specific humidity
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[qgrs(:,1,index_for_water_vapor)]
-  standard_name = water_vapor_specific_humidity_at_lowest_model_layer
+[qgrs(:,1,index_of_specific_humidity_in_tracer_concentration_array)]
+  standard_name = specific_humidity_at_surface_adjacent_layer
   long_name = water vapor specific humidity at lowest model layer
   units = kg kg-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_liquid_cloud_condensate)]
-  standard_name = cloud_condensed_water_mixing_ratio
+[qgrs(:,:,index_of_cloud_liquid_water_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = cloud_liquid_water_mixing_ratio
   long_name = ratio of mass of cloud water to mass of dry air plus vapor (without condensates)
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[qgrs(:,1,index_for_liquid_cloud_condensate)]
-  standard_name = cloud_condensed_water_mixing_ratio_at_lowest_model_layer
+[qgrs(:,1,index_of_cloud_liquid_water_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = cloud_liquid_water_mixing_ratio_at_surface_adjacent_layer
   long_name = ratio of mass of cloud water to mass of dry air plus vapor (without condensates) at lowest model layer
   units = kg kg-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_ice_cloud_condensate)]
-  standard_name = ice_water_mixing_ratio
+[qgrs(:,:,index_of_cloud_ice_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = cloud_ice_mixing_ratio
   long_name = ratio of mass of ice water to mass of dry air plus vapor (without condensates)
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_rain_water)]
-  standard_name = rain_water_mixing_ratio
+[qgrs(:,:,index_of_rain_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = rain_mixing_ratio
   long_name = ratio of mass of rain water to mass of dry air plus vapor (without condensates)
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_snow_water)]
-  standard_name = snow_water_mixing_ratio
+[qgrs(:,:,index_of_snow_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = snow_mixing_ratio
   long_name = ratio of mass of snow water to mass of dry air plus vapor (without condensates)
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_graupel)]
+[qgrs(:,:,index_of_graupel_mixing_ratio_in_tracer_concentration_array)]
   standard_name = graupel_mixing_ratio
   long_name = ratio of mass of graupel to mass of dry air plus vapor (without condensates)
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_ozone)]
+[qgrs(:,:,index_of_ozone_mixing_ratio_in_tracer_concentration_array)]
   standard_name = ozone_mixing_ratio
   long_name = ozone mixing ratio
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_water_friendly_aerosols)]
-  standard_name = water_friendly_aerosol_number_concentration
+[qgrs(:,:,index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_hygroscopic_aerosols
   long_name = number concentration of water-friendly aerosols
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
-  active = (index_for_water_friendly_aerosols > 0)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  active = (index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array > 0)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_ice_friendly_aerosols)]
-  standard_name = ice_friendly_aerosol_number_concentration
+[qgrs(:,:,index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols
   long_name = number concentration of ice-friendly aerosols
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
-  active = (index_for_ice_friendly_aerosols > 0)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  active = (index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array > 0)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_liquid_cloud_number_concentration)]
-  standard_name = cloud_droplet_number_concentration
+[qgrs(:,:,index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_cloud_liquid_water_particles_in_air
   long_name = number concentration of cloud droplets (liquid)
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_liquid_cloud_number_concentration > 0)
-[qgrs(:,:,index_for_ice_cloud_number_concentration)]
-  standard_name = ice_number_concentration
+  active = (index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array > 0)
+[qgrs(:,:,index_of_mass_number_concentration_of_cloud_ice_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_cloud_ice_water_crystals_in_air
   long_name = number concentration of ice
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_rain_number_concentration)]
-  standard_name = rain_number_concentration
+[qgrs(:,:,index_of_mass_number_concentration_of_rain_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_rain_water_in_air
   long_name = number concentration of rain
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_snow_number_concentration)]
-  standard_name = snow_number_concentration
+[qgrs(:,:,index_of_mass_number_concentration_of_snow_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_snow_in_air
   long_name = number concentration of snow
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_graupel_number_concentration)]
-  standard_name = graupel_number_concentration
+[qgrs(:,:,index_of_mass_number_concentration_of_graupel_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_graupel_in_air
   long_name = number concentration of graupel
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[qgrs(:,:,index_for_turbulent_kinetic_energy)]
+[qgrs(:,:,index_of_turbulent_kinetic_energy_in_tracer_concentration_array)]
   standard_name = turbulent_kinetic_energy
   long_name = turbulent kinetic energy
   units = J
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [diss_est]
   standard_name = dissipation_estimate_of_air_temperature_at_model_layers
   long_name = dissipation estimate model layer mean temperature
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 
@@ -279,174 +279,174 @@
   name = GFS_stateout_type
   type = ddt
 [gu0]
-  standard_name = x_wind_updated_by_physics
+  standard_name = x_wind_of_new_state
   long_name = zonal wind updated by physics
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [gu0(:,1)]
-  standard_name = x_wind_at_lowest_model_layer_updated_by_physics
+  standard_name = x_wind_of_new_state_at_surface_adjacent_layer
   long_name = zonal wind at lowest model layer updated by physics
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [gv0]
-  standard_name = y_wind_updated_by_physics
+  standard_name = y_wind_of_new_state
   long_name = meridional wind updated by physics
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [gv0(:,1)]
-  standard_name = y_wind_at_lowest_model_layer_updated_by_physics
+  standard_name = y_wind_of_new_state_at_surface_adjacent_layer
   long_name = meridional wind at lowest model layer updated by physics
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [gt0]
-  standard_name = air_temperature_updated_by_physics
+  standard_name = air_temperature_of_new_state
   long_name = temperature updated by physics
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [gt0(:,1)]
-  standard_name = air_temperature_at_lowest_model_layer_updated_by_physics
+  standard_name = air_temperature_of_new_state_at_surface_adjacent_layer
   long_name = temperature at lowest model layer updated by physics
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [gq0]
-  standard_name = tracer_concentration_updated_by_physics
+  standard_name = tracer_concentration_of_new_state
   long_name = tracer concentration updated by physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_water_vapor)]
-  standard_name = water_vapor_specific_humidity_updated_by_physics
+[gq0(:,:,index_of_specific_humidity_in_tracer_concentration_array)]
+  standard_name = specific_humidity_of_new_state
   long_name = water vapor specific humidity updated by physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,1,index_for_water_vapor)]
-  standard_name = water_vapor_specific_humidity_at_lowest_model_layer_updated_by_physics
+[gq0(:,1,index_of_specific_humidity_in_tracer_concentration_array)]
+  standard_name = specific_humidity_of_new_state_at_surface_adjacent_layer
   long_name = water vapor specific humidity at lowest model layer updated by physics
   units = kg kg-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_ozone)]
-  standard_name = ozone_concentration_updated_by_physics
+[gq0(:,:,index_of_ozone_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = ozone_concentration_of_new_state
   long_name = ozone concentration updated by physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_liquid_cloud_condensate)]
-  standard_name = cloud_condensed_water_mixing_ratio_updated_by_physics
+[gq0(:,:,index_of_cloud_liquid_water_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = cloud_liquid_water_mixing_ratio_of_new_state
   long_name = ratio of mass of cloud water to mass of dry air plus vapor (without condensates) updated by physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_ice_cloud_condensate)]
-  standard_name = ice_water_mixing_ratio_updated_by_physics
+[gq0(:,:,index_of_cloud_ice_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = cloud_ice_mixing_ratio_of_new_state
   long_name = ratio of mass of ice water to mass of dry air plus vapor (without condensates) updated by physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_rain_water)]
-  standard_name = rain_water_mixing_ratio_updated_by_physics
+[gq0(:,:,index_of_rain_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = rain_mixing_ratio_of_new_state
   long_name = ratio of mass of rain water to mass of dry air plus vapor (without condensates) updated by physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_snow_water)]
-  standard_name = snow_water_mixing_ratio_updated_by_physics
+[gq0(:,:,index_of_snow_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = snow_mixing_ratio_of_new_state
   long_name = ratio of mass of snow water to mass of dry air plus vapor (without condensates) updated by physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_graupel)]
-  standard_name = graupel_mixing_ratio_updated_by_physics
+[gq0(:,:,index_of_graupel_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = graupel_mixing_ratio_of_new_state
   long_name = ratio of mass of graupel to mass of dry air plus vapor (without condensates) updated by physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_mass_weighted_rime_factor)]
-  standard_name = mass_weighted_rime_factor_updated_by_physics
+[gq0(:,:,index_of_mass_weighted_rime_factor_in_tracer_concentration_array)]
+  standard_name = mass_weighted_rime_factor_of_new_state
   long_name = mass weighted rime factor updated by physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_water_friendly_aerosols)]
-  standard_name = water_friendly_aerosol_number_concentration_updated_by_physics
+[gq0(:,:,index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_hygroscopic_aerosols_of_new_state
   long_name = number concentration of water-friendly aerosols updated by physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_water_friendly_aerosols > 0)
-[gq0(:,:,index_for_ice_friendly_aerosols)]
-  standard_name = ice_friendly_aerosol_number_concentration_updated_by_physics
+  active = (index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array > 0)
+[gq0(:,:,index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_of_new_state
   long_name = number concentration of ice-friendly aerosols updated by physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_ice_friendly_aerosols > 0)
-[gq0(:,:,index_for_liquid_cloud_number_concentration)]
-  standard_name = cloud_droplet_number_concentration_updated_by_physics
+  active = (index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array > 0)
+[gq0(:,:,index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state
   long_name = number concentration of cloud droplets updated by physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_liquid_cloud_number_concentration > 0)
-[gq0(:,:,index_for_ice_cloud_number_concentration)]
-  standard_name = ice_number_concentration_updated_by_physics
+  active = (index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array > 0)
+[gq0(:,:,index_of_mass_number_concentration_of_cloud_ice_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_cloud_ice_water_crystals_in_air_of_new_state
   long_name = number concentration of ice updated by physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_rain_number_concentration)]
-  standard_name = rain_number_concentration_updated_by_physics
+[gq0(:,:,index_of_mass_number_concentration_of_rain_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_rain_of_new_state
   long_name = number concentration of rain updated by physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_snow_number_concentration)]
-  standard_name = snow_number_concentration_updated_by_physics
+[gq0(:,:,index_of_mass_number_concentration_of_snow_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_snow_of_new_state
   long_name = number concentration of snow updated by physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_graupel_number_concentration)]
-  standard_name = graupel_number_concentration_updated_by_physics
+[gq0(:,:,index_of_mass_number_concentration_of_graupel_in_tracer_concentration_array)]
+  standard_name = mass_number_concentration_of_graupel_of_new_state
   long_name = number concentration of graupel updated by physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[gq0(:,:,index_for_cloud_amount)]
-  standard_name = cloud_fraction_updated_by_physics
+[gq0(:,:,index_of_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array)]
+  standard_name = cloud_area_fraction_in_atmosphere_layer_of_new_state
   long_name = cloud fraction updated by physics
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 
@@ -460,7 +460,7 @@
   name = GFS_sfcprop_type
   type = ddt
 [slmsk]
-  standard_name = sea_land_ice_mask_real
+  standard_name = area_type
   long_name = landmask: sea/land/ice=0/1/2
   units = flag
   dimensions = (horizontal_loop_extent)
@@ -523,14 +523,14 @@
   type = real
   kind = kind_phys
 [tiice]
-  standard_name = internal_ice_temperature
+  standard_name = temperature_in_ice_layer
   long_name = sea ice internal temperature
   units = K
-  dimensions = (horizontal_loop_extent,ice_vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_sea_ice)
   type = real
   kind = kind_phys
 [snowd]
-  standard_name = surface_snow_thickness_water_equivalent
+  standard_name = lwe_surface_snow
   long_name = water equivalent snow depth
   units = mm
   dimensions = (horizontal_loop_extent)
@@ -572,14 +572,14 @@
   type = real
   kind = kind_phys
 [fice]
-  standard_name = sea_ice_concentration
+  standard_name = sea_ice_area_fraction_of_sea_area_fraction
   long_name = ice fraction over open water
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [hprime]
-  standard_name = statistical_measures_of_subgrid_orography
+  standard_name = statistical_measures_of_subgrid_orography_collection_array
   long_name = orographic metrics
   units = various
   dimensions = (horizontal_loop_extent,number_of_statistical_measures_of_subgrid_orography)
@@ -587,7 +587,7 @@
   kind = kind_phys
 [hprime(:,1)]
   standard_name = standard_deviation_of_subgrid_orography
-  long_name = standard deviation of subgrid orography
+  long_name = standard deviation of subgrid height_above_mean_sea_level
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
@@ -620,9 +620,9 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [snoalb]
-  standard_name = upper_bound_on_max_albedo_over_deep_snow
+  standard_name = upper_bound_of_max_albedo_assuming_deep_snow
   long_name = maximum snow albedo
   units = frac
   dimensions = (horizontal_loop_extent)
@@ -642,7 +642,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [sfalb_lnd]
   standard_name = surface_diffused_shortwave_albedo_over_land
   long_name = mean surface diffused sw albedo over land
@@ -651,7 +651,7 @@
   type = real
   kind = kind_phys
   optional = F
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [sfalb_ice]
   standard_name = surface_diffused_shortwave_albedo_over_ice
   long_name = mean surface diffused sw albedo over ice
@@ -659,7 +659,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [sfalb_lnd_bck]
   standard_name = surface_snow_free_albedo_over_land
   long_name = surface snow-free albedo over ice
@@ -667,16 +667,16 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [alvwf]
-  standard_name = mean_vis_albedo_with_weak_cosz_dependency
+  standard_name = vis_albedo_weak_cosz
   long_name = mean vis albedo with weak cosz dependency
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [alnwf]
-  standard_name = mean_nir_albedo_with_weak_cosz_dependency
+  standard_name = nir_albedo_weak_cosz
   long_name = mean nir albedo with weak cosz dependency
   units = frac
   dimensions = (horizontal_loop_extent)
@@ -690,14 +690,14 @@
   type = real
   kind = kind_phys
 [shdmin]
-  standard_name = minimum_vegetation_area_fraction
+  standard_name = min_vegetation_area_fraction
   long_name = min fractional coverage of green vegetation
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [shdmax]
-  standard_name = maximum_vegetation_area_fraction
+  standard_name = max_vegetation_area_fraction
   long_name = max fractional coverage of green vegetation
   units = frac
   dimensions = (horizontal_loop_extent)
@@ -739,27 +739,27 @@
   type = real
   kind = kind_phys
 [oro]
-  standard_name = orography
-  long_name = orography
+  standard_name = height_above_mean_sea_level
+  long_name = height_above_mean_sea_level
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [oro_uf]
-  standard_name = orography_unfiltered
-  long_name = unfiltered orography
+  standard_name = unfiltered_height_above_mean_sea_level
+  long_name = unfiltered height_above_mean_sea_level
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [conv_act]
-  standard_name = gf_memory_counter
+  standard_name = consecutive_calls_for_grell_freitas_convection
   long_name = Memory counter for GF
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_mass_flux_deep_convection_scheme == flag_for_gf_deep_convection_scheme)
+  active = (control_for_deep_convection_scheme == identifier_for_grell_freitas_deep_convection)
 [hice]
   standard_name = sea_ice_thickness
   long_name = sea ice thickness
@@ -768,7 +768,7 @@
   type = real
   kind = kind_phys
 [weasd]
-  standard_name = water_equivalent_accumulated_snow_depth
+  standard_name = lwe_thickness_of_surface_snow_amount
   long_name = water equiv of acc snow depth over land and sea ice
   units = mm
   dimensions = (horizontal_loop_extent)
@@ -796,7 +796,7 @@
   type = real
   kind = kind_phys
 [f10m]
-  standard_name = ratio_of_wind_at_lowest_model_layer_and_wind_at_10m
+  standard_name = ratio_of_wind_at_surface_adjacent_layer_to_wind_at_10m
   long_name = ratio of sigma level 1 wind and 10m wind
   units = ratio
   dimensions = (horizontal_loop_extent)
@@ -810,42 +810,42 @@
   type = real
   kind = kind_phys
 [srflag]
-  standard_name = flag_for_precipitation_type
+  standard_name = precipitation_type
   long_name = snow/rain flag for precipitation
   units = flag
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [slc]
-  standard_name = volume_fraction_of_unfrozen_soil_moisture
+  standard_name = volume_fraction_of_unfrozen_water_in_soil
   long_name = liquid soil moisture
   units = frac
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil)
   type = real
   kind = kind_phys
 [smc]
-  standard_name = volume_fraction_of_soil_moisture
+  standard_name = volume_fraction_of_condensed_water_in_soil
   long_name = total soil moisture
   units = frac
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil)
   type = real
   kind = kind_phys
 [stc]
   standard_name = soil_temperature
   long_name = soil temperature
   units = K
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil)
   type = real
   kind = kind_phys
 [t2m]
-  standard_name = temperature_at_2m
+  standard_name = air_temperature_at_2m
   long_name = 2 meter temperature
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [th2m]
-  standard_name = potential_temperature_at_2m
+  standard_name = air_potential_temperature_at_2m
   long_name = 2 meter potential temperature
   units = K
   dimensions = (horizontal_loop_extent)
@@ -859,21 +859,21 @@
   type = real
   kind = kind_phys
 [tref]
-  standard_name = sea_surface_reference_temperature
+  standard_name = reference_sea_surface_temperature
   long_name = sea surface reference temperature
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [z_c]
-  standard_name = sub_layer_cooling_thickness
+  standard_name = molecular_sublayer_thickness_in_sea_water
   long_name = sub-layer cooling thickness
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [c_0]
   standard_name = coefficient_c_0
   long_name = coefficient 1 to calculate d(Tz)/d(Ts)
@@ -881,7 +881,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [c_d]
   standard_name = coefficient_c_d
   long_name = coefficient 2 to calculate d(Tz)/d(Ts)
@@ -889,7 +889,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [w_0]
   standard_name = coefficient_w_0
   long_name = coefficient 3 to calculate d(Tz)/d(Ts)
@@ -897,7 +897,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [w_d]
   standard_name = coefficient_w_d
   long_name = coefficient 4 to calculate d(Tz)/d(Ts)
@@ -905,39 +905,39 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [xt]
-  standard_name = diurnal_thermocline_layer_heat_content
+  standard_name = heat_content_in_diurnal_thermocline
   long_name = heat content in diurnal thermocline layer
   units = K m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [xs]
-  standard_name = sea_water_salinity
+  standard_name = sea_water_salinity_in_diurnal_thermocline
   long_name = salinity  content in diurnal thermocline layer
   units = ppt m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [xu]
-  standard_name = diurnal_thermocline_layer_x_current
+  standard_name = x_current_in_diurnal_thermocline
   long_name = u-current content in diurnal thermocline layer
   units = m2 s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [xv]
-  standard_name = diurnal_thermocline_layer_y_current
+  standard_name = y_current_in_diurnal_thermocline
   long_name = v-current content in diurnal thermocline layer
   units = m2 s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [xz]
   standard_name = diurnal_thermocline_layer_thickness
   long_name = diurnal thermocline layer thickness
@@ -945,7 +945,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [zm]
   standard_name = ocean_mixed_layer_thickness
   long_name = mixed layer thickness
@@ -953,55 +953,55 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [xtts]
-  standard_name = sensitivity_of_dtl_heat_content_to_surface_temperature
+  standard_name = derivative_of_heat_content_in_diurnal_thermocline_wrt_surface_skin_temperature
   long_name = d(xt)/d(ts)
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [xzts]
-  standard_name = sensitivity_of_dtl_thickness_to_surface_temperature
+  standard_name = derivative_of_diurnal_thermocline_layer_thickness_wrt_surface_skin_temperature
   long_name = d(xz)/d(ts)
   units = m K-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [d_conv]
-  standard_name = free_convection_layer_thickness
+  standard_name = free_convection_layer_thickness_in_sea_water
   long_name = thickness of free convection layer (FCL)
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [ifd]
-  standard_name = index_of_dtlm_start
+  standard_name = control_for_diurnal_thermocline_calculation
   long_name = index to start dtlm run or not
   units = index
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [dt_cool]
-  standard_name = sub_layer_cooling_amount
+  standard_name = molecular_sublayer_temperature_correction_in_sea_water
   long_name = sub-layer cooling amount
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [qrain]
-  standard_name = sensible_heat_flux_due_to_rainfall
+  standard_name = surface_sensible_heat_due_to_rainfall
   long_name = sensible heat flux due to rainfall
   units = W
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_nsstm_run > 0)
+  active = (control_for_nsstm > 0)
 [snowxy]
   standard_name = number_of_snow_layers
   long_name = number of snow layers
@@ -1009,23 +1009,23 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [tvxy]
-  standard_name = vegetation_temperature
+  standard_name = canopy_temperature
   long_name = vegetation temperature
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [tgxy]
-  standard_name = ground_temperature_for_noahmp
+  standard_name = ground_temperature
   long_name = ground temperature for noahmp
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [canicexy]
   standard_name = canopy_intercepted_ice_mass
   long_name = canopy intercepted ice mass
@@ -1033,7 +1033,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [canliqxy]
   standard_name = canopy_intercepted_liquid_water
   long_name = canopy intercepted liquid water
@@ -1041,23 +1041,23 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [eahxy]
-  standard_name = canopy_air_vapor_pressure
+  standard_name = air_vapor_pressure_in_canopy
   long_name = canopy air vapor pressure
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [tahxy]
-  standard_name = canopy_air_temperature
+  standard_name = air_temperature_in_canopy
   long_name = canopy air temperature
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [cmxy]
   standard_name = surface_drag_coefficient_for_momentum_for_noahmp
   long_name = surface drag coefficient for momentum for noahmp
@@ -1065,7 +1065,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [chxy]
   standard_name = surface_drag_coefficient_for_heat_and_moisture_for_noahmp
   long_name = surface exchange coeff heat & moisture for noahmp
@@ -1073,47 +1073,47 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [fwetxy]
-  standard_name = area_fraction_of_wet_canopy
+  standard_name = wet_canopy_area_fraction
   long_name = area fraction of canopy that is wetted/snowed
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [sneqvoxy]
-  standard_name = snow_mass_at_previous_time_step
+  standard_name = lwe_thickness_of_snowfall_amount_on_previous_timestep
   long_name = snow mass at previous time step
   units = mm
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [alboldxy]
-  standard_name = snow_albedo_at_previous_time_step
+  standard_name = surface_albedo_assuming_deep_snow_on_previous_timestep
   long_name = snow albedo at previous time step
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [qsnowxy]
-  standard_name = snow_precipitation_rate_at_surface
+  standard_name = lwe_snowfall_rate
   long_name = snow precipitation rate at surface
   units = mm s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [wslakexy]
-  standard_name = lake_water_storage
+  standard_name = water_storage_in_lake
   long_name = lake water storage
   units = mm
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [zwtxy]
   standard_name = water_table_depth
   long_name = water table depth
@@ -1121,7 +1121,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [waxy]
   standard_name = water_storage_in_aquifer
   long_name = water storage in aquifer
@@ -1129,7 +1129,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [wtxy]
   standard_name = water_storage_in_aquifer_and_saturated_soil
   long_name = water storage in aquifer and saturated soil
@@ -1137,71 +1137,71 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [tsnoxy]
-  standard_name = snow_temperature
-  long_name = snow_temperature
+  standard_name = temperature_in_surface_snow
+  long_name = temperature_in_surface_snow
   units = K
-  dimensions = (horizontal_loop_extent, lower_bound_of_snow_vertical_dimension_for_land_surface_model:0)
+  dimensions = (horizontal_loop_extent, lower_bound_of_vertical_dimension_of_surface_snow:0)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [zsnsoxy]
-  standard_name = layer_bottom_depth_from_snow_surface
+  standard_name = depth_from_snow_surface_at_bottom_interface
   long_name = depth from the top of the snow surface at the bottom of the layer
   units = m
-  dimensions = (horizontal_loop_extent, lower_bound_of_snow_vertical_dimension_for_land_surface_model:soil_vertical_dimension_for_land_surface_model)
+  dimensions = (horizontal_loop_extent, lower_bound_of_vertical_dimension_of_surface_snow:vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [snicexy]
-  standard_name = snow_layer_ice
+  standard_name = lwe_thickness_of_ice_in_surface_snow
   long_name = snow layer ice
   units = mm
-  dimensions = (horizontal_loop_extent, lower_bound_of_snow_vertical_dimension_for_land_surface_model:0)
+  dimensions = (horizontal_loop_extent, lower_bound_of_vertical_dimension_of_surface_snow:0)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [snliqxy]
-  standard_name = snow_layer_liquid_water
+  standard_name = lwe_thickness_of_liquid_water_in_surface_snow
   long_name = snow layer liquid water
   units = mm
-  dimensions = (horizontal_loop_extent, lower_bound_of_snow_vertical_dimension_for_land_surface_model:0)
+  dimensions = (horizontal_loop_extent, lower_bound_of_vertical_dimension_of_surface_snow:0)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [lfmassxy]
-  standard_name = leaf_mass
+  standard_name = leaf_mass_content
   long_name = leaf mass
   units = g m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [rtmassxy]
-  standard_name = fine_root_mass
+  standard_name = fine_root_mass_content
   long_name = fine root mass
   units = g m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [stmassxy]
-  standard_name = stem_mass
+  standard_name = stem_mass_content
   long_name = stem mass
   units = g m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [woodxy]
-  standard_name = wood_mass
+  standard_name = wood_mass_content
   long_name = wood mass including woody roots
   units = g m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [stblcpxy]
   standard_name = slow_soil_pool_mass_content_of_carbon
   long_name = stable carbon in deep soil
@@ -1209,7 +1209,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [fastcpxy]
   standard_name = fast_soil_pool_mass_content_of_carbon
   long_name = short-lived carbon in shallow soil
@@ -1217,7 +1217,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [xlaixy]
   standard_name = leaf_area_index
   long_name = leaf area index
@@ -1225,7 +1225,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme .and. flag_for_reading_leaf_area_index_from_input))
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .and. flag_for_reading_leaf_area_index_from_input))
 [xsaixy]
   standard_name = stem_area_index
   long_name = stem area index
@@ -1233,47 +1233,47 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [taussxy]
-  standard_name = nondimensional_snow_age
+  standard_name = dimensionless_age_of_surface_snow
   long_name = non-dimensional snow age
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [smoiseq]
-  standard_name = equilibrium_soil_water_content
+  standard_name = volumetric_equilibrium_soil_moisture
   long_name = equilibrium soil water content
   units = m3 m-3
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [smcwtdxy]
-  standard_name = soil_water_content_between_soil_bottom_and_water_table
+  standard_name = volumetric_soil_moisture_between_soil_bottom_and_water_table
   long_name = soil water content between the bottom of the soil and the water table
   units = m3 m-3
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [deeprechxy]
-  standard_name = water_table_recharge_when_deep
+  standard_name = water_table_recharge_assuming_deep
   long_name = recharge to or from the water table when deep
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [rechxy]
-  standard_name = water_table_recharge_when_shallow
+  standard_name = water_table_recharge_assuming_shallow
   long_name = recharge to or from the water table when shallow
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [snotime]
   standard_name = time_since_last_snowfall
   long_name = elapsed time since last snowfall
@@ -1281,7 +1281,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [albdvis_lnd]
   standard_name = surface_albedo_direct_visible_over_land
   long_name = direct surface albedo visible band over land
@@ -1289,7 +1289,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [albdnir_lnd]
   standard_name = surface_albedo_direct_NIR_over_land
   long_name = direct surface albedo NIR band over land
@@ -1297,7 +1297,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [albivis_lnd]
   standard_name = surface_albedo_diffuse_visible_over_land
   long_name = diffuse surface albedo visible band over land
@@ -1305,7 +1305,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [albinir_lnd]
   standard_name = surface_albedo_diffuse_NIR_over_land
   long_name = diffuse surface albedo NIR band over land
@@ -1313,7 +1313,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [albdvis_ice]
   standard_name = surface_albedo_direct_visible_over_ice
   long_name = direct surface albedo visible band over ice
@@ -1321,7 +1321,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [albdnir_ice]
   standard_name = surface_albedo_direct_NIR_over_ice
   long_name = direct surface albedo NIR band over ice
@@ -1329,7 +1329,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [albivis_ice]
   standard_name = surface_albedo_diffuse_visible_over_ice
   long_name = diffuse surface albedo visible band over ice
@@ -1337,7 +1337,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [albinir_ice]
   standard_name = surface_albedo_diffuse_NIR_over_ice
   long_name = diffuse surface albedo NIR band over ice
@@ -1345,7 +1345,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = ( flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = ( control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [wetness]
   standard_name = normalized_soil_wetness_for_land_surface_model
   long_name = normalized soil wetness for lsm
@@ -1353,39 +1353,39 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [sh2o]
   standard_name = volume_fraction_of_unfrozen_soil_moisture_for_land_surface_model
   long_name = volume fraction of unfrozen soil moisture for lsm
   units = frac
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [keepsmfr]
   standard_name = volume_fraction_of_frozen_soil_moisture_for_land_surface_model
   long_name = volume fraction of frozen soil moisture for lsm
   units = frac
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [smois]
   standard_name = volume_fraction_of_soil_moisture_for_land_surface_model
   long_name = volumetric fraction of soil moisture for lsm
   units = frac
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [tslb]
   standard_name = soil_temperature_for_land_surface_model
   long_name = soil temperature for land surface model
   units = K
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [clw_surf_land]
   standard_name = cloud_condensed_water_mixing_ratio_at_surface_over_land
   long_name = moist cloud water mixing ratio at surface over land
@@ -1393,7 +1393,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [clw_surf_ice]
   standard_name = cloud_condensed_water_mixing_ratio_at_surface_over_ice
   long_name = moist cloud water mixing ratio at surface over ice
@@ -1401,7 +1401,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [qwv_surf_land]
   standard_name = water_vapor_mixing_ratio_at_surface_over_land
   long_name = water vapor mixing ratio at surface over land
@@ -1409,7 +1409,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [qwv_surf_ice]
   standard_name = water_vapor_mixing_ratio_at_surface_over_ice
   long_name = water vapor mixing ratio at surface over ice
@@ -1417,79 +1417,79 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [flag_frsoil]
-  standard_name = flag_for_frozen_soil_physics
+  standard_name = control_for_frozen_soil_physics
   long_name = flag for frozen soil physics (RUC)
   units = flag
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [rhofr]
-  standard_name = density_of_frozen_precipitation
+  standard_name = frozen_precipitation_density
   long_name = density of frozen precipitation
   units = kg m-3
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [tsnow_land]
-  standard_name = snow_temperature_bottom_first_layer_over_land
+  standard_name = temperature_in_surface_snow_at_surface_adjacent_layer_over_land
   long_name = snow temperature at the bottom of the first snow layer over land
   units = K
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [tsnow_ice]
-  standard_name = snow_temperature_bottom_first_layer_over_ice
+  standard_name = temperature_in_surface_snow_at_surface_adjacent_layer_over_ice
   long_name = snow temperature at the bottom of the first snow layer over ice
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [snowfallac_land]
-  standard_name = total_accumulated_snowfall_over_land
+  standard_name = surface_snow_amount_over_land
   long_name = run-total snow accumulation on the ground
   units = kg m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [snowfallac_ice]
-  standard_name = total_accumulated_snowfall_over_ice
+  standard_name = surface_snow_amount_over_ice
   long_name = run-total snow accumulation on the ice
   units = kg m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [ustm]
-  standard_name = surface_friction_velocity_drag
+  standard_name = surface_friction_velocity_for_momentum
   long_name = friction velocity isolated for momentum only
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_mynnsfclay)
+  active = (flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme)
 [zol]
-  standard_name = surface_stability_parameter
+  standard_name = ratio_of_height_to_monin_obukhov_length
   long_name = monin obukhov surface stability parameter
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_mynnsfclay)
+  active = (flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme)
 [mol]
-  standard_name = theta_star
+  standard_name = surface_temperature_scale
   long_name = temperature flux divided by ustar (temperature scale)
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_mynnsfclay)
+  active = (flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme)
 [rmol]
   standard_name = reciprocal_of_obukhov_length
   long_name = one over obukhov length
@@ -1497,7 +1497,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_mynnsfclay)
+  active = (flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme)
 [flhc]
   standard_name = surface_exchange_coefficient_for_heat
   long_name = surface exchange coefficient for heat
@@ -1505,7 +1505,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_mynnsfclay)
+  active = (flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme)
 [flqc]
   standard_name = surface_exchange_coefficient_for_moisture
   long_name = surface exchange coefficient for moisture
@@ -1513,7 +1513,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_mynnsfclay)
+  active = (flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme)
 [chs2]
   standard_name = surface_exchange_coefficient_for_heat_at_2m
   long_name = exchange coefficient for heat at 2 meters
@@ -1521,7 +1521,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_mynnsfclay)
+  active = (flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme)
 [cqs2]
   standard_name = surface_exchange_coefficient_for_moisture_at_2m
   long_name = exchange coefficient for moisture at 2 meters
@@ -1529,24 +1529,24 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_mynnsfclay)
+  active = (flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme)
 [lh]
-  standard_name = surface_latent_heat
+  standard_name = surface_upward_latent_heat_flux
   long_name = latent heating at the surface (pos = up)
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_mynnsfclay)
+  active = (flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme)
 [evap]
-  standard_name = kinematic_surface_upward_latent_heat_flux
+  standard_name = surface_upward_specific_humidity_flux
   long_name = kinematic surface upward latent heat flux
   units = kg kg-1 m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [hflx]
-  standard_name = kinematic_surface_upward_sensible_heat_flux
+  standard_name = surface_upward_temperature_flux
   long_name = kinematic surface upward sensible heat flux
   units = K m s-1
   dimensions = (horizontal_loop_extent)
@@ -1560,108 +1560,108 @@
   type = real
   kind = kind_phys
 [raincprv]
-  standard_name = lwe_thickness_of_convective_precipitation_amount_from_previous_timestep
+  standard_name = lwe_thickness_of_convective_precipitation_amount_on_previous_timestep
   long_name = convective_precipitation_amount from previous timestep
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [rainncprv]
-  standard_name = lwe_thickness_of_explicit_rainfall_amount_from_previous_timestep
+  standard_name = lwe_thickness_of_explicit_precipitation_amount_on_previous_timestep
   long_name = explicit rainfall from previous timestep
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [iceprv]
-  standard_name = lwe_thickness_of_ice_amount_from_previous_timestep
+  standard_name = lwe_thickness_of_ice_precipitation_amount_on_previous_timestep
   long_name = ice amount from previous timestep
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [snowprv]
-  standard_name = lwe_thickness_of_snow_amount_from_previous_timestep
+  standard_name = snow_mass_on_previous_timestep
   long_name = snow amount from previous timestep
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [graupelprv]
-  standard_name = lwe_thickness_of_graupel_amount_from_previous_timestep
+  standard_name = lwe_thickness_of_graupel_amount_on_previous_timestep
   long_name = graupel amount from previous timestep
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme .or. control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [draincprv]
-  standard_name = convective_precipitation_rate_from_previous_timestep
+  standard_name = convective_precipitation_rate_on_previous_timestep
   long_name = convective precipitation rate from previous timestep
   units = mm s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [drainncprv]
-  standard_name = explicit_rainfall_rate_from_previous_timestep
+  standard_name = explicit_precipitation_rate_on_previous_timestep
   long_name = explicit rainfall rate previous timestep
   units = mm s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [diceprv]
-  standard_name = ice_precipitation_rate_from_previous_timestep
+  standard_name = ice_precipitation_rate_on_previous_timestep
   long_name = ice precipitation rate from previous timestep
   units = mm s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [dsnowprv]
-  standard_name = snow_precipitation_rate_from_previous_timestep
+  standard_name = snowfall_rate_on_previous_timestep
   long_name = snow precipitation rate from previous timestep
   units = mm s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [dgraupelprv]
-  standard_name = graupel_precipitation_rate_from_previous_timestep
+  standard_name = graupel_precipitation_rate_on_previous_timestep
   long_name = graupel precipitation rate from previous timestep
   units = mm s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [alvsf]
-  standard_name = mean_vis_albedo_with_strong_cosz_dependency
+  standard_name = vis_albedo_strong_cosz
   long_name = mean vis albedo with strong cosz dependency
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [alnsf]
-  standard_name = mean_nir_albedo_with_strong_cosz_dependency
+  standard_name = nir_albedo_strong_cosz
   long_name = mean nir albedo with strong cosz dependency
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [facsf]
-  standard_name =fractional_coverage_with_strong_cosz_dependency
+  standard_name =strong_cosz_area_fraction
   long_name = fractional coverage with strong cosz dependency
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [facwf]
-  standard_name = fractional_coverage_with_weak_cosz_dependency
+  standard_name = weak_cosz_area_fraction
   long_name = fractional coverage with weak cosz dependency
   units = frac
   dimensions = (horizontal_loop_extent)
@@ -1678,94 +1678,94 @@
   name = GFS_coupling_type
   type = ddt
 [nirbmdi]
-  standard_name = surface_downwelling_direct_near_infrared_shortwave_flux_on_radiation_time_step
+  standard_name = surface_downwelling_direct_nir_shortwave_flux_on_radiation_timestep
   long_name = sfc nir beam sw downward flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [nirdfdi]
-  standard_name = surface_downwelling_diffuse_near_infrared_shortwave_flux_on_radiation_time_step
+  standard_name = surface_downwelling_diffuse_nir_shortwave_flux_on_radiation_timestep
   long_name = sfc nir diff sw downward flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [visbmdi]
-  standard_name = surface_downwelling_direct_ultraviolet_and_visible_shortwave_flux_on_radiation_time_step
+  standard_name = surface_downwelling_direct_uv_and_vis_shortwave_flux_on_radiation_timestep
   long_name = sfc uv+vis beam sw downward flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [visdfdi]
-  standard_name = surface_downwelling_diffuse_ultraviolet_and_visible_shortwave_flux_on_radiation_time_step
+  standard_name = surface_downwelling_diffuse_uv_and_vis_shortwave_flux_on_radiation_timestep
   long_name = sfc uv+vis diff sw downward flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [nirbmui]
-  standard_name = surface_upwelling_direct_near_infrared_shortwave_flux_on_radiation_time_step
+  standard_name = surface_upwelling_direct_nir_shortwave_flux_on_radiation_timestep
   long_name = sfc nir beam sw upward flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [nirdfui]
-  standard_name = surface_upwelling_diffuse_near_infrared_shortwave_flux_on_radiation_time_step
+  standard_name = surface_upwelling_diffuse_nir_shortwave_flux_on_radiation_timestep
   long_name = sfc nir diff sw upward flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [visbmui]
-  standard_name = surface_upwelling_direct_ultraviolet_and_visible_shortwave_flux_on_radiation_time_step
+  standard_name = surface_upwelling_direct_uv_and_vis_shortwave_flux_on_radiation_timestep
   long_name = sfc uv+vis beam sw upward flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [visdfui]
-  standard_name = surface_upwelling_diffuse_ultraviolet_and_visible_shortwave_flux_on_radiation_time_step
+  standard_name = surface_upwelling_diffuse_uv_and_vis_shortwave_flux_on_radiation_timestep
   long_name = sfc uv+vis diff sw upward flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [sfcdsw]
-  standard_name = surface_downwelling_shortwave_flux_on_radiation_time_step
+  standard_name = surface_downwelling_shortwave_flux_on_radiation_timestep
   long_name = total sky sfc downward sw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [sfcnsw]
-  standard_name = surface_net_downwelling_shortwave_flux_on_radiation_time_step
+  standard_name = surface_net_downwelling_shortwave_flux_on_radiation_timestep
   long_name = total sky sfc netsw flx into ground
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [sfcdlw]
-  standard_name = surface_downwelling_longwave_flux_on_radiation_time_step
+  standard_name = surface_downwelling_longwave_flux_on_radiation_timestep
   long_name = total sky sfc downward lw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [sfculw]
-  standard_name = surface_upwelling_longwave_flux_on_radiation_time_step
+  standard_name = surface_upwelling_longwave_flux_on_radiation_timestep
   long_name = total sky sfc upward lw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [htrlw]
-  standard_name = updated_tendency_of_air_temperature_due_to_longwave_heating_on_physics_time_step
+  standard_name = updated_tendency_of_air_temperature_due_to_longwave_heating_on_physics_timestep
   long_name = total sky longwave heating rate on physics time step
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -1773,7 +1773,7 @@
   standard_name = RRTMGP_jacobian_of_lw_flux_upward
   long_name = RRTMGP Jacobian upward longwave flux profile
   units = W m-2 K-1
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -1781,7 +1781,7 @@
   standard_name = RRTMGP_lw_flux_profile_upward_allsky
   long_name = RRTMGP upward longwave all-sky flux profile
   units = W m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -1789,33 +1789,33 @@
   standard_name = RRTMGP_lw_flux_profile_downward_allsky
   long_name = RRTMGP downward longwave all-sky flux profile
   units = W m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
 [rain_cpl]
-  standard_name = lwe_thickness_of_precipitation_amount_for_coupling
+  standard_name = cumulative_lwe_thickness_of_precipitation_amount_for_coupling
   long_name = total rain precipitation
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling .or. flag_for_stochastic_physics_perturbations .or. flag_for_chemistry_coupling .or. flag_for_global_cellular_automata)
+  active = (flag_for_surface_flux_coupling .or. flag_for_stochastic_physics_perturbations .or. flag_for_chemistry_coupling .or. flag_for_global_cellular_automata)
 [rainc_cpl]
-  standard_name = lwe_thickness_of_convective_precipitation_amount_for_coupling
+  standard_name = cumulative_lwe_thickness_of_convective_precipitation_amount_for_coupling
   long_name = total convective precipitation
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [snow_cpl]
-  standard_name = lwe_thickness_of_snow_amount_for_coupling
+  standard_name = cumulative_lwe_thickness_of_snow_amount_for_coupling
   long_name = total snow precipitation
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling .or. flag_for_stochastic_physics_perturbations .or. flag_for_chemistry_coupling .or. flag_for_global_cellular_automata)
+  active = (flag_for_surface_flux_coupling .or. flag_for_stochastic_physics_perturbations .or. flag_for_chemistry_coupling .or. flag_for_global_cellular_automata)
 [dusfc_cpl]
   standard_name = cumulative_surface_x_momentum_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc x momentum flux multiplied by timestep
@@ -1823,7 +1823,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dvsfc_cpl]
   standard_name = cumulative_surface_y_momentum_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc y momentum flux multiplied by timestep
@@ -1831,7 +1831,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dtsfc_cpl]
   standard_name = cumulative_surface_upward_sensible_heat_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc sensible heat flux multiplied by timestep
@@ -1839,7 +1839,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dqsfc_cpl]
   standard_name = cumulative_surface_upward_latent_heat_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc latent heat flux multiplied by timestep
@@ -1847,7 +1847,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dlwsfc_cpl]
   standard_name = cumulative_surface_downwelling_longwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc downward lw flux mulitplied by timestep
@@ -1855,7 +1855,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dswsfc_cpl]
   standard_name = cumulative_surface_downwelling_shortwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc downward sw flux multiplied by timestep
@@ -1863,305 +1863,305 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dnirbm_cpl]
-  standard_name = cumulative_surface_downwelling_direct_near_infrared_shortwave_flux_for_coupling_multiplied_by_timestep
+  standard_name = cumulative_surface_downwelling_direct_nir_shortwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc nir beam downward sw flux multiplied by timestep
   units = W m-2 s
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dnirdf_cpl]
-  standard_name = cumulative_surface_downwelling_diffuse_near_infrared_shortwave_flux_for_coupling_multiplied_by_timestep
+  standard_name = cumulative_surface_downwelling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc nir diff downward sw flux multiplied by timestep
   units = W m-2 s
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dvisbm_cpl]
-  standard_name = cumulative_surface_downwelling_direct_ultraviolet_and_visible_shortwave_flux_for_coupling_multiplied_by_timestep
+  standard_name = cumulative_surface_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc uv+vis beam dnwd sw flux multiplied by timestep
   units = W m-2 s
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dvisdf_cpl]
-  standard_name = cumulative_surface_downwelling_diffuse_ultraviolet_and_visible_shortwave_flux_for_coupling_multiplied_by_timestep
+  standard_name = cumulative_surface_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc uv+vis diff dnwd sw flux multiplied by timestep
   units = W m-2 s
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nlwsfc_cpl]
-  standard_name = cumulative_surface_net_downward_longwave_flux_for_coupling_multiplied_by_timestep
+  standard_name = cumulative_surface_net_downwelling_longwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative net downward lw flux multiplied by timestep
   units = W m-2 s
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nswsfc_cpl]
-  standard_name = cumulative_surface_net_downward_shortwave_flux_for_coupling_multiplied_by_timestep
+  standard_name = cumulative_surface_net_downwelling_shortwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative net downward sw flux multiplied by timestep
   units = W m-2 s
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nnirbm_cpl]
-  standard_name = cumulative_surface_net_downward_direct_near_infrared_shortwave_flux_for_coupling_multiplied_by_timestep
+  standard_name = cumulative_surface_net_downwelling_direct_nir_shortwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative net nir beam downward sw flux multiplied by timestep
   units = W m-2 s
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nnirdf_cpl]
-  standard_name = cumulative_surface_net_downward_diffuse_near_infrared_shortwave_flux_for_coupling_multiplied_by_timestep
+  standard_name = cumulative_surface_net_downwellling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative net nir diff downward sw flux multiplied by timestep
   units = W m-2 s
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nvisbm_cpl]
-  standard_name = cumulative_surface_net_downward_direct_ultraviolet_and_visible_shortwave_flux_for_coupling_multiplied_by_timestep
+  standard_name = cumulative_surface_net_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative net uv+vis beam downward sw rad flux multiplied by timestep
   units = W m-2 s
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nvisdf_cpl]
-  standard_name = cumulative_surface_net_downward_diffuse_ultraviolet_and_visible_shortwave_flux_for_coupling_multiplied_by_timestep
+  standard_name = cumulative_surface_net_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative net uv+vis diff downward sw rad flux multiplied by timestep
   units = W m-2 s
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dusfci_cpl]
-  standard_name = instantaneous_surface_x_momentum_flux_for_coupling
+  standard_name = surface_x_momentum_flux_for_coupling
   long_name = instantaneous sfc x momentum flux
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dvsfci_cpl]
-  standard_name = instantaneous_surface_y_momentum_flux_for_coupling
+  standard_name = surface_y_momentum_flux_for_coupling
   long_name = instantaneous sfc y momentum flux
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dtsfci_cpl]
-  standard_name = instantaneous_surface_upward_sensible_heat_flux_for_coupling
+  standard_name = surface_upward_sensible_heat_flux_for_coupling
   long_name = instantaneous sfc sensible heat flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dqsfci_cpl]
-  standard_name = instantaneous_surface_upward_latent_heat_flux_for_coupling
+  standard_name = surface_upward_latent_heat_flux_for_coupling
   long_name = instantaneous sfc latent heat flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dlwsfci_cpl]
-  standard_name = instantaneous_surface_downwelling_longwave_flux_for_coupling
+  standard_name = surface_downwelling_longwave_flux_for_coupling
   long_name = instantaneous sfc downward lw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dswsfci_cpl]
-  standard_name = instantaneous_surface_downwelling_shortwave_flux_for_coupling
+  standard_name = surface_downwelling_shortwave_flux_for_coupling
   long_name = instantaneous sfc downward sw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dnirbmi_cpl]
-  standard_name = instantaneous_surface_downwelling_direct_near_infrared_shortwave_flux_for_coupling
+  standard_name = surface_downwelling_direct_nir_shortwave_flux_for_coupling
   long_name = instantaneous sfc nir beam downward sw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dnirdfi_cpl]
-  standard_name = instantaneous_surface_downwelling_diffuse_near_infrared_shortwave_flux_for_coupling
+  standard_name = surface_downwelling_diffuse_nir_shortwave_flux_for_coupling
   long_name = instantaneous sfc nir diff downward sw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dvisbmi_cpl]
-  standard_name = instantaneous_surface_downwelling_direct_ultraviolet_and_visible_shortwave_flux_for_coupling
+  standard_name = surface_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling
   long_name = instantaneous sfc uv+vis beam downward sw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dvisdfi_cpl]
-  standard_name = instantaneous_surface_downwelling_diffuse_ultraviolet_and_visible_shortwave_flux_for_coupling
+  standard_name = surface_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling
   long_name = instantaneous sfc uv+vis diff downward sw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nlwsfci_cpl]
-  standard_name = instantaneous_surface_net_downward_longwave_flux_for_coupling
+  standard_name = surface_net_downwelling_longwave_flux_for_coupling
   long_name = instantaneous net sfc downward lw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nswsfci_cpl]
-  standard_name = instantaneous_surface_net_downward_shortwave_flux_for_coupling
+  standard_name = surface_net_downwelling_shortwave_flux_for_coupling
   long_name = instantaneous net sfc downward sw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nnirbmi_cpl]
-  standard_name = instantaneous_surface_net_downward_direct_near_infrared_shortwave_flux_for_coupling
+  standard_name = surface_net_downwelling_direct_nir_shortwave_flux_for_coupling
   long_name = instantaneous net nir beam sfc downward sw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nnirdfi_cpl]
-  standard_name = instantaneous_surface_net_downward_diffuse_near_infrared_shortwave_flux_for_coupling
+  standard_name = surface_net_downwelling_diffuse_nir_shortwave_flux_for_coupling
   long_name = instantaneous net nir diff sfc downward sw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nvisbmi_cpl]
-  standard_name = instantaneous_surface_net_downward_direct_ultraviolet_and_visible_shortwave_flux_for_coupling
+  standard_name = surface_net_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling
   long_name = instantaneous net uv+vis beam downward sw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [nvisdfi_cpl]
-  standard_name = instantaneous_surface_net_downward_diffuse_ultraviolet_and_visible_shortwave_flux_for_coupling
+  standard_name = surface_net_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling
   long_name = instantaneous net uv+vis diff downward sw flux
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [t2mi_cpl]
-  standard_name = instantaneous_temperature_at_2m_for_coupling
+  standard_name = temperature_at_2m_for_coupling
   long_name = instantaneous T2m
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [q2mi_cpl]
-  standard_name = instantaneous_specific_humidity_at_2m_for_coupling
+  standard_name = specific_humidity_at_2m_for_coupling
   long_name = instantaneous Q2m
   units = kg kg-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [u10mi_cpl]
-  standard_name = instantaneous_x_wind_at_10m_for_coupling
+  standard_name = x_wind_at_10m_for_coupling
   long_name = instantaneous U10m
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling .or. flag_for_wave_coupling)
+  active = (flag_for_surface_flux_coupling .or. flag_for_ocean_wave_coupling)
 [v10mi_cpl]
-  standard_name = instantaneous_y_wind_at_10m_for_coupling
+  standard_name = y_wind_at_10m_for_coupling
   long_name = instantaneous V10m
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling .or. flag_for_wave_coupling)
+  active = (flag_for_surface_flux_coupling .or. flag_for_ocean_wave_coupling)
 [tsfci_cpl]
-  standard_name = instantaneous_surface_skin_temperature_for_coupling
+  standard_name = surface_skin_temperature_for_coupling
   long_name = instantaneous sfc temperature
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [psurfi_cpl]
-  standard_name = instantaneous_surface_air_pressure_for_coupling
+  standard_name = surface_air_pressure_for_coupling
   long_name = instantaneous sfc pressure
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [ulwsfcin_cpl]
-  standard_name = surface_upwelling_longwave_flux_for_coupling
+  standard_name = surface_upwelling_longwave_flux_from_coupled_process
   long_name = surface upwelling LW flux for coupling
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dusfcin_cpl]
-  standard_name = surface_x_momentum_flux_for_coupling
+  standard_name = surface_x_momentum_flux_from_coupled_process
   long_name = sfc x momentum flux for coupling
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dvsfcin_cpl]
-  standard_name = surface_y_momentum_flux_for_coupling
+  standard_name = surface_y_momentum_flux_from_coupled_process
   long_name = sfc y momentum flux for coupling
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dtsfcin_cpl]
-  standard_name = surface_upward_sensible_heat_flux_for_coupling
+  standard_name = surface_upward_sensible_heat_flux_from_coupled_process
   long_name = sfc sensible heat flux input
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [dqsfcin_cpl]
-  standard_name = surface_upward_latent_heat_flux_for_coupling
+  standard_name = surface_upward_latent_heat_flux_from_coupled_process
   long_name = sfc latent heat flux input for coupling
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [hsnoin_cpl]
-  standard_name = surface_snow_thickness_for_coupling
+  standard_name = lwe_surface_snow_from_coupled_process
   long_name = sfc snow depth in meters over sea ice for coupling
   units = m
   dimensions = (horizontal_loop_extent)
@@ -2174,7 +2174,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [sfc_alb_nir_dif_cpl]
   standard_name = surface_nir_albedo_diffuse_rad_for_coupling
   long_name = sfc near IR albedo for diffuse radiation for coupling
@@ -2182,7 +2182,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [sfc_alb_vis_dir_cpl]
   standard_name = surface_vis_albedo_direct_rad_for_coupling
   long_name = sfc visible albedo for direct radiation for coupling
@@ -2190,7 +2190,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [sfc_alb_vis_dif_cpl]
   standard_name = surface_vis_albedo_diffuse_rad_for_coupling
   long_name = sfc visible albedo for diffuse radiation for coupling
@@ -2198,17 +2198,17 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [slimskin_cpl]
-  standard_name = sea_land_ice_mask_in	
+  standard_name = area_type_from_coupled_process	
   long_name = sea/land/ice mask input (=0/1/2)
   units = flag
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling)
+  active = (flag_for_surface_flux_coupling)
 [ca_deep]
-  standard_name = fraction_of_cellular_automata_for_deep_convection
+  standard_name = cellular_automata_area_fraction_for_deep_convection_from_coupled_process
   long_name = fraction of cellular automata for deep convection
   units = frac
   dimensions = (horizontal_loop_extent)
@@ -2216,14 +2216,14 @@
   kind = kind_phys
   active = (flag_for_cellular_automata)
 [vfact_ca]
-  standard_name = vertical_weight_for_ca
+  standard_name = cellular_automata_vertical_weight
   long_name = vertical weight for ca
   units = frac
-  dimensions = (vertical_dimension)
+  dimensions = (vertical_layer_dimension)
   type = real
   kind = kind_phys
 [ca1]
-  standard_name = cellular_automata_global_pattern
+  standard_name = cellular_automata_global_pattern_from_coupled_process
   long_name = cellular automata global pattern
   units = flag
   dimensions = (horizontal_loop_extent)
@@ -2238,63 +2238,63 @@
   type = real
   kind = kind_phys
 [shum_wts]
-  standard_name = weights_for_stochastic_shum_perturbation
+  standard_name = shum_weights_from_coupled_process
   long_name = weights for stochastic shum perturbation
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_stochastic_shum_option)
 [sppt_wts]
-  standard_name = weights_for_stochastic_sppt_perturbation
+  standard_name = sppt_weights_from_coupled_process
   long_name = weights for stochastic sppt perturbation
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_stochastic_physics_perturbations .or. flag_for_global_cellular_automata)
 [skebu_wts]
-  standard_name = weights_for_stochastic_skeb_perturbation_of_x_wind
+  standard_name = skeb_x_wind_weights_from_coupled_process
   long_name = weights for stochastic skeb perturbation of x wind
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_stochastic_skeb_option)
 [skebv_wts]
-  standard_name = weights_for_stochastic_skeb_perturbation_of_y_wind
+  standard_name = skeb_y_wind_weights_from_coupled_process
   long_name = weights for stochastic skeb perturbation of y wind
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_stochastic_skeb_option)
 [sfc_wts]
-  standard_name = weights_for_stochastic_surface_physics_perturbation
+  standard_name = surface_stochastic_weights_from_coupled_process
   long_name = weights for stochastic surface physics perturbation
   units = none
-  dimensions = (horizontal_loop_extent,number_of_land_surface_variables_perturbed)
+  dimensions = (horizontal_loop_extent,number_of_perturbed_land_surface_variables)
   type = real
   kind = kind_phys
-  active = (index_for_stochastic_land_surface_perturbation_type .ne. 0)
+  active = (control_for_stochastic_land_surface_perturbation .ne. 0)
 [nwfa2d]
-  standard_name = tendency_of_water_friendly_aerosols_at_surface
+  standard_name = tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer
   long_name = instantaneous water-friendly sfc aerosol source
   units = kg-1 s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_thompson_microphysics_scheme .and. flag_for_aerosol_physics)
+  active = (control_for_microphysics_scheme == identifier_for_thompson_microphysics_scheme .and. flag_for_aerosol_physics)
 [nifa2d]
-  standard_name = tendency_of_ice_friendly_aerosols_at_surface
+  standard_name = tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer
   long_name = instantaneous ice-friendly sfc aerosol source
   units = kg-1 s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_thompson_microphysics_scheme .and. flag_for_aerosol_physics)
+  active = (control_for_microphysics_scheme == identifier_for_thompson_microphysics_scheme .and. flag_for_aerosol_physics)
 [ushfsfci]
-  standard_name = instantaneous_surface_upward_sensible_heat_flux_for_chemistry_coupling
+  standard_name = surface_upward_sensible_heat_flux_for_chemistry_coupling
   long_name = instantaneous upward sensible heat flux for chemistry coupling
   units = W m-2
   dimensions = (horizontal_loop_extent)
@@ -2305,15 +2305,15 @@
   standard_name = convective_cloud_condesate_after_rainout
   long_name = convective cloud condesate after rainout
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_mass_flux_deep_convection_scheme == flag_for_gf_deep_convection_scheme)
+  active = (control_for_deep_convection_scheme == identifier_for_grell_freitas_deep_convection)
 [pfi_lsan]
   standard_name = ice_flux_due_to_large_scale_precipitation
   long_name = instantaneous 3D flux of ice from nonconvective precipitation
   units = kg m-2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_chemistry_coupling)
@@ -2321,7 +2321,7 @@
   standard_name = liquid_flux_due_to_large_scale_precipitation
   long_name = instantaneous 3D flux of liquid water from nonconvective precipitation
   units = kg m-2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_chemistry_coupling)
@@ -2347,58 +2347,58 @@
   dimensions = ()
   type = integer
 [communicator]
-  standard_name = mpi_comm
+  standard_name = mpi_communicator
   long_name = MPI communicator
   units = index
   dimensions = ()
   type = integer
 [ntasks]
-  standard_name = mpi_size
+  standard_name = number_of_mpi_tasks
   long_name = number of MPI tasks in communicator
   units = count
   dimensions = ()
   type = integer
 [nthreads]
-  standard_name = omp_threads
+  standard_name = number_of_openmp_threads
   long_name = number of OpenMP threads available for physics schemes
   units = count
   dimensions = ()
   type = integer
 [nlunit]
-  standard_name = iounit_namelist
+  standard_name = iounit_of_namelist
   long_name = fortran unit number for file opens
   units = none
   dimensions = ()
   type = integer
 [fhzero]
-  standard_name = hours_between_clearing_of_diagnostic_buckets
+  standard_name = period_of_diagnostics_reset
   long_name = hours between clearing of diagnostic buckets
   units = h
   dimensions = ()
   type = real
   kind = kind_phys
 [fn_nml]
-  standard_name = namelist_filename
+  standard_name = filename_of_namelist
   long_name = namelist filename
   units = none
   dimensions = ()
   type = character
   kind = len=64
 [input_nml_file_length]
-  standard_name = number_of_lines_of_namelist_filename_for_internal_file_reads
+  standard_name = number_of_lines_in_internal_namelist
   long_name = lines in namelist file for internal file reads
   units = count
   dimensions = ()
   type = integer
 [input_nml_file]
-  standard_name = namelist_filename_for_internal_file_reads
+  standard_name = filename_of_internal_namelist
   long_name = namelist filename for internal file reads
   units = none
-  dimensions = (number_of_lines_of_namelist_filename_for_internal_file_reads)
+  dimensions = (number_of_lines_in_internal_namelist)
   type = character
   kind = len=256
 [logunit]
-  standard_name = iounit_log
+  standard_name = iounit_of_log
   long_name = fortran unit number for logfile
   units = none
   dimensions = ()
@@ -2423,31 +2423,31 @@
   dimensions = ()
   type = logical
 [flag_for_gwd_generic_tend]
-  standard_name = flag_for_generic_gravity_wave_drag_tendency
+  standard_name = flag_for_generic_tendency_due_to_gravity_wave_drag
   long_name = true if GFS_GWD_generic should calculate tendencies
   units = flag
   dimensions = ()
   type = logical
 [flag_for_pbl_generic_tend]
-  standard_name = flag_for_generic_planetary_boundary_layer_tendency
+  standard_name = flag_for_generic_tendency_due_to_planetary_boundary_layer
   long_name = true if GFS_PBL_generic should calculate tendencies
   units = flag
   dimensions = ()
   type = logical
 [flag_for_dcnv_generic_tend]
-  standard_name = flag_for_generic_deep_convection_tendency
+  standard_name = flag_for_generic_tendency_due_to_deep_convection
   long_name = true if GFS_DCNV_generic should calculate tendencies
   units = flag
   dimensions = ()
   type = logical
 [flag_for_scnv_generic_tend]
-  standard_name = flag_for_generic_shallow_convection_tendency
+  standard_name = flag_for_generic_tendency_due_to_shallow_convection
   long_name = true if GFS_SCNV_generic should calculate tendencies
   units = flag
   dimensions = ()
   type = logical
 [lssav]
-  standard_name = flag_diagnostics
+  standard_name = flag_for_diagnostics
   long_name = logical flag for storing diagnostics
   units = flag
   dimensions = ()
@@ -2477,55 +2477,55 @@
   dimensions = ()
   type = integer
 [cnx]
-  standard_name = number_of_points_in_x_direction_for_this_cubed_sphere_face
+  standard_name = number_of_x_points_for_current_cubed_sphere_tile
   long_name = number of points in x direction for this cubed sphere face
   units = count
   dimensions = ()
   type = integer
 [cny]
-  standard_name = number_of_points_in_y_direction_for_this_cubed_sphere_face
+  standard_name = number_of_y_points_for_current_cubed_sphere_tile
   long_name = number of points in y direction for this cubed sphere face
   units = count
   dimensions = ()
   type = integer
 [naux2d]
-  standard_name = number_of_2d_auxiliary_arrays
+  standard_name = number_of_xy_dimensioned_auxiliary_arrays
   long_name = number of 2d auxiliary arrays to output (for debugging)
   units = count
   dimensions = ()
   type = integer
 [naux3d]
-  standard_name = number_of_3d_auxiliary_arrays
+  standard_name = number_of_xyz_dimensioned_auxiliary_arrays
   long_name = number of 3d auxiliary arrays to output (for debugging)
   units = count
   dimensions = ()
   type = integer
 [levs]
-  standard_name = vertical_dimension
+  standard_name = vertical_layer_dimension
   long_name = number of vertical levels
   units = count
   dimensions = ()
   type = integer
 [ak]
-  standard_name = a_parameter_of_the_hybrid_coordinate
+  standard_name = sigma_pressure_hybrid_coordinate_a_coefficient
   long_name = a parameter for sigma pressure level calculations
   units = Pa
-  dimensions = (number_of_vertical_layers_for_radiation_calculations_plus_one)
+  dimensions = (vertical_interface_dimension_for_radiation)
   type = real
 [bk]
-  standard_name = b_parameter_of_the_hybrid_coordinate
+  standard_name = sigma_pressure_hybrid_coordinate_b_coefficient
   long_name = b parameter for sigma pressure level calculations
   units = none
-  dimensions = (number_of_vertical_layers_for_radiation_calculations_plus_one)
+  dimensions = (vertical_interface_dimension_for_radiation)
   type = real
 [levsp1]
-  standard_name = vertical_dimension_plus_one
+  standard_name = vertical_interface_dimension
   long_name = number of vertical levels plus one
   units = count
   dimensions = ()
   type = integer
 [levsm1]
-  standard_name = vertical_dimension_minus_one
+  standard_name = vertical_layer_dimension_minus_one
   long_name = number of vertical levels minus one
   units = count
   dimensions = ()
@@ -2567,25 +2567,25 @@
   dimensions = ()
   type = integer
 [tile_num]
-  standard_name = number_of_tile
+  standard_name = index_of_cubed_sphere_tile
   long_name = tile number
   units = none
   dimensions = ()
   type = integer
 [cplflx]
-  standard_name = flag_for_flux_coupling
+  standard_name = flag_for_surface_flux_coupling
   long_name = flag controlling cplflx collection (default off)
   units = flag
   dimensions = ()
   type = logical
 [cplwav]
-  standard_name = flag_for_wave_coupling
+  standard_name = flag_for_ocean_wave_coupling
   long_name = flag controlling cplwav collection (default off)
   units = flag
   dimensions = ()
   type = logical
 [cplwav2atm]
-  standard_name = flag_for_wave_coupling_to_atm
+  standard_name = flag_for_one_way_ocean_wave_coupling_to_atmosphere
   long_name = flag controlling ocean wave coupling to the atmosphere (default off)
   units = flag
   dimensions = ()
@@ -2597,7 +2597,7 @@
   dimensions = ()
   type = logical
 [lsidea]
-  standard_name = flag_idealized_physics
+  standard_name = flag_for_integrated_dynamics_through_earths_atmosphere
   long_name = flag for idealized physics
   units = flag
   dimensions = ()
@@ -2616,33 +2616,33 @@
   dimensions = ()
   type = integer
 [nszero]
-  standard_name = number_of_timesteps_between_diagnostic_clearing
+  standard_name = number_of_timesteps_between_diagnostics_resetting
   long_name = number of timesteps between calls to clear diagnostic variables
   units = count
   dimensions = ()
   type = integer
 [dtp]
-  standard_name = time_step_for_physics
+  standard_name = timestep_for_physics
   long_name = physics timestep
   units = s
   dimensions = ()
   type = real
   kind = kind_phys
 [dtf]
-  standard_name = time_step_for_dynamics
+  standard_name = timestep_for_dynamics
   long_name = dynamics timestep
   units = s
   dimensions = ()
   type = real
   kind = kind_phys
 [idat]
-  standard_name = date_and_time_at_model_initialization
+  standard_name = date_and_time_at_model_initialization_in_iso_order
   long_name = initialization date and time
   units = none
   dimensions = (8)
   type = integer
 [idate]
-  standard_name = date_and_time_at_model_initialization_reordered
+  standard_name = date_and_time_at_model_initialization_in_united_states_order
   long_name = initial date with different size and ordering
   units = none
   dimensions = (4)
@@ -2660,39 +2660,39 @@
   dimensions = ()
   type = integer
 [fhswr]
-  standard_name = frequency_for_shortwave_radiation
+  standard_name = period_of_shortwave_radiation_calls
   long_name = frequency for shortwave radiation
   units = s
   dimensions = ()
   type = real
   kind = kind_phys
 [fhlwr]
-  standard_name = frequency_for_longwave_radiation
+  standard_name = period_of_longwave_radiation_calls
   long_name = frequency for longwave radiation
   units = s
   dimensions = ()
   type = real
   kind = kind_phys
 [nhfrad]
-  standard_name = number_of_timesteps_for_radiation_calls_on_physics_timestep
+  standard_name = number_of_timesteps_for_concurrent_radiation_and_remainder_physics_calls_after_model_initialization
   long_name = number of timesteps for radiation calls on physics timestep (coldstarts only)
   units = count
   dimensions = ()
   type = integer
 [levr]
-  standard_name = number_of_vertical_layers_for_radiation_calculations
+  standard_name = vertical_dimension_for_radiation
   long_name = number of vertical levels for radiation calculations
   units = count
   dimensions = ()
   type = integer
 [levrp1]
-  standard_name = number_of_vertical_layers_for_radiation_calculations_plus_one
+  standard_name = vertical_interface_dimension_for_radiation
   long_name = number of vertical levels for radiation calculations + 1
   units = count
   dimensions = ()
   type = integer
 [nfxr]
-  standard_name = number_of_radiation_diagnostic_variables
+  standard_name = number_of_diagnostics_variables_for_radiation
   long_name = number of variables stored in the fluxr array
   units = count
   dimensions = ()
@@ -2710,49 +2710,49 @@
   dimensions = ()
   type = integer
 [nrcm]
-  standard_name = array_dimension_of_random_number
+  standard_name = number_of_random_numbers
   long_name = second dimension of random number stream for RAS
   units = count
   dimensions = ()
   type = integer
 [iflip]
-  standard_name = flag_for_vertical_index_direction_control
+  standard_name = control_for_vertical_index_direction
   long_name = iflip - is not the same as flipv
   units = flag
   dimensions = ()
   type = integer
 [isol]
-  standard_name = flag_for_solar_constant
+  standard_name = control_for_solar_constant
   long_name = use prescribed solar constant
   units = flag
   dimensions = ()
   type = integer
 [ico2]
-  standard_name = flag_for_using_prescribed_global_mean_co2_value
+  standard_name = control_for_co2
   long_name = prescribed global mean value (old opernl)
   units = flag
   dimensions = ()
   type = integer
 [ialb]
-  standard_name = flag_for_using_climatology_albedo
+  standard_name = control_for_surface_albedo
   long_name = flag for using climatology alb, based on sfc type
   units = flag
   dimensions = ()
   type = integer
 [iems]
-  standard_name = flag_for_surface_emissivity_control
+  standard_name = control_for_surface_emissivity
   long_name = surface emissivity control flag, use fixed value of 1
   units = flag
   dimensions = ()
   type = integer
 [iaer]
-  standard_name = flag_for_default_aerosol_effect_in_shortwave_radiation
+  standard_name = control_for_shortwave_radiation_aerosols
   long_name = default aerosol effect in sw only
   units = flag
   dimensions = ()
   type = integer
 [icliq_sw]
-  standard_name = flag_for_optical_property_for_liquid_clouds_for_shortwave_radiation
+  standard_name = control_for_shortwave_radiation_liquid_clouds
   long_name = sw optical property for liquid clouds
   units = flag
   dimensions = ()
@@ -2812,25 +2812,25 @@
   dimensions = ()
   type = logical
 [ccnorm]
-  standard_name = flag_for_cloud_condensate_normalized_by_cloud_cover
+  standard_name = flag_for_in_cloud_condensate
   long_name = flag for cloud condensate normalized by cloud cover
   units = flag
   dimensions = ()
   type = logical
 [norad_precip]
-  standard_name = flag_for_precipitation_effect_on_radiation
+  standard_name = flag_for_turning_off_precipitation_radiative_effect
   long_name = radiation precip flag for Ferrier/Moorthi
   units = flag
   dimensions = ()
   type = logical
 [lwhtr]
-  standard_name = flag_for_output_of_longwave_heating_rate
+  standard_name = flag_for_output_of_tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep_assuming_clear_sky
   long_name = flag to output lw heating rate (Radtend%lwhc)
   units = flag
   dimensions = ()
   type = logical
 [swhtr]
-  standard_name = flag_for_output_of_shortwave_heating_rate
+  standard_name = flag_for_output_of_tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep_assuming_clear_sky
   long_name = flag to output sw heating rate (Radtend%swhc)
   units = flag
   dimensions = ()
@@ -2856,53 +2856,53 @@
   type = character
   kind = len=128
 [lw_file_gas]
-  standard_name = rrtmgp_kdistribution_lw
+  standard_name = filename_of_rrtmgp_longwave_k_distribution
   long_name = file containing RRTMGP LW k-distribution (Model%lw_file_gas)
   units = none
   dimensions =  ()
   type = character
   kind = len=128
 [lw_file_clouds]
-  standard_name = rrtmgp_coeff_lw_cloud_optics
+  standard_name = filename_of_rrtmgp_longwave_cloud_optics_coefficients
   long_name = file containing coefficients for RRTMGP LW cloud optics (Model%lw_file_clouds)
   units = none
   dimensions =  ()
   type = character
   kind = len=128
 [rrtmgp_nBandsLW]
-  standard_name = number_of_lw_bands_rrtmgp
+  standard_name = number_of_longwave_bands
   long_name = number of lw bands used in RRTMGP (Model%rrtmgp_nBandsLW)
   units = count
   dimensions =  ()
   type = integer
 [rrtmgp_nGptsLW]
-  standard_name = number_of_lw_spectral_points_rrtmgp
+  standard_name = number_of_longwave_spectral_points
   long_name = number of spectral points in RRTMGP LW calculation (model%rrtmgp_nGptsLW)
   units = count
   dimensions =  ()
   type = integer
 [sw_file_gas]
-  standard_name = rrtmgp_kdistribution_sw
+  standard_name = filename_of_rrtmgp_shortwave_k_distribution
   long_name = file containing RRTMGP SW k-distribution (Model%sw_file_gas)
   units = none
   dimensions =  ()
   type = character
   kind = len=128
 [sw_file_clouds]
-  standard_name = rrtmgp_coeff_sw_cloud_optics
+  standard_name = filename_of_rrtmgp_shortwave_cloud_optics_coefficients
   long_name = file containing coefficients for RRTMGP SW cloud optics (Model%sw_file_clouds)
   units = none
   dimensions =  ()
   type = character
   kind = len=128
 [rrtmgp_nBandsSW]
-  standard_name = number_of_sw_bands_rrtmgp
+  standard_name = number_of_shortwave_bands
   long_name = number of sw bands used in RRTMGP (Model%rrtmgp_nBandsSW)
   units = count
   dimensions =  ()
   type = integer
 [rrtmgp_nGptsSW]
-  standard_name = number_of_sw_spectral_points_rrtmgp
+  standard_name = number_of_shortwave_spectral_points
   long_name = number of spectral points in RRTMGP SW calculation (model%rrtmgp_nGptsSW)
   units = count
   dimensions =  ()
@@ -2938,13 +2938,13 @@
   dimensions = ()
   type = logical
 [rrtmgp_nrghice]
-  standard_name = number_of_rrtmgp_ice_roughness
+  standard_name = number_of_ice_roughness_categories
   long_name = number of ice-roughness categories in RRTMGP calculation (Model%rrtmgp_nrghice)
   units = count
   dimensions =  ()
   type = integer
 [rrtmgp_nGauss_ang]
-  standard_name = number_of_angles_used_in_gaussian_quadrature
+  standard_name = number_of_gaussian_quadrature_angles_for_radiation
   long_name = Number of angles used in Gaussian quadrature
   units = count
   dimensions =  ()
@@ -2956,7 +2956,7 @@
   dimensions =  ()
   type = logical
 [do_GPsw_Glw]
-  standard_name = scheme_flag
+  standard_name = flag_for_rrtmgp_shortwave_and_rrtmg_longwave_radiation
   long_name = When true GP is used for SW calculation and G is used for LW calculation
   units = flag
   dimensions =  ()
@@ -2988,49 +2988,49 @@
   dimensions = ()
   type = logical
 [imp_physics]
-  standard_name = flag_for_microphysics_scheme
+  standard_name = control_for_microphysics_scheme
   long_name = choice of microphysics scheme
   units = flag
   dimensions = ()
   type = integer
 [imp_physics_fer_hires]
-  standard_name = flag_for_fer_hires_microphysics_scheme
+  standard_name = identifier_for_fer_hires_microphysics_scheme
   long_name = choice of Ferrier-Aligo microphysics scheme
   units = flag
   dimensions = ()
   type = integer
 [imp_physics_gfdl]
-  standard_name = flag_for_gfdl_microphysics_scheme
+  standard_name = identifier_for_gfdl_microphysics_scheme
   long_name = choice of GFDL microphysics scheme
   units = flag
   dimensions = ()
   type = integer
 [imp_physics_thompson]
-  standard_name = flag_for_thompson_microphysics_scheme
+  standard_name = identifier_for_thompson_microphysics_scheme
   long_name = choice of Thompson microphysics scheme
   units = flag
   dimensions = ()
   type = integer
 [imp_physics_wsm6]
-  standard_name = flag_for_wsm6_microphysics_scheme
+  standard_name = identifier_for_wsm6_microphysics_scheme
   long_name = choice of WSM6 microphysics scheme
   units = flag
   dimensions = ()
   type = integer
 [imp_physics_zhao_carr]
-  standard_name = flag_for_zhao_carr_microphysics_scheme
+  standard_name = identifier_for_zhao_carr_microphysics_scheme
   long_name = choice of Zhao-Carr microphysics scheme
   units = flag
   dimensions = ()
   type = integer
 [imp_physics_zhao_carr_pdf]
-  standard_name = flag_for_zhao_carr_pdf_microphysics_scheme
+  standard_name = identifier_for_zhao_carr_pdf_microphysics_scheme
   long_name = choice of Zhao-Carr microphysics scheme with PDF clouds
   units = flag
   dimensions = ()
   type = integer
 [imp_physics_mg]
-  standard_name = flag_for_morrison_gettelman_microphysics_scheme
+  standard_name = identifier_for_morrison_gettelman_microphysics_scheme
   long_name = choice of Morrison-Gettelman microphysics scheme
   units = flag
   dimensions = ()
@@ -3090,55 +3090,55 @@
   dimensions = ()
   type = integer
 [dcorr_con]
-  standard_name = decorreltion_length_used_by_overlap_method
+  standard_name = decorrelation_length_used_by_overlap_method
   long_name = decorrelation length (default) used by cloud overlap method (iovr)
   units = km
   dimensions = ()
   type = real
 [psautco]
-  standard_name = coefficient_from_cloud_ice_to_snow
+  standard_name = autoconversion_to_snow_coefficient
   long_name = auto conversion coeff from ice to snow
   units = none
   dimensions = (2)
   type = real
   kind = kind_phys
 [prautco]
-  standard_name = coefficient_from_cloud_water_to_rain
+  standard_name = autoconversion_to_rain_coefficient
   long_name = auto conversion coeff from cloud to rain
   units = none
   dimensions = (2)
   type = real
   kind = kind_phys
 [psauras]
-  standard_name = coefficient_from_cloud_ice_to_snow_ras
+  standard_name = autoconversion_to_snow_coefficient_for_deep_convection
   long_name = conversion coefficient from cloud ice to snow in ras
   units = none
   dimensions = (2)
   type = real
   kind = kind_phys
 [prauras]
-  standard_name = coefficient_from_cloud_water_to_rain_ras
+  standard_name = autoconversion_to_rain_coefficient_for_deep_convection
   long_name = conversion coefficient from cloud water to rain in ras
   units = none
   dimensions = (2)
   type = real
   kind = kind_phys
 [evpco]
-  standard_name = coefficient_for_evaporation_of_rainfall
+  standard_name = precipitation_evaporation_coefficient
   long_name = coeff for evaporation of largescale rain
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [wminco]
-  standard_name = cloud_condensed_water_conversion_threshold
+  standard_name = cloud_condensate_autoconversion_threshold_coefficient
   long_name = water and ice minimum threshold for Zhao
   units = none
   dimensions = (2)
   type = real
   kind = kind_phys
 [wminras]
-  standard_name = cloud_condensed_water_ice_conversion_threshold_ras
+  standard_name = cloud_condensate_autoconversion_threshold_coefficient_for_deep_convection
   long_name = conversion coefficient from cloud liquid and ice to precipitation in ras
   units = none
   dimensions = (2)
@@ -3151,14 +3151,14 @@
   dimensions = ()
   type = integer
 [dlqf]
-  standard_name = condensate_fraction_detrained_in_updraft_layers
+  standard_name = cloud_condensate_detrainment_coefficient
   long_name = condensate fraction detrained with in a updraft layers
   units = none
   dimensions = (2)
   type = real
   kind = kind_phys
 [avg_max_length]
-  standard_name = time_interval_for_maximum_hourly_fields
+  standard_name = period_of_maximum_diagnostics_reset
   long_name = reset time interval for maximum hourly fields
   units = s
   dimensions = ()
@@ -3171,104 +3171,104 @@
   dimensions = ()
   type = integer
 [pdfflag]
-  standard_name = flag_for_pdf_for_morrison_gettelman_microphysics_scheme
+  standard_name = control_for_pdf_shape_for_microphysics
   long_name = pdf flag for MG macrophysics
   units = flag
   dimensions = ()
   type = integer
 [mg_dcs]
-  standard_name = mg_autoconversion_size_threshold_ice_snow
+  standard_name = autoconverion_to_snow_size_threshold
   long_name = autoconversion size threshold for cloud ice to snow for MG microphysics
   units = um
   dimensions = ()
   type = real
   kind = kind_phys
 [mg_qcvar]
-  standard_name = mg_cloud_water_variance
+  standard_name = relative_variance_of_subgrid_cloud_condensate_distribution
   long_name = cloud water relative variance for MG microphysics
   units =
   dimensions = ()
   type = real
   kind = kind_phys
 [mg_ts_auto_ice]
-  standard_name = mg_time_scale_for_autoconversion_of_ice
+  standard_name = timescale_for_autoconversion_to_snow
   long_name = autoconversion time scale for ice for MG microphysics
   units = s
   dimensions = (2)
   type = real
   kind = kind_phys
 [mg_rhmini]
-  standard_name = mg_minimum_rh_for_ice
+  standard_name = relative_humidity_threshold_for_ice_nucleation
   long_name = relative humidity threshold parameter for nucleating ice for MG microphysics
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [mg_ncnst]
-  standard_name = mg_drop_concentration_constant
+  standard_name = prescribed_cloud_droplet_number_concentration
   long_name = droplet concentration constant for MG microphysics
   units = m-3
   dimensions = ()
   type = real
   kind = kind_phys
 [mg_ninst]
-  standard_name = mg_ice_concentration_constant
+  standard_name = prescribed_cloud_ice_number_concentration
   long_name = ice concentration constant for MG microphysics
   units = m-3
   dimensions = ()
   type = real
   kind = kind_phys
 [mg_ngnst]
-  standard_name = mg_graupel_concentration_constant
+  standard_name = prescribed_graupel_number_concentration
   long_name = graupel concentration constant for MG microphysics
   units = m-3
   dimensions = ()
   type = real
   kind = kind_phys
 [mg_berg_eff_factor]
-  standard_name = mg_bergeron_efficiency_factor
+  standard_name = bergeron_findeisen_process_efficiency_factor
   long_name = bergeron efficiency factor for MG microphysics
   units = frac
   dimensions = ()
   type = real
   kind = kind_phys
 [mg_alf]
-  standard_name = mg_tuning_factor_for_alphas
+  standard_name = alpha_tuning_coefficient_for_morrison_gettelman_microphysics_scheme
   long_name = tuning factor for alphas (alpha = 1 - critical relative humidity)
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [mg_qcmin]
-  standard_name = mg_minimum_cloud_condensed_water_and_ice_mixing_ratio
+  standard_name = minimum_cloud_condensate_mixing_ratio_threshold
   long_name = minimum cloud condensed water and ice mixing ratio in MG macro clouds
   units = kg kg-1
   dimensions = (2)
   type = real
   kind = kind_phys
 [mg_qcmin(1)]
-  standard_name = mg_minimum_cloud_condensed_water_mixing_ratio
+  standard_name = minimum_cloud_liquid_water_mixing_ratio_threshold
   long_name = minimum cloud condensed water mixing ratio in MG macro clouds
   units = kg kg-1
   dimensions = ()
   type = real
   kind = kind_phys
 [mg_qcmin(2)]
-  standard_name = mg_minimum_ice_mixing_ratio
+  standard_name = minimum_cloud_ice_mixing_ratio_threshold
   long_name = minimum ice mixing ratio in MG macro clouds
   units = kg kg-1
   dimensions = ()
   type = real
   kind = kind_phys
 [mg_precip_frac_method]
-  standard_name = mg_type_of_precip_fraction_method
+  standard_name = control_for_precipitation_area_fraction_method
   long_name = type of precip fraction method for MG microphysics (in_cloud or max_overlap)
   units = none
   dimensions = ()
   type = character
   kind = len=16
 [tf]
-  standard_name = frozen_cloud_threshold_temperature
+  standard_name = all_ice_cloud_threshold_temperature
   long_name = threshold temperature below which all cloud is ice
   units = K
   dimensions = ()
@@ -3282,7 +3282,7 @@
   type = real
   kind = kind_phys
 [tcrf]
-  standard_name = cloud_phase_transition_denominator
+  standard_name = reciprocal_of_cloud_phase_transition_temperature_range
   long_name = denominator in cloud phase transition = 1/(tcr-tf)
   units = K-1
   dimensions = ()
@@ -3295,93 +3295,93 @@
   dimensions = ()
   type = logical
 [microp_uniform]
-  standard_name = mg_flag_for_uniform_subcolumns
+  standard_name = flag_for_uniform_subcolumns
   long_name = flag for uniform subcolumns for MG microphysics
   units = flag
   dimensions = ()
   type = logical
 [do_cldice]
-  standard_name = mg_flag_for_cloud_ice_processes
+  standard_name = flag_for_cloud_ice_processes
   long_name = flag for cloud ice processes for MG microphysics
   units = flag
   dimensions = ()
   type = logical
 [hetfrz_classnuc]
-  standard_name = mg_flag_for_heterogeneous_freezing
+  standard_name = flag_for_heterogeneous_nucleation
   long_name = flag for heterogeneous freezing for MG microphysics
   units = flag
   dimensions = ()
   type = logical
 [mg_nccons]
-  standard_name = mg_flag_drop_concentration_constant
+  standard_name = flag_for_prescribed_cloud_droplet_number_concentration
   long_name = flag for constant droplet concentration for MG microphysics
   units = flag
   dimensions = ()
   type = logical
 [mg_nicons]
-  standard_name = mg_flag_ice_concentration_constant
+  standard_name = flag_for_prescribed_cloud_ice_number_concentration
   long_name = flag for constant ice concentration for MG microphysics
   units = flag
   dimensions = ()
   type = logical
 [mg_ngcons]
-  standard_name = mg_flag_graupel_concentration_constant
+  standard_name = flag_for_prescribed_graupel_number_concentration
   long_name = flag for constant graupel concentration for MG microphysics
   units = flag
   dimensions = ()
   type = logical
 [sed_supersat]
-  standard_name = mg_allow_supersat_after_sed
+  standard_name = flag_for_allowance_of_supersaturation_after_sedimentation
   long_name = allow supersaturation after sedimentation for MG microphysics
   units = flag
   dimensions = ()
   type = logical
 [do_sb_physics]
-  standard_name = mg_flag_for_sb2001_autoconversion
+  standard_name = flag_for_seifert_and_beheng_2001_autoconversion
   long_name = flag for SB 2001 autoconversion or accretion for MG microphysics
   units = flag
   dimensions = ()
   type = logical
 [mg_do_graupel]
-  standard_name = mg_flag_for_graupel
+  standard_name = flag_for_graupel_instead_of_hail
   long_name = flag for graupel for MG microphysics (hail possible if false)
   units = flag
   dimensions = ()
   type = logical
 [mg_do_hail]
-  standard_name = mg_flag_for_hail
+  standard_name = flag_for_hail_instead_of_graupel
   long_name = flag for hail for MG microphysics (graupel possible if false)
   units = flag
   dimensions = ()
   type = logical
 [mg_do_ice_gmao]
-  standard_name = mg_flag_for_gmao_ice_formulation
+  standard_name = flag_for_gmao_autoconversion_to_snow
   long_name = flag for gmao ice formulation
   units = flag
   dimensions = ()
   type = logical
 [mg_do_liq_liu]
-  standard_name = mg_flag_for_liu_liquid_treatment
+  standard_name = flag_for_liu_autoconversion_to_rain
   long_name = flag for liu liquid treatment
   units = flag
   dimensions = ()
   type = logical
 [shoc_parm(1)]
-  standard_name = shoc_tke_dissipatation_pressure_threshold
+  standard_name = pressure_threshold_for_increased_tke_dissipation
   long_name = pressure below which extra TKE diss. is applied in SHOC
   units = Pa
   dimensions = ()
   type = real
   kind = kind_phys
 [shoc_parm(2)]
-  standard_name = shoc_tke_dissipation_tunable_parameter
+  standard_name = multiplicative_tunable_parameter_for_tke_dissipation
   long_name = mult. tuning parameter for TKE diss. in SHOC
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [shoc_parm(3)]
-  standard_name = shoc_tke_dissipation_tunable_parameter_near_surface
+  standard_name = multiplicative_tunable_parameter_for_tke_dissipation_at_surface_adjacent_layer
   long_name = mult. tuning parameter for TKE diss. at surface in SHOC
   units = none
   dimensions = ()
@@ -3402,7 +3402,7 @@
   type = real
   kind = kind_phys
 [ncnd]
-  standard_name = number_of_cloud_condensate_types
+  standard_name = number_of_condensate_species
   long_name = number of cloud condensate types
   units = count
   dimensions = ()
@@ -3420,7 +3420,7 @@
   dimensions = ()
   type = logical
 [ttendlim]
-  standard_name = limit_for_temperature_tendency_for_microphysics
+  standard_name = max_tendency_of_air_potential_temperature_due_to_large_scale_precipitation
   long_name = temperature tendency limiter per physics time step
   units = K s-1
   dimensions = ()
@@ -3433,83 +3433,83 @@
   dimensions = ()
   type = logical
 [lsm]
-  standard_name = flag_for_land_surface_scheme
+  standard_name = control_for_land_surface_scheme
   long_name = flag for land surface model
   units = flag
   dimensions = ()
   type = integer
 [lsm_noah]
-  standard_name = flag_for_noah_land_surface_scheme
+  standard_name = identifier_for_noah_land_surface_scheme
   long_name = flag for NOAH land surface model
   units = flag
   dimensions = ()
   type = integer
 [lsm_noahmp]
-  standard_name = flag_for_noahmp_land_surface_scheme
+  standard_name = identifier_for_noahmp_land_surface_scheme
   long_name = flag for NOAH MP land surface model
   units = flag
   dimensions = ()
   type = integer
 [lsm_ruc]
-  standard_name = flag_for_ruc_land_surface_scheme
+  standard_name = identifier_for_ruc_land_surface_scheme
   long_name = flag for RUC land surface model
   units = flag
   dimensions = ()
   type = integer
 [lsm_noah_wrfv4]
-  standard_name = flag_for_noah_wrfv4_land_surface_scheme
+  standard_name = identifier_for_noah_wrfv4_land_surface_scheme
   long_name = flag for NOAH WRFv4 land surface model
   units = flag
   dimensions = ()
   type = integer
 [kice]
-  standard_name = ice_vertical_dimension
+  standard_name = vertical_dimension_of_sea_ice
   long_name = vertical loop extent for ice levels, start at 1
   units = count
   dimensions = ()
   type = integer
 [lsoil]
-  standard_name = soil_vertical_dimension
+  standard_name = vertical_dimension_of_soil
   long_name = number of soil layers
   units = count
   dimensions = ()
   type = integer
 [lsoil_lsm]
-  standard_name = soil_vertical_dimension_for_land_surface_model
+  standard_name = vertical_dimension_of_soil_internal_to_land_surface_scheme
   long_name = number of soil layers internal to land surface model
   units = count
   dimensions = ()
   type = integer
 [lsnow_lsm]
-  standard_name = snow_vertical_dimension_for_land_surface_model
+  standard_name = vertical_dimension_of_surface_snow
   long_name = maximum number of snow layers for land surface model
   units = count
   dimensions = ()
   type = integer
 [lsnow_lsm_lbound]
-  standard_name = lower_bound_of_snow_vertical_dimension_for_land_surface_model
+  standard_name = lower_bound_of_vertical_dimension_of_surface_snow
   long_name = lower bound of of snow-related arrays for land surface model
   units = count
   dimensions = ()
   type = integer
 [lsnow_lsm_ubound]
-  standard_name = upper_bound_of_snow_vertical_dimension_for_land_surface_model
+  standard_name = upper_bound_of_vertical_dimension_of_surface_snow
   long_name = upper bound of of snow-related arrays for land surface model
   units = count
   dimensions = ()
   type = integer
 [zs]
-  standard_name = depth_of_soil_levels_for_land_surface_model
+  standard_name = depth_of_soil_layers
   long_name = depth of soil levels for land surface model
   units = m
-  dimensions = (soil_vertical_dimension_for_land_surface_model)
+  dimensions = (vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
 [dzs]
-  standard_name = thickness_of_soil_levels_for_land_surface_model
+  standard_name = thickness_of_soil_layers_for_land_surface_model
   long_name = thickness of soil levels for land surface model
   units = m
-  dimensions = (soil_vertical_dimension_for_land_surface_model)
+  dimensions = (vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
 [pores]
@@ -3539,62 +3539,62 @@
   dimensions = ()
   type = logical
 [usemonalb]
-  standard_name = flag_for_reading_surface_diffused_shortwave_albedo_from_input
+  standard_name = flag_for_reading_surface_albedo_for_diffused_shortwave_from_input
   long_name = flag for reading surface diffused shortwave albedo for NOAH LSM WRFv4 (see module_sf_noahlsm.F)
   units = flag
   dimensions = ()
   type = logical
 [aoasis]
-  standard_name = potential_evaporation_multiplicative_factor
+  standard_name = multiplicative_tuning_parameter_for_potential_evaporation
   long_name = potential evaporation multiplicative factor for NOAH LSM WRFv4 (see module_sf_noahlsm.F)
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [fasdas]
-  standard_name = flag_flux_adjusting_surface_data_assimilation_system
+  standard_name = control_for_flux_adjusting_surface_data_assimilation_system
   long_name = flag to use the flux adjusting surface data assimilation system for NOAH LSM WRFv4 (see module_sf_noahlsm.F)
   units = flag
   dimensions = ()
   type = integer
 [ivegsrc]
-  standard_name = vegetation_type_dataset_choice
+  standard_name = control_for_vegetation_dataset
   long_name = land use dataset choice
   units = index
   dimensions = ()
   type = integer
 [isot]
-  standard_name = soil_type_dataset_choice
+  standard_name = control_for_soil_type_dataset
   long_name = soil type dataset choice
   units = index
   dimensions = ()
   type = integer
 [isurban]
-  standard_name = urban_vegetation_category
+  standard_name = index_of_urban_vegetation_category
   long_name = index of the urban vegetation category in the chosen vegetation dataset
   units = index
   dimensions = ()
   type = integer
 [isice]
-  standard_name = ice_vegetation_category
+  standard_name = index_of_ice_vegetation_category
   long_name = index of the permanent snow/ice category in the chosen vegetation dataset
   units = index
   dimensions = ()
   type = integer
 [iswater]
-  standard_name = water_vegetation_category
+  standard_name = index_of_water_vegetation_category
   long_name = index of the water body vegetation category in the chosen vegetation dataset
   units = index
   dimensions = ()
   type = integer
 [iopt_thcnd]
-  standard_name = flag_for_thermal_conductivity_option
+  standard_name = control_for_land_surface_scheme_thermal_conductivity_option
   long_name = choice for thermal conductivity option (see module_sf_noahlsm)
   units = index
   dimensions = ()
   type = integer
 [spec_adv]
-  standard_name = flag_for_individual_cloud_species_advected
+  standard_name = flag_for_separate_advection_of_condensate_species
   long_name = flag for individual cloud species advected
   units = flag
   dimensions = ()
@@ -3607,73 +3607,73 @@
   type = real
   kind = kind_phys
 [iopt_dveg]
-  standard_name = flag_for_dynamic_vegetation_option
+  standard_name = control_for_land_surface_scheme_dynamic_vegetation
   long_name = choice for dynamic vegetation option (see noahmp module for definition)
   units = index
   dimensions = ()
   type = integer
 [iopt_crs]
-  standard_name = flag_for_canopy_stomatal_resistance_option
+  standard_name = control_for_land_surface_scheme_canopy_stomatal_resistance
   long_name = choice for canopy stomatal resistance option (see noahmp module for definition)
   units = index
   dimensions = ()
   type = integer
 [iopt_btr]
-  standard_name = flag_for_soil_moisture_factor_stomatal_resistance_option
+  standard_name = control_for_land_surface_scheme_soil_moisture_factor_stomatal_resistance
   long_name = choice for soil moisture factor for canopy stomatal resistance option (see noahmp module for definition)
   units = index
   dimensions = ()
   type = integer
 [iopt_run]
-  standard_name = flag_for_runoff_and_groundwater_option
+  standard_name = control_for_land_surface_scheme_runoff_and_groundwater
   long_name = choice for runoff and groundwater option (see noahmp module for definition)
   units = index
   dimensions = ()
   type = integer
 [iopt_sfc]
-  standard_name = flag_for_surface_layer_drag_coefficient_option
+  standard_name = control_for_land_surface_scheme_surface_layer_drag_coefficient
   long_name = choice for surface layer drag coefficient option (see noahmp module for definition)
   units = index
   dimensions = ()
   type = integer
 [iopt_frz]
-  standard_name = flag_for_supercooled_liquid_water_option
+  standard_name = control_for_land_surface_scheme_supercooled_liquid_water
   long_name = choice for supercooled liquid water option (see noahmp module for definition)
   units = index
   dimensions = ()
   type = integer
 [iopt_inf]
-  standard_name = flag_for_frozen_soil_permeability_option
+  standard_name = control_for_land_surface_scheme_frozen_soil_permeability
   long_name = choice for frozen soil permeability option (see noahmp module for definition)
   units = index
   dimensions = ()
   type = integer
 [iopt_rad]
-  standard_name = flag_for_radiation_transfer_option
+  standard_name = control_for_land_surface_scheme_radiative_transfer
   long_name = choice for radiation transfer option (see noahmp module for definition)
   units = index
   dimensions = ()
   type = integer
 [iopt_alb]
-  standard_name = flag_for_ground_snow_surface_albedo_option
+  standard_name = control_for_land_surface_scheme_surface_snow_albedo
   long_name = choice for ground snow surface albedo option (see noahmp module for definition)
   units = index
   dimensions = ()
   type = integer
 [iopt_snf]
-  standard_name = flag_for_precipitation_partition_option
+  standard_name = control_for_land_surface_scheme_precipitation_type_partition
   long_name = choice for precipitation partition option (see noahmp module for definition)
   units = index
   dimensions = ()
   type = integer
 [iopt_tbot]
-  standard_name = flag_for_lower_boundary_soil_temperature_option
+  standard_name = control_for_land_surface_scheme_lower_boundary_soil_temperature
   long_name = choice for lower boundary soil temperature option (see noahmp module for definition)
   units = index
   dimensions = ()
   type = integer
 [iopt_stc]
-  standard_name = flag_for_soil_and_snow_temperature_time_stepping_option
+  standard_name = control_for_land_surface_scheme_soil_and_snow_temperature_time_integration
   long_name = choice for soil and snow temperature time stepping option (see noahmp module for definition)
   units = index
   dimensions = ()
@@ -3685,44 +3685,44 @@
   dimensions = ()
   type = logical
 [lcurr_sf]
-  standard_name = flag_for_ocean_currents_in_surface_layer_scheme
+  standard_name = flag_for_surface_layer_scheme_ocean_currents
   long_name = flag for taking ocean currents into account in surface layer scheme
   units = flag
   dimensions = ()
   type = logical
 [pert_cd]
-  standard_name = flag_for_perturbation_of_surface_drag_coefficient_for_momentum_in_air
+  standard_name = flag_for_surface_layer_scheme_surface_drag_coefficient_for_momentum_in_air_perturbations
   long_name = flag for perturbing the surface drag coefficient for momentum in surface layer scheme
   units = flag
   dimensions = ()
   type = logical
 [ntsflg]
-  standard_name = flag_for_updating_skin_temperatuer_in_surface_layer_scheme
+  standard_name = control_for_surface_layer_scheme_skin_temperature_update
   long_name = flag for updating skin temperature in the surface layer scheme
   units = flag
   dimensions = ()
   type = integer
 [sfenth]
-  standard_name = enthalpy_flux_factor
+  standard_name = surface_layer_scheme_enthalpy_flux_factor
   long_name = enthalpy flux factor used in surface layer scheme
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [lkm]
-  standard_name = flag_for_lake_surface_scheme
+  standard_name = control_for_lake_surface_scheme
   long_name = flag for lake surface model
   units = flag
   dimensions = ()
   type = integer
 [ras]
-  standard_name = flag_for_ras_deep_convection
+  standard_name = flag_for_relaxed_arakawa_schubert_deep_convection
   long_name = flag for ras convection scheme
   units = flag
   dimensions = ()
   type = logical
 [rhgrd]
-  standard_name = fa_threshold_relative_humidity_for_onset_of_condensation
+  standard_name = relative_humidity_threshold_for_condensation
   long_name = relative humidity threshold parameter for condensation for FA scheme
   units = none
   dimensions = ()
@@ -3771,13 +3771,13 @@
   dimensions = ()
   type = logical
 [do_ysu]
-  standard_name = flag_for_ysu
+  standard_name = flag_for_ysu_pbl_scheme
   long_name = flag for YSU PBL scheme
   units = flag
   dimensions = ()
   type = logical
 [cal_pre]
-  standard_name = flag_for_precipitation_type_algorithm
+  standard_name = flag_for_dominant_precipitation_type_partition
   long_name = flag controls precip type algorithm
   units = flag
   dimensions = ()
@@ -3789,7 +3789,7 @@
   dimensions = ()
   type = logical
 [do_awdd]
-  standard_name = flag_arakawa_wu_downdraft
+  standard_name = flag_for_arakawa_wu_downdrafts_for_deep_convection
   long_name = AW scale-aware option in cs convection downdraft
   units = flag
   dimensions = ()
@@ -3813,13 +3813,13 @@
   dimensions = ()
   type = logical
 [oz_phys]
-  standard_name = flag_for_ozone_physics
+  standard_name = flag_for_nrl_2006_ozone_scheme
   long_name = flag for old (2006) ozone physics
   units = flag
   dimensions = ()
   type = logical
 [oz_phys_2015]
-  standard_name = flag_for_2015_ozone_physics
+  standard_name = flag_for_nrl_2015_ozone_scheme
   long_name = flag for new (2015) ozone physics
   units = flag
   dimensions = ()
@@ -3831,13 +3831,13 @@
   dimensions = ()
   type = logical
 [shcnvcw]
-  standard_name = flag_shallow_convective_cloud
+  standard_name = flag_for_saving_shallow_convective_cloud_area_fraction
   long_name = flag for shallow convective cloud
   units =
   dimensions = ()
   type = logical
 [redrag]
-  standard_name = flag_for_reduced_drag_coefficient_over_sea
+  standard_name = flag_for_limited_surface_roughness_length_over_ocean
   long_name = flag for reduced drag coeff. over sea
   units = flag
   dimensions = ()
@@ -3849,7 +3849,7 @@
   dimensions = ()
   type = logical
 [hybedmf]
-  standard_name = flag_for_hedmf
+  standard_name = flag_for_hybrid_edmf_pbl_scheme
   long_name = flag for hybrid edmf pbl scheme (moninedmf)
   units = flag
   dimensions = ()
@@ -3867,7 +3867,7 @@
   dimensions = ()
   type = logical
 [lheatstrg]
-  standard_name = flag_for_canopy_heat_storage
+  standard_name = flag_for_canopy_heat_storage_in_land_surface_scheme
   long_name = flag for canopy heat storage parameterization
   units = flag
   dimensions = ()
@@ -3879,79 +3879,79 @@
   dimensions = ()
   type = logical
 [shal_cnv]
-  standard_name = flag_for_shallow_convection
+  standard_name = flag_for_simplified_arakawa_schubert_shallow_convection
   long_name = flag for calling shallow convection
   units = flag
   dimensions = ()
   type = logical
 [imfshalcnv]
-  standard_name = flag_for_mass_flux_shallow_convection_scheme
+  standard_name = control_for_shallow_convection_scheme
   long_name = flag for mass-flux shallow convection scheme
   units = flag
   dimensions = ()
   type = integer
 [imfshalcnv_sas]
-  standard_name = flag_for_sas_shallow_convection_scheme
+  standard_name = identifier_for_simplified_arakawa_schubert_shallow_convection
   long_name = flag for SAS shallow convection scheme
   units = flag
   dimensions = ()
   type = integer
 [imfshalcnv_samf]
-  standard_name = flag_for_samf_shallow_convection_scheme
+  standard_name = identifier_for_scale_aware_mass_flux_shallow_convection
   long_name = flag for SAMF shallow convection scheme
   units = flag
   dimensions = ()
   type = integer
 [imfshalcnv_gf]
-  standard_name = flag_for_gf_shallow_convection_scheme
+  standard_name = identifier_for_grell_freitas_shallow_convection
   long_name = flag for Grell-Freitas shallow convection scheme
   units = flag
   dimensions = ()
   type = integer
 [imfshalcnv_ntiedtke]
-  standard_name = flag_for_ntiedtke_shallow_convection_scheme
+  standard_name = identifier_for_new_tiedtke_shallow_convection
   long_name = flag for new Tiedtke shallow convection scheme
   units = flag
   dimensions = ()
   type = integer
 [imfdeepcnv]
-  standard_name = flag_for_mass_flux_deep_convection_scheme
+  standard_name = control_for_deep_convection_scheme
   long_name = flag for mass-flux deep convection scheme
   units = flag
   dimensions = ()
   type = integer
 [imfdeepcnv_sas]
-  standard_name = flag_for_sas_deep_convection_scheme
+  standard_name = identifier_for_simplified_arakawa_schubert_deep_convection
   long_name = flag for SAS deep convection scheme
   units = flag
   dimensions = ()
   type = integer
 [imfdeepcnv_samf]
-  standard_name = flag_for_samf_deep_convection_scheme
+  standard_name = identifer_for_scale_aware_mass_flux_deep_convection
   long_name = flag for SAMF deep convection scheme
   units = flag
   dimensions = ()
   type = integer
 [imfdeepcnv_gf]
-  standard_name = flag_for_gf_deep_convection_scheme
+  standard_name = identifier_for_grell_freitas_deep_convection
   long_name = flag for Grell-Freitas deep convection scheme
   units = flag
   dimensions = ()
   type = integer
 [imfdeepcnv_ntiedtke]
-  standard_name = flag_for_ntiedtke_deep_convection_scheme
+  standard_name = identifier_for_new_tiedtke_deep_convection
   long_name = flag for new Tiedtke deep convection scheme
   units = flag
   dimensions = ()
   type = integer
 [hwrf_samfdeep]
-  standard_name = flag_for_hwrf_samfdeepcnv_scheme
+  standard_name = flag_for_hurricane_specific_code_in_scale_aware_mass_flux_deep_convection
   long_name = flag for hwrf samfdeepcnv scheme
   units = flag
   dimensions = ()
   type = logical
 [hwrf_samfshal]
-  standard_name = flag_for_hwrf_samfshalcnv_scheme
+  standard_name = flag_for_hurricane_specific_code_in_scale_aware_mass_flux_shallow_convection
   long_name = flag for hwrf samfshalcnv scheme
   units = flag
   dimensions = ()
@@ -3981,7 +3981,7 @@
   dimensions = ()
   type = integer
 [jcap]
-  standard_name = number_of_spectral_wave_trancation_for_sas
+  standard_name = number_of_spectral_wave_truncation_for_simplified_arakawa_schubert_convection
   long_name = number of spectral wave trancation used only by sascnv and shalcnv
   units = count
   dimensions = ()
@@ -4022,35 +4022,35 @@
   type = real
   kind = kind_phys
 [cgwf]
-  standard_name = multiplication_factors_for_convective_gravity_wave_drag
+  standard_name = tunable_parameters_for_convective_gravity_wave_drag
   long_name = multiplication factor for convective GWD
   units = none
   dimensions = (2)
   type = real
   kind = kind_phys
 [cdmbgwd]
-  standard_name = multiplication_factors_for_mountain_blocking_and_orographic_gravity_wave_drag
+  standard_name = multiplicative_tunable_parameters_for_mountain_blocking_and_orographic_gravity_wave_drag
   long_name = multiplication factors for cdmb and gwd
   units = none
   dimensions = (4)
   type = real
   kind = kind_phys
 [ccwf]
-  standard_name = multiplication_factor_for_critical_cloud_workfunction
+  standard_name = tunable_parameter_for_critical_cloud_workfunction_in_relaxed_arakawa_schubert_deep_convection
   long_name = multiplication factor for tical_cloud_workfunction
   units = none
   dimensions = (2)
   type = real
   kind = kind_phys
 [sup]
-  standard_name = ice_supersaturation_threshold
+  standard_name = tunable_parameter_for_ice_supersaturation
   long_name = ice supersaturation parameter for PDF clouds
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [ctei_rm]
-  standard_name = critical_cloud_top_entrainment_instability_criteria
+  standard_name = tunable_parameter_for_critical_cloud_top_entrainment_instability_criteria
   long_name = critical cloud top entrainment instability criteria
   units = none
   dimensions = (2)
@@ -4071,140 +4071,140 @@
   type = real
   kind = kind_phys
 [crtrh(3)]
-  standard_name = critical_relative_humidity_at_top_of_atmosphere
+  standard_name = critical_relative_humidity_at_toa
   long_name = critical relative humidity at the top of atmosphere
   units = frac
   dimensions = ()
   type = real
   kind = kind_phys
 [prslrd0]
-  standard_name = pressure_cutoff_for_rayleigh_damping
+  standard_name = air_pressure_at_bottom_extent_of_rayleigh_damping
   long_name = pressure level from which Rayleigh Damping is applied
   units = Pa
   dimensions = ()
   type = real
   kind = kind_phys
 [ral_ts]
-  standard_name = time_scale_for_rayleigh_damping
+  standard_name = timescale_for_rayleigh_damping
   long_name = time scale for Rayleigh damping in days
   units = d
   dimensions = ()
   type = real
   kind = kind_phys
 [clam_deep]
-  standard_name = entrainment_rate_coefficient_deep_convection
+  standard_name = entrainment_rate_coefficient_for_deep_convection
   long_name = entrainment rate coefficient for deep convection
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [c0s_deep]
-  standard_name = rain_conversion_parameter_deep_convection
+  standard_name = rain_conversion_parameter_for_deep_convection
   long_name = convective rain conversion parameter for deep convection
   units = m-1
   dimensions = ()
   type = real
   kind = kind_phys
 [c1_deep]
-  standard_name = detrainment_conversion_parameter_deep_convection
+  standard_name = detrainment_conversion_parameter_for_deep_convection
   long_name = convective detrainment conversion parameter for deep convection
   units = m-1
   dimensions = ()
   type = real
   kind = kind_phys
 [betal_deep]
-  standard_name = downdraft_fraction_reaching_surface_over_land_deep_convection
+  standard_name = downdraft_fraction_reaching_surface_over_land_for_deep_convection
   long_name = downdraft fraction reaching surface over land for deep convection
   units = frac
   dimensions = ()
   type = real
   kind = kind_phys
 [betas_deep]
-  standard_name = downdraft_fraction_reaching_surface_over_water_deep_convection
+  standard_name = downdraft_fraction_reaching_surface_over_water_for_deep_convection
   long_name = downdraft fraction reaching surface over water for deep convection
   units = frac
   dimensions = ()
   type = real
   kind = kind_phys
 [evfact_deep]
-  standard_name = rain_evaporation_coefficient_deep_convection
+  standard_name = rain_evaporation_coefficient_over_ocean_for_deep_convection
   long_name = convective rain evaporation coefficient for deep convection
   units = frac
   dimensions = ()
   type = real
   kind = kind_phys
 [evfactl_deep]
-  standard_name = rain_evaporation_coefficient_over_land_deep_convection
+  standard_name = rain_evaporation_coefficient_over_land_for_deep_convection
   long_name = convective rain evaporation coefficient over land for deep convection
   units = frac
   dimensions = ()
   type = real
   kind = kind_phys
 [pgcon_deep]
-  standard_name = momentum_transport_reduction_factor_pgf_deep_convection
+  standard_name = momentum_transport_reduction_factor_due_to_pressure_gradient_force_for_deep_convection
   long_name = reduction factor in momentum transport due to deep convection induced pressure gradient force
   units = frac
   dimensions = ()
   type = real
   kind = kind_phys
 [asolfac_deep]
-  standard_name = aerosol_aware_parameter_deep_convection
+  standard_name = aerosol_aware_multiplicative_rain_conversion_parameter_for_deep_convection
   long_name = aerosol-aware parameter inversely proportional to CCN number concentraion from Lim (2011) for deep convection
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [clam_shal]
-  standard_name = entrainment_rate_coefficient_shallow_convection
+  standard_name = entrainment_rate_coefficient_for_shallow_convection
   long_name = entrainment rate coefficient for shallow convection
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [c0s_shal]
-  standard_name = rain_conversion_parameter_shallow_convection
+  standard_name = rain_conversion_parameter_for_shallow_convection
   long_name = convective rain conversion parameter for shallow convection
   units = m-1
   dimensions = ()
   type = real
   kind = kind_phys
 [c1_shal]
-  standard_name = detrainment_conversion_parameter_shallow_convection
+  standard_name = detrainment_conversion_parameter_for_shallow_convection
   long_name = convective detrainment conversion parameter for shallow convection
   units = m-1
   dimensions = ()
   type = real
   kind = kind_phys
 [pgcon_shal]
-  standard_name = momentum_transport_reduction_factor_pgf_shallow_convection
+  standard_name = momentum_transport_reduction_factor_due_to_pressure_gradient_force_for_shallow_convection
   long_name = reduction factor in momentum transport due to shallow convection induced pressure gradient force
   units = frac
   dimensions = ()
   type = real
   kind = kind_phys
 [asolfac_shal]
-  standard_name = aerosol_aware_parameter_shallow_convection
+  standard_name = aerosol_aware_multiplicative_rain_conversion_parameter_for_shallow_convection
   long_name = aerosol-aware parameter inversely proportional to CCN number concentraion from Lim (2011) for shallow convection
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [xkzm_m]
-  standard_name = atmosphere_momentum_diffusivity_background
+  standard_name = atmosphere_momentum_diffusivity_due_to_background
   long_name = background vertical diffusion for momentum
   units = m2 s-1
   dimensions = ()
   type = real
   kind = kind_phys
 [xkzm_h]
-  standard_name = atmosphere_heat_diffusivity_background
+  standard_name = atmosphere_heat_diffusivity_due_to_background
   long_name = background vertical diffusion for heat q
   units = m2 s-1
   dimensions = ()
   type = real
   kind = kind_phys
 [xkzm_s]
-  standard_name = diffusivity_background_sigma_level
+  standard_name = sigma_pressure_threshold_at_upper_extent_of_background_diffusion
   long_name = sigma threshold for background mom. diffusion
   units = none
   dimensions = ()
@@ -4217,38 +4217,38 @@
   dimensions = ()
   type = logical
 [nstf_name(1)]
-  standard_name = flag_for_nsstm_run
+  standard_name = control_for_nsstm
   long_name = NSSTM flag: off/uncoupled/coupled=0/1/2
   units = flag
   dimensions = ()
   type = integer
 [nstf_name(4)]
-  standard_name = vertical_temperature_average_range_lower_bound
+  standard_name = lower_bound_for_depth_of_sea_temperature_for_nsstm
   long_name = zsea1 in mm
   units = mm
   dimensions = ()
   type = integer
 [nstf_name(5)]
-  standard_name = vertical_temperature_average_range_upper_bound
+  standard_name = upper_bound_for_depth_of_sea_temperature_for_nsstm
   long_name = zsea2 in mm
   units = mm
   dimensions = ()
   type = integer
 [frac_grid]
-  standard_name = flag_for_fractional_grid
+  standard_name = flag_for_fractional_landmask
   long_name = flag for fractional grid
   units = flag
   dimensions = ()
   type = logical
 [min_lakeice]
-  standard_name = lake_ice_minimum
+  standard_name = min_lake_ice_area_fraction
   long_name = minimum lake ice value
   units = frac
   dimensions = ()
   type = real
   kind = kind_phys
 [min_seaice]
-  standard_name = sea_ice_minimum
+  standard_name = min_sea_ice_area_fraction
   long_name = minimum sea ice value
   units = frac
   dimensions = ()
@@ -4268,49 +4268,49 @@
   dimensions = ()
   type = integer
 [xkzminv]
-  standard_name = atmosphere_heat_diffusivity_background_maximum
+  standard_name = max_atmosphere_heat_diffusivity_due_to_background
   long_name = maximum background value of heat diffusivity
   units = m2 s-1
   dimensions = ()
   type = real
   kind = kind_phys
 [moninq_fac]
-  standard_name = atmosphere_diffusivity_coefficient_factor
+  standard_name = multiplicative_tuning_parameter_for_atmosphere_diffusivity
   long_name = multiplicative constant for atmospheric diffusivities (AKA alpha)
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [dspfac]
-  standard_name = tke_dissipative_heating_factor
+  standard_name = multiplicative_tuning_parameter_for_tke_dissipative_heating
   long_name = tke dissipative heating factor
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [bl_upfr]
-  standard_name = updraft_fraction_in_boundary_layer_mass_flux_scheme
+  standard_name = updraft_area_fraction_in_scale_aware_tke_moist_edmf_pbl_scheme
   long_name = updraft fraction in boundary layer mass flux scheme
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [bl_dnfr]
-  standard_name = downdraft_fraction_in_boundary_layer_mass_flux_scheme
+  standard_name = downdraft_area_fraction_in_scale_aware_tke_moist_edmf_pbl_scheme
   long_name = downdraft fraction in boundary layer mass flux scheme
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [z0fac]
-  standard_name = surface_roughness_fraction_factor
+  standard_name = multiplicative_tuning_parameter_for_reduced_surface_heat_fluxes_due_to_canopy_heat_storage
   long_name = surface roughness fraction for canopy heat storage parameterization
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [e0fac]
-  standard_name = latent_heat_flux_fraction_factor_relative_to_sensible_heat_flux
+  standard_name = multiplicative_tuning_parameter_for_reduced_latent_heat_flux_due_to_canopy_heat_storage
   long_name = latent heat flux fraction relative to sensible heat flux for canopy heat storage parameterization
   units = none
   dimensions = ()
@@ -4341,7 +4341,7 @@
   dimensions = ()
   type = logical
 [ca_entr]
-  standard_name = flag_for_global_cellular_automata_entr
+  standard_name =  flag_for_global_cellular_automata_deep_convective_entrainment
   long_name = switch for ca on entr
   units = flag
   dimensions = ()
@@ -4353,7 +4353,7 @@
   dimensions = ()
   type = logical
 [nthresh]
-  standard_name = threshold_for_perturbed_vertical_velocity
+  standard_name =  cellular_automata_vertical_velocity_perturbation_threshold_for_deep_convection
   long_name = threshold used for perturbed vertical velocity
   units = m s-1
   dimensions = ()
@@ -4378,7 +4378,7 @@
   dimensions = ()
   type = logical
 [sppt_amp]
-  standard_name = total_ampltiude_of_sppt_perturbation
+  standard_name = total_amplitude_of_sppt_perturbation
   long_name = toal ampltidue of stochastic sppt perturbation
   units = none
   dimensions = ()
@@ -4391,7 +4391,7 @@
   dimensions = ()
   type = logical
 [use_zmtnblck]
-  standard_name = flag_for_mountain_blocking
+  standard_name = flag_for_mountain_blocking_for_sppt
   long_name = flag for mountain blocking
   units = flag
   dimensions = ()
@@ -4409,29 +4409,29 @@
   dimensions = ()
   type = logical
 [lndp_type]
-  standard_name = index_for_stochastic_land_surface_perturbation_type
+  standard_name = control_for_stochastic_land_surface_perturbation
   long_name = index for stochastic land surface perturbations type
   units = index
   dimensions = ()
   type = integer
 [n_var_lndp]
-  standard_name = number_of_land_surface_variables_perturbed
+  standard_name = number_of_perturbed_land_surface_variables
   long_name = number of land surface variables perturbed
   units = count
   dimensions = ()
   type = integer
 [lndp_prt_list]
-  standard_name =magnitude_of_perturbations_for_landperts
+  standard_name =land_surface_perturbation_magnitudes
   long_name = magnitude of perturbations for landperts
   units = variable
-  dimensions = (number_of_land_surface_variables_perturbed)
+  dimensions = (number_of_perturbed_land_surface_variables)
   type = real
   kind = kind_phys
 [lndp_var_list]
-  standard_name = variables_to_be_perturbed_for_landperts
+  standard_name = land_surface_perturbation_variables
   long_name = variables to be perturbed for landperts
   units = none
-  dimensions =  (number_of_land_surface_variables_perturbed)
+  dimensions =  (number_of_perturbed_land_surface_variables)
   type = character
   kind = len=3
 [ntrac]
@@ -4447,103 +4447,103 @@
   dimensions = ()
   type = integer
 [ntqv]
-  standard_name = index_for_water_vapor
+  standard_name = index_of_specific_humidity_in_tracer_concentration_array
   long_name = tracer index for water vapor (specific humidity)
   units = index
   dimensions = ()
   type = integer
 [ntoz]
-  standard_name = index_for_ozone
+  standard_name = index_of_ozone_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for ozone mixing ratio
   units = index
   dimensions = ()
   type = integer
 [ntcw]
-  standard_name = index_for_liquid_cloud_condensate
+  standard_name = index_of_cloud_liquid_water_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for cloud condensate (or liquid water)
   units = index
   dimensions = ()
   type = integer
 [ntiw]
-  standard_name = index_for_ice_cloud_condensate
+  standard_name = index_of_cloud_ice_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for  ice water
   units = index
   dimensions = ()
   type = integer
 [ntrw]
-  standard_name = index_for_rain_water
+  standard_name = index_of_rain_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for rain water
   units = index
   dimensions = ()
   type = integer
 [ntsw]
-  standard_name = index_for_snow_water
+  standard_name = index_of_snow_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for snow water
   units = index
   dimensions = ()
   type = integer
 [ntgl]
-  standard_name = index_for_graupel
+  standard_name = index_of_graupel_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for graupel
   units = index
   dimensions = ()
   type = integer
 [ntclamt]
-  standard_name = index_for_cloud_amount
+  standard_name = index_of_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array
   long_name = tracer index for cloud amount integer
   units = index
   dimensions = ()
   type = integer
 [ntlnc]
-  standard_name = index_for_liquid_cloud_number_concentration
+  standard_name = index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array
   long_name = tracer index for liquid number concentration
   units = index
   dimensions = ()
   type = integer
 [ntinc]
-  standard_name = index_for_ice_cloud_number_concentration
+  standard_name = index_of_mass_number_concentration_of_cloud_ice_in_tracer_concentration_array
   long_name = tracer index for ice    number concentration
   units = index
   dimensions = ()
   type = integer
 [ntrnc]
-  standard_name = index_for_rain_number_concentration
+  standard_name = index_of_mass_number_concentration_of_rain_in_tracer_concentration_array
   long_name = tracer index for rain   number concentration
   units = index
   dimensions = ()
   type = integer
 [ntsnc]
-  standard_name = index_for_snow_number_concentration
+  standard_name = index_of_mass_number_concentration_of_snow_in_tracer_concentration_array
   long_name = tracer index for snow   number concentration
   units = index
   dimensions = ()
   type = integer
 [ntgnc]
-  standard_name = index_for_graupel_number_concentration
+  standard_name = index_of_mass_number_concentration_of_graupel_in_tracer_concentration_array
   long_name = tracer index for graupel number concentration
   units = index
   dimensions = ()
   type = integer
 [ntke]
-  standard_name = index_for_turbulent_kinetic_energy
+  standard_name = index_of_turbulent_kinetic_energy_in_tracer_concentration_array
   long_name = tracer index for turbulent kinetic energy
   units = index
   dimensions = ()
   type = integer
 [nqrimef]
-  standard_name = index_for_mass_weighted_rime_factor
+  standard_name = index_of_mass_weighted_rime_factor_in_tracer_concentration_array
   long_name = tracer index for mass weighted rime factor
   units = index
   dimensions = ()
   type = integer
 [ntwa]
-  standard_name = index_for_water_friendly_aerosols
+  standard_name = index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array
   long_name = tracer index for water friendly aerosol
   units = index
   dimensions = ()
   type = integer
 [ntia]
-  standard_name = index_for_ice_friendly_aerosols
+  standard_name = index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array
   long_name = tracer index for ice friendly aerosol
   units = index
   dimensions = ()
@@ -4555,7 +4555,7 @@
   dimensions = ()
   type = integer
 [ntchs]
-  standard_name = index_for_first_chemical_tracer
+  standard_name = index_of_first_chemical_tracer_in_tracer_concentration_array
   long_name = tracer index for first chemical tracer
   units = index
   dimensions = ()
@@ -4585,74 +4585,74 @@
   dimensions = ()
   type = integer
 [ntdiag]
-  standard_name = diagnostics_control_for_chemical_tracers
+  standard_name = flags_for_chemical_tracer_diagnostics
   long_name = array to control diagnostics for chemical tracers
   units = flag
   dimensions = (number_of_chemical_tracers)
   type = logical
 [fscav]
-  standard_name = coefficients_for_aerosol_scavenging
+  standard_name = chemical_tracer_scavenging_fractions
   long_name = array of aerosol scavenging coefficients
   units = none
   dimensions = (number_of_chemical_tracers)
   type = real
   kind = kind_phys
 [ntot2d]
-  standard_name = number_of_fields_in_phyf2d
+  standard_name = number_of_variables_in_xy_dimensioned_restart_array
   long_name = total number of variables for phyf2d
   units = count
   dimensions = ()
   type = integer
 [ntot3d]
-  standard_name = number_of_fields_in_phyf3d
+  standard_name = number_of_variables_in_xyz_dimensioned_restart_array
   long_name = total number of variables for phyf3d
   units = count
   dimensions = ()
   type = integer
 [indcld]
-  standard_name = index_for_cloud_fraction_in_3d_arrays_for_microphysics
+  standard_name = index_of_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array
   long_name = index of cloud fraction in phyf3d (used only for SHOC or MG)
   units = index
   dimensions = ()
   type = integer
 [num_p2d]
-  standard_name = array_dimension_of_2d_arrays_for_microphysics
+  standard_name = number_of_microphysics_varaibles_in_xy_dimensioned_restart_array
   long_name = number of 2D arrays needed for microphysics
   units = count
   dimensions = ()
   type = integer
 [num_p3d]
-  standard_name = array_dimension_of_3d_arrays_for_microphysics
+  standard_name = number_of_microphysics_variables_in_xyz_dimensioned_restart_array
   long_name = number of 3D arrays needed for microphysics
   units = count
   dimensions = ()
   type = integer
 [nkbfshoc]
-  standard_name = index_of_kinematic_buoyancy_flux_from_shoc_in_phy_f3d
+  standard_name = index_of_upward_virtual_potential_temperature_flux_in_xyz_dimensioned_restart_array
   long_name = the index of upward kinematic buoyancy flux from SHOC in phy_f3d
   units = index
   dimensions = ()
   type = integer
 [nahdshoc]
-  standard_name = index_of_atmosphere_heat_diffusivity_from_shoc_in_phy_f3d
+  standard_name = index_of_atmosphere_heat_diffusivity_in_xyz_dimensioned_restart_array
   long_name = the index of diffusivity for heat from from SHOC in phy_f3d
   units = index
   dimensions = ()
   type = integer
 [nscfshoc]
-  standard_name = index_of_subgrid_scale_cloud_fraction_from_shoc_in_phy_f3d
+  standard_name = index_of_subgrid_cloud_area_fracation_in_atmosphere_layer_in_xyz_dimensioned_restart_array
   long_name = the index of subgrid-scale cloud fraction from from SHOC in phy_f3d
   units = index
   dimensions = ()
   type = integer
 [ncnvcld3d]
-  standard_name = number_of_convective_3d_cloud_fields
+  standard_name = number_of_convective_cloud_variables_in_xyz_dimensioned_restart_array
   long_name = number of convective 3d clouds fields
   units = count
   dimensions = ()
   type = integer
 [npdf3d]
-  standard_name = number_of_3d_arrays_associated_with_pdf_based_clouds
+  standard_name = number_of_pdf_based_variables_in_xyz_dimensioned_restart_array
   long_name = number of 3d arrays associated with pdf based clouds/mp
   units = count
   dimensions = ()
@@ -4664,97 +4664,97 @@
   dimensions = ()
   type = integer
 [ncnvw]
-  standard_name = index_for_convective_cloud_water_mixing_ratio_in_phy_f3d
+  standard_name = index_of_convective_cloud_condensate_mixing_ratio_in_xyz_dimensioned_restart_array
   long_name = the index of convective cloud water mixing ratio in phy f3d
   units = index
   dimensions = ()
   type = integer
 [ncnvc]
-  standard_name = index_for_convective_cloud_cover_in_phy_f3d
+  standard_name = index_of_convective_cloud_area_fraction_in_xyz_dimensioned_restart_array
   long_name = the index of convective cloud cover in phy f3d
   units = index
   dimensions = ()
   type = integer
 [nleffr]
-  standard_name = index_for_cloud_liquid_water_effective_radius
+  standard_name = index_of_cloud_liquid_water_effective_radius_in_xyz_dimensioned_restart_array
   long_name = the index of cloud liquid water effective radius in phy_f3d
   units = index
   dimensions = ()
   type = integer
 [nieffr]
-  standard_name = index_for_ice_effective_radius
+  standard_name = index_of_cloud_ice_effective_radius_in_xyz_dimensioned_restart_array
   long_name = the index of ice effective radius in phy_f3d
   units = index
   dimensions = ()
   type = integer
 [nreffr]
-  standard_name = index_for_rain_effective_radius
+  standard_name = index_of_rain_effective_radius_in_xyz_dimensioned_restart_array
   long_name = the index of rain effective radius in phy_f3d
   units = index
   dimensions = ()
   type = integer
 [nseffr]
-  standard_name = index_for_snow_effective_radius
+  standard_name = index_of_snow_effective_radius_in_xyz_dimensioned_restart_array
   long_name = the index of snow effective radius in phy_f3d
   units = index
   dimensions = ()
   type = integer
 [ngeffr]
-  standard_name = index_for_graupel_effective_radius
+  standard_name = index_of_graupel_effective_radius_in_xyz_dimensioned_restart_array
   long_name = the index of graupel effective radius in phy_f3d
   units = index
   dimensions = ()
   type = integer
 [nT2delt]
-  standard_name = index_for_air_temperature_two_timesteps_back
+  standard_name = index_of_air_temperature_two_timesteps_back_in_xyz_dimensioned_restart_array
   long_name = the index of air temperature two timesteps back in phy f3d
   units =
   dimensions = ()
   type = integer
 [nTdelt]
-  standard_name = index_for_air_temperature_at_previous_timestep
+  standard_name = index_of_air_temperature_on_previous_timestep_in_xyz_dimensioned_restart_array
   long_name = the index of air temperature at previous timestep in phy f3d
   units =
   dimensions = ()
   type = integer
 [nqv2delt]
-  standard_name = index_for_specific_humidity_two_timesteps_back
+  standard_name = index_of_specific_humidity_two_timesteps_back_in_xyz_dimensioned_restart_array
   long_name = the index of specific humidity two timesteps back in phy f3d
   units =
   dimensions = ()
   type = integer
 [nqvdelt]
-  standard_name = index_for_specific_humidity_at_previous_timestep
+  standard_name = index_of_specific_humidity_on_previous_timestep_in_xyz_dimensioned_restart_array
   long_name = the index of specific humidity at previous timestep in phy f3d
   units =
   dimensions = ()
   type = integer
 [nps2delt]
-  standard_name = index_for_surface_air_pressure_two_timesteps_back
+  standard_name = index_of_surface_air_pressure_two_timesteps_back_in_xyz_dimensioned_tracer_array
   long_name = the index of surface air pressure two timesteps back in phy f2d
   units =
   dimensions = ()
   type = integer
 [npsdelt]
-  standard_name = index_for_surface_air_pressure_at_previous_timestep
+  standard_name = index_of_surface_air_pressure_on_previous_timestep_in_xyz_dimensioned_restart_array
   long_name = the index of surface air pressure at previous timestep in phy f2d
   units =
   dimensions = ()
   type = integer
 [ncnvwind]
-  standard_name = index_for_surface_wind_enhancement_due_to_convection
+  standard_name = index_of_enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convectionin_in_xy_dimensioned_restart_array
   long_name = the index of surface wind enhancement due to convection in phy f2d
   units =
   dimensions = ()
   type = integer
 [debug]
-  standard_name = flag_debug
+  standard_name = flag_for_debug_output
   long_name = control flag for debug
   units = flag
   dimensions = ()
   type = logical
 [ipt]
-  standard_name = index_for_diagnostic_printout
+  standard_name = index_of_horizontal_gridpoint_for_debug_output
   long_name = horizontal index for point used for diagnostic printout
   units = index
   dimensions = ()
@@ -4766,19 +4766,19 @@
   dimensions = ()
   type = logical
 [lsswr]
-  standard_name = flag_to_calc_sw
+  standard_name = flag_for_calling_shortwave_radiation
   long_name = logical flags for sw radiation calls
   units = flag
   dimensions = ()
   type = logical
 [lslwr]
-  standard_name = flag_to_calc_lw
+  standard_name = flag_for_calling_longwave_radiation
   long_name = logical flags for lw radiation calls
   units = flag
   dimensions = ()
   type = logical
 [solhr]
-  standard_name = forecast_hour_of_the_day
+  standard_name = forecast_utc_hour
   long_name = time in hours after 00z at the current timestep
   units = h
   dimensions = ()
@@ -4813,14 +4813,14 @@
   type = real
   kind = kind_phys
 [clstp]
-  standard_name = convective_cloud_switch
+  standard_name = control_for_convective_cloud_diagnostics
   long_name = index used by cnvc90 (for convective clouds)
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [phour]
-  standard_name = forecast_time_at_previous_timestep
+  standard_name = forecast_time_on_previous_timestep
   long_name = forecast time at the previous timestep
   units = h
   dimensions = ()
@@ -4834,20 +4834,20 @@
   type = real
   kind = kind_phys
 [zhour]
-  standard_name = time_since_diagnostics_zeroed
+  standard_name = time_elapsed_since_diagnostics_reset
   long_name = time since diagnostics variables have been zeroed
   units = h
   dimensions = ()
   type = real
   kind = kind_phys
 [kdt]
-  standard_name = index_of_time_step
+  standard_name = index_of_timestep
   long_name = current forecast iteration
   units = index
   dimensions = ()
   type = integer
 [first_time_step]
-  standard_name = flag_for_first_time_step
+  standard_name = flag_for_first_timestep
   long_name = flag for first time step for time integration loop (cold/warmstart)
   units = flag
   dimensions = ()
@@ -4865,7 +4865,7 @@
   dimensions = ()
   type = logical
 [jdat]
-  standard_name = forecast_date_and_time
+  standard_name = date_and_time_of_forecast_in_united_states_order
   long_name = current forecast date and time
   units = none
   dimensions = (8)
@@ -4877,182 +4877,182 @@
   dimensions = ()
   type = integer
 [yearlen]
-  standard_name = number_of_days_in_year
+  standard_name = number_of_days_in_current_year
   long_name = number of days in a year
   units = days
   dimensions = ()
   type = integer
 [julian]
-  standard_name = julian_day
+  standard_name = forecast_julian_day
   long_name = julian day
   units = days
   dimensions = ()
   type = real
   kind = kind_phys
 [iccn]
-  standard_name = flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics
+  standard_name = control_for_ice_cloud_condensation_nuclei_forcing
   long_name = flag for IN and CCN forcing for morrison gettelman microphysics
   units = none
   dimensions = ()
   type = integer
 [sec]
-  standard_name = seconds_elapsed_since_model_initialization
+  standard_name = forecast_time_in_seconds
   long_name = seconds elapsed since model initialization
   units = s
   dimensions = ()
   type = real
   kind = kind_phys
 [si]
-  standard_name = vertical_sigma_coordinate_for_radiation_initialization
+  standard_name = sigma_pressure_hybrid_vertical_coordinate
   long_name = vertical sigma coordinate for radiation initialization
   units = none
-  dimensions = (number_of_vertical_layers_for_radiation_calculations_plus_one)
+  dimensions = (vertical_interface_dimension_for_radiation)
   type = real
   kind = kind_phys
 [dxinv]
-  standard_name = inverse_scaling_factor_for_critical_relative_humidity
+  standard_name = reciprocal_of_grid_scale_range
   long_name = inverse scaling factor for critical relative humidity
   units = rad2 m-2
   dimensions = ()
   type = real
   kind = kind_phys
 [dxmax]
-  standard_name = maximum_scaling_factor_for_critical_relative_humidity
+  standard_name = max_grid_scale
   long_name = maximum scaling factor for critical relative humidity
   units = m2 rad-2
   dimensions = ()
   type = real
   kind = kind_phys
 [dxmin]
-  standard_name = minimum_scaling_factor_for_critical_relative_humidity
+  standard_name = min_grid_scale
   long_name = minimum scaling factor for critical relative humidity
   units = m2 rad-2
   dimensions = ()
   type = real
   kind = kind_phys
 [rhcmax]
-  standard_name = maximum_critical_relative_humidity
+  standard_name = max_critical_relative_humidity
   long_name = maximum critical relative humidity
   units = frac
   dimensions = ()
   type = real
   kind = kind_phys
 [icloud]
-  standard_name = cloud_effect_to_optical_depth_and_cloud_fraction
+  standard_name = control_for_cloud_area_fraction_option
   long_name = cloud effect to the optical depth and cloud fraction in radiation
   units = flag
   dimensions = ()
   type = integer
 [gwd_opt]
-  standard_name = gwd_opt
+  standard_name = control_for_drag_suite_gravity_wave_drag
   long_name = flag to choose gwd scheme
   units = flag
   dimensions = ()
   type = integer
 [do_mynnedmf]
-  standard_name = do_mynnedmf
+  standard_name = flag_for_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate MYNN-EDMF
   units = flag
   dimensions = ()
   type = logical
 [do_mynnsfclay]
-  standard_name = do_mynnsfclay
+  standard_name = flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme
   long_name = flag to activate MYNN surface layer
   units = flag
   dimensions = ()
   type = logical
 [do_myjsfc]
-  standard_name = do_myjsfc
+  standard_name = flag_for_mellor_yamada_janic_surface_layer_scheme
   long_name = flag to activate MYJ surface layer scheme
   units = flag
   dimensions = ()
   type = logical
 [do_myjpbl]
-  standard_name = do_myjpbl
+  standard_name = flag_for_mellor_yamada_janic_pbl_scheme
   long_name = flag to activate MYJ PBL scheme
   units = flag
   dimensions = ()
   type = logical
 [grav_settling]
-  standard_name = grav_settling
+  standard_name = control_for_gravitational_settling_of_cloud_droplets
   long_name = flag to activate gravitational setting of fog
   units = flag
   dimensions = ()
   type = integer
 [bl_mynn_tkebudget]
-  standard_name = tke_budget
+  standard_name = control_for_tke_budget_output
   long_name = flag for activating TKE budget
   units = flag
   dimensions = ()
   type = integer
 [bl_mynn_tkeadvect]
-  standard_name = tke_advect
+  standard_name = flag_for_tke_advection
   long_name = flag for activating TKE advection
   units = flag
   dimensions = ()
   type = logical
 [bl_mynn_cloudpdf]
-  standard_name = cloudpdf
+  standard_name = control_for_cloud_pdf_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to determine which cloud PDF to use
   units = flag
   dimensions = ()
   type = integer
 [bl_mynn_mixlength]
-  standard_name = mixing_length_flag
+  standard_name = control_for_mixing_length_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to determine which mixing length form to use
   units = flag
   dimensions = ()
   type = integer
 [bl_mynn_edmf]
-  standard_name = edmf_flag
+  standard_name = control_for_edmf_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate the mass-flux scheme
   units = flag
   dimensions = ()
   type = integer
 [bl_mynn_edmf_mom]
-  standard_name = edmf_momentum_transport_flag
+  standard_name = control_for_edmf_momentum_transport_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate the transport of momentum
   units = flag
   dimensions = ()
   type = integer
 [bl_mynn_edmf_tke]
-  standard_name = edmf_tke_transport_flag
+  standard_name = control_for_edmf_tke_transport_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate the transport of TKE
   units = flag
   dimensions = ()
   type = integer
 [bl_mynn_edmf_part]
-  standard_name = edmf_partition_flag
+  standard_name = control_for_edmf_partitioning_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to partitioning og the MF and ED areas
   units = flag
   dimensions = ()
   type = integer
 [bl_mynn_cloudmix]
-  standard_name = cloud_specie_mix_flag
+  standard_name = control_for_cloud_species_mixing_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate mixing of cloud species
   units = flag
   dimensions = ()
   type = integer
 [bl_mynn_mixqt]
-  standard_name = mix_total_water_flag
+  standard_name = control_for_total_water_mixing_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to mix total water or individual species
   units = flag
   dimensions = ()
   type = integer
 [bl_mynn_output]
-  standard_name = mynn_output_flag
+  standard_name = control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag initialize and output extra 3D variables
   units = flag
   dimensions = ()
   type = integer
 [icloud_bl]
-  standard_name = couple_sgs_clouds_to_radiation_flag
+  standard_name = control_for_sgs_cloud_radiation_coupling_in_mellor_yamamda_nakanishi_niino_pbl_scheme
   long_name = flag for coupling sgs clouds to radiation
   units = flag
   dimensions = ()
   type = integer
 [var_ric]
-  standard_name = flag_variable_bulk_richardson_number
+  standard_name = control_for_variable_bulk_richardson_number
   long_name = flag for calculating variable bulk richardson number for hurricane PBL
   units = flag
   dimensions = ()
@@ -5073,13 +5073,13 @@
   type = real
   kind = kind_phys
 [do_ugwp]
-  standard_name = do_ugwp
+  standard_name = flag_for_unified_gravity_wave_physics_gravity_wave_drag_scheme
   long_name = flag to activate CIRES UGWP
   units = flag
   dimensions = ()
   type = logical
 [do_tofd]
-  standard_name = turb_oro_form_drag_flag
+  standard_name = flag_for_turbulent_orographic_form_drag_in_unified_gravity_wave_physics_gravitiy_wave_drag_scheme
   long_name = flag for turbulent orographic form drag
   units = flag
   dimensions = ()
@@ -5097,19 +5097,19 @@
   dimensions = ()
   type = logical
 [ldiag_ugwp]
-  standard_name = diag_ugwp_flag
+  standard_name = flag_for_unified_gravity_wave_physics_diagnostics
   long_name = flag for CIRES UGWP Diagnostics
   units = flag
   dimensions = ()
   type = logical
 [uni_cld]
-  standard_name = flag_for_uni_cld
+  standard_name = flag_for_shoc_cloud_area_fraction_for_radiation
   long_name = flag for uni_cld
   units = flag
   dimensions = ()
   type = logical
 [lmfshal]
-  standard_name = flag_for_lmfshal
+  standard_name = flag_for_cloud_area_fraction_option_for_radiation
   long_name = flag for lmfshal
   units = flag
   dimensions = ()
@@ -5187,7 +5187,7 @@
   intent = in
   optional = F
 [lmfdeep2]
-  standard_name = flag_for_scale_aware_mass_flux_convection
+  standard_name = flag_for_scale_aware_mass_flux_deep_convection_for_radiation
   long_name = flag for some scale-aware mass-flux convection scheme active
   units = flag
   dimensions = ()
@@ -5210,7 +5210,7 @@
   type = real
   kind = kind_phys
 [dx]
-  standard_name = cell_size
+  standard_name = characteristic_grid_lengthscale
   long_name = relative dx for the grid cell
   units = m
   dimensions = (horizontal_loop_extent)
@@ -5259,43 +5259,43 @@
   type = real
   kind = kind_phys
 [jindx1_o3]
-  standard_name = lower_ozone_interpolation_index
+  standard_name = lower_latitude_index_of_ozone_forcing_for_interpolation
   long_name = interpolation low index for ozone
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
-  active = (index_for_ozone>0)
+  active = (index_of_ozone_mixing_ratio_in_tracer_concentration_array>0)
 [jindx2_o3]
-  standard_name = upper_ozone_interpolation_index
+  standard_name = upper_latitude_index_of_ozone_forcing_for_interpolation
   long_name = interpolation high index for ozone
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
-  active = (index_for_ozone>0)
+  active = (index_of_ozone_mixing_ratio_in_tracer_concentration_array>0)
 [ddy_o3]
-  standard_name = ozone_interpolation_weight
+  standard_name = latitude_interpolation_weight_for_ozone_forcing
   long_name = interpolation high index for ozone
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (index_for_ozone>0)
+  active = (index_of_ozone_mixing_ratio_in_tracer_concentration_array>0)
 [jindx1_h]
-  standard_name = lower_water_vapor_interpolation_index
+  standard_name = lower_latitude_index_of_stratospheric_water_vapor_forcing_for_interpolation
   long_name = interpolation low index for stratospheric water vapor
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
   active = (flag_for_stratospheric_water_vapor_physics)
 [jindx2_h]
-  standard_name = upper_water_vapor_interpolation_index
+  standard_name = upper_latitude_index_of_stratospheric_water_vapor_forcing_for_interpolation
   long_name = interpolation high index for stratospheric water vapor
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
   active = (flag_for_stratospheric_water_vapor_physics)
 [ddy_h]
-  standard_name = water_vapor_interpolation_weight
+  standard_name = latitude_interpolation_weight_for_stratospheric_water_vapor_forcing
   long_name = interpolation high index for stratospheric water vapor
   units = none
   dimensions = (horizontal_loop_extent)
@@ -5303,21 +5303,21 @@
   kind = kind_phys
   active = (flag_for_stratospheric_water_vapor_physics)
 [jindx1_aer]
-  standard_name = lower_aerosol_y_interpolation_index
+  standard_name = lower_latitude_index_of_aerosol_forcing_for_interpolation
   long_name = interpolation low index for prescribed aerosols in the y direction
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
   active = (flag_for_aerosol_input_MG_radiation)
 [jindx2_aer]
-  standard_name = upper_aerosol_y_interpolation_index
+  standard_name = upper_latitude_index_of_aerosol_forcing_for_interpolation
   long_name = interpolation high index for prescribed aerosols in the y direction
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
   active = (flag_for_aerosol_input_MG_radiation)
 [ddy_aer]
-  standard_name = aerosol_y_interpolation_weight
+  standard_name = latitude_interpolation_weight_for_aerosol_forcing
   long_name = interpolation high index for prescribed aerosols in the y direction
   units = none
   dimensions = (horizontal_loop_extent)
@@ -5325,21 +5325,21 @@
   kind = kind_phys
   active = (flag_for_aerosol_input_MG_radiation)
 [iindx1_aer]
-  standard_name = lower_aerosol_x_interpolation_index
+  standard_name = lower_longitude_index_of_aerosol_forcing_for_interpolation
   long_name = interpolation low index for prescribed aerosols in the x direction
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
   active = (flag_for_aerosol_input_MG_radiation)
 [iindx2_aer]
-  standard_name = upper_aerosol_x_interpolation_index
+  standard_name = upper_longitude_index_of_aerosol_forcing_for_interpolation
   long_name = interpolation high index for prescribed aerosols in the x direction
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
   active = (flag_for_aerosol_input_MG_radiation)
 [ddx_aer]
-  standard_name = aerosol_x_interpolation_weight
+  standard_name = longitude_interpolation_weight_for_aerosol_forcing
   long_name = interpolation high index for prescribed aerosols in the x direction
   units = none
   dimensions = (horizontal_loop_extent)
@@ -5347,49 +5347,49 @@
   kind = kind_phys
   active = (flag_for_aerosol_input_MG_radiation)
 [jindx1_ci]
-  standard_name = lower_cloud_nuclei_y_interpolation_index
+  standard_name = lower_latitude_index_of_cloud_nuclei_forcing_for_interpolation
   long_name = interpolation low index for ice and cloud condensation nuclei in the y direction
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
-  active = (flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics==1)
+  active = (control_for_ice_cloud_condensation_nuclei_forcing==1)
 [jindx2_ci]
-  standard_name = upper_cloud_nuclei_y_interpolation_index
+  standard_name = upper_latitude_index_of_cloud_nuclei_forcing_for_interpolation
   long_name = interpolation high index for ice and cloud condensation nuclei in the y direction
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
-  active = (flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics==1)
+  active = (control_for_ice_cloud_condensation_nuclei_forcing==1)
 [ddy_ci]
-  standard_name = cloud_nuclei_y_interpolation_weight
+  standard_name = latitude_interpolation_weight_for_cloud_nuclei_forcing
   long_name = interpolation high index for ice and cloud condensation nuclei in the y direction
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics==1)
+  active = (control_for_ice_cloud_condensation_nuclei_forcing==1)
 [iindx1_ci]
-  standard_name = lower_cloud_nuclei_x_interpolation_index
+  standard_name = lower_longitude_index_of_cloud_nuclei_forcing_for_interpolation
   long_name = interpolation low index for ice and cloud condensation nuclei in the x direction
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
-  active = (flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics==1)
+  active = (control_for_ice_cloud_condensation_nuclei_forcing==1)
 [iindx2_ci]
-  standard_name = upper_cloud_nuclei_x_interpolation_index
+  standard_name = upper_longitude_index_of_cloud_nuclei_forcing_for_interpolation
   long_name = interpolation high index for ice and cloud condensation nuclei in the x direction
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
-  active = (flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics==1)
+  active = (control_for_ice_cloud_condensation_nuclei_forcing==1)
 [ddx_ci]
-  standard_name = cloud_nuclei_x_interpolation_weight
+  standard_name = longitude_interpolation_weight_for_cloud_nuclei_forcing
   long_name = interpolation high index for ice and cloud condensation nuclei in the x direction
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics==1)
+  active = (control_for_ice_cloud_condensation_nuclei_forcing==1)
 [jindx1_tau]
   standard_name = lower_latitude_index_of_absolute_momentum_flux_due_to_nonorographic_gravity_wave_drag_for_interpolation
   long_name = index1 for weight1 for tau NGWs
@@ -5431,14 +5431,14 @@
   name = GFS_tbd_type
   type = ddt
 [icsdsw]
-  standard_name = seed_random_numbers_sw
+  standard_name = random_number_seed_for_mcica_shortwave
   long_name = random seeds for sub-column cloud generators sw
   units = none
   dimensions = (horizontal_loop_extent)
   type = integer
   active = (flag_for_lw_clouds_sub_grid_approximation == 2 .or. flag_for_sw_clouds_grid_approximation == 2)
 [icsdlw]
-  standard_name = seed_random_numbers_lw
+  standard_name = random_number_seed_for_mcica_longwave
   long_name = random seeds for sub-column cloud generators lw
   units = none
   dimensions = (horizontal_loop_extent)
@@ -5459,7 +5459,7 @@
   type = real
   kind = kind_phys
 [h2opl]
-  standard_name = h2o_forcing
+  standard_name = stratospheric_water_vapor_forcing
   long_name = water forcing data
   units = various
   dimensions = (horizontal_loop_extent,vertical_dimension_of_h2o_forcing_data,number_of_coefficients_in_h2o_forcing_data)
@@ -5473,24 +5473,24 @@
   type = real
   kind = kind_phys
 [in_nm]
-  standard_name = ice_nucleation_number
+  standard_name = ice_nucleation_number_from_climatology
   long_name = ice nucleation number in MG MP
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [ccn_nm]
-  standard_name = tendency_of_ccn_activated_number
+  standard_name = tendency_of_activated_cloud_condensation_nuclei_from_climatology
   long_name = tendency of ccn activated number
   units = kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [aer_nm]
-  standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
+  standard_name = mass_number_concentration_of_aerosol_from_gocart_climatology
   long_name = GOCART aerosol climatology number concentration
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_aerosol_tracers_MG)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_aerosol_tracers_MG)
   type = real
   kind = kind_phys
 [imap]
@@ -5506,28 +5506,28 @@
   dimensions = (horizontal_loop_extent)
   type = integer
 [rann]
-  standard_name = random_number_array
+  standard_name = random_number
   long_name = random number array (0-1)
   units = none
-  dimensions = (horizontal_loop_extent,array_dimension_of_random_number)
+  dimensions = (horizontal_loop_extent,number_of_random_numbers)
   type = real
   kind = kind_phys
 [acv]
-  standard_name = accumulated_lwe_thickness_of_convective_precipitation_amount_cnvc90
+  standard_name = cumulative_lwe_thickness_of_convective_precipitation_amount_between_sw_radiation_calls
   long_name = accumulated convective rainfall amount for cnvc90 only
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [acvb]
-  standard_name = smallest_cloud_base_vertical_index_encountered_thus_far
+  standard_name = cumulative_min_vertical_index_at_cloud_base_between_sw_radiation_calls
   long_name = smallest cloud base vertical index encountered thus far
   units = index
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [acvt]
-  standard_name = largest_cloud_top_vertical_index_encountered_thus_far
+  standard_name = cumulative_max_vertical_index_at_cloud_base_between_sw_radiation_calls
   long_name = largest cloud top vertical index encountered thus far
   units = index
   dimensions = (horizontal_loop_extent)
@@ -5537,289 +5537,289 @@
   standard_name = tendency_of_air_temperature_to_withold_from_sppt
   long_name = temp. change from physics that should not be perturbed by sppt
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_stochastic_physics_perturbations .or. flag_for_global_cellular_automata)
 [drain_cpl]
-  standard_name = tendency_of_lwe_thickness_of_precipitation_amount_for_coupling
+  standard_name = lwe_thickness_of_rain_amount_on_dynamics_timestep_for_coupling
   long_name = change in rain_cpl (coupling_type)
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling .or. flag_for_chemistry_coupling)
+  active = (flag_for_surface_flux_coupling .or. flag_for_chemistry_coupling)
 [dsnow_cpl]
-  standard_name = tendency_of_lwe_thickness_of_snow_amount_for_coupling
+  standard_name = lwe_thickness_of_snowfall_amount_on_dynamics_timestep_for_coupling
   long_name = change in show_cpl (coupling_type)
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_flux_coupling .or. flag_for_chemistry_coupling)
+  active = (flag_for_surface_flux_coupling .or. flag_for_chemistry_coupling)
 [phy_fctd]
-  standard_name = cloud_base_mass_flux
+  standard_name = atmosphere_updraft_convective_mass_flux_at_cloud_base_by_cloud_type
   long_name = cloud base mass flux for CS convection
   units = kg m-2 s-1
   dimensions = (horizontal_loop_extent,number_of_cloud_types_CS)
   type = real
   kind = kind_phys
   active = (number_of_cloud_types_CS > 0 .and. flag_for_Chikira_Sugiyama_deep_convection)
-[phy_f2d(:,index_for_surface_air_pressure_two_timesteps_back)]
+[phy_f2d(:,index_of_surface_air_pressure_two_timesteps_back_in_xyz_dimensioned_tracer_array)]
   standard_name = surface_air_pressure_two_timesteps_back
   long_name = surface air pressure two timesteps back
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (index_for_surface_air_pressure_two_timesteps_back > 0)
-[phy_f2d(:,index_for_surface_air_pressure_at_previous_timestep)]
-  standard_name = surface_air_pressure_at_previous_timestep
+  active = (index_of_surface_air_pressure_two_timesteps_back_in_xyz_dimensioned_tracer_array > 0)
+[phy_f2d(:,index_of_surface_air_pressure_on_previous_timestep_in_xyz_dimensioned_restart_array)]
+  standard_name = surface_air_pressure_on_previous_timestep
   long_name = surface air pressure at previous timestep
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (index_for_surface_air_pressure_at_previous_timestep > 0)
-[phy_f2d(:,index_for_surface_wind_enhancement_due_to_convection)]
-  standard_name = surface_wind_enhancement_due_to_convection
+  active = (index_of_surface_air_pressure_on_previous_timestep_in_xyz_dimensioned_restart_array > 0)
+[phy_f2d(:,index_of_enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convectionin_in_xy_dimensioned_restart_array)]
+  standard_name = enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convection
   long_name = surface wind enhancement due to convection
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (index_for_surface_wind_enhancement_due_to_convection > 0)
-[phy_f3d(:,:,index_for_air_temperature_two_timesteps_back)]
+  active = (index_of_enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convectionin_in_xy_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_air_temperature_two_timesteps_back_in_xyz_dimensioned_restart_array)]
   standard_name = air_temperature_two_timesteps_back
   long_name = air temperature two timesteps back
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_air_temperature_two_timesteps_back > 0)
-[phy_f3d(:,:,index_for_specific_humidity_two_timesteps_back)]
-  standard_name = water_vapor_specific_humidity_two_timesteps_back
+  active = (index_of_air_temperature_two_timesteps_back_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_specific_humidity_two_timesteps_back_in_xyz_dimensioned_restart_array)]
+  standard_name = specific_humidity_two_timesteps_back
   long_name = water vapor specific humidity two timesteps back
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_specific_humidity_two_timesteps_back > 0)
-[phy_f3d(:,:,index_for_air_temperature_at_previous_timestep)]
-  standard_name = air_temperature_at_previous_timestep
+  active = (index_of_specific_humidity_two_timesteps_back_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_air_temperature_on_previous_timestep_in_xyz_dimensioned_restart_array)]
+  standard_name = air_temperature_on_previous_timestep_in_xyz_dimensioned_restart_array
   long_name = air temperature at previous timestep
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_air_temperature_at_previous_timestep > 0)
-[phy_f3d(:,:,index_for_specific_humidity_at_previous_timestep)]
-  standard_name = water_vapor_specific_humidity_at_previous_timestep
+  active = (index_of_air_temperature_on_previous_timestep_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_specific_humidity_on_previous_timestep_in_xyz_dimensioned_restart_array)]
+  standard_name = specific_humidity_on_previous_timestep_in_xyz_dimensioned_restart_array
   long_name = water vapor specific humidity at previous timestep
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_specific_humidity_at_previous_timestep > 0)
-[phy_f3d(:,:,index_for_convective_cloud_water_mixing_ratio_in_phy_f3d)]
-  standard_name = convective_cloud_water_mixing_ratio_in_phy_f3d
+  active = (index_of_specific_humidity_on_previous_timestep_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_convective_cloud_condensate_mixing_ratio_in_xyz_dimensioned_restart_array)]
+  standard_name = convective_cloud_condensate_mixing_ratio
   long_name = convective cloud water mixing ratio in the phy_f3d array
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_convective_cloud_water_mixing_ratio_in_phy_f3d > 0)
-[phy_f3d(:,:,index_for_convective_cloud_cover_in_phy_f3d)]
-  standard_name = convective_cloud_cover_in_phy_f3d
+  active = (index_of_convective_cloud_condensate_mixing_ratio_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_convective_cloud_area_fraction_in_xyz_dimensioned_restart_array)]
+  standard_name = convective_cloud_area_fraction
   long_name = convective cloud cover in the phy_f3d array
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_convective_cloud_cover_in_phy_f3d > 0)
-[phy_f3d(:,:,index_of_kinematic_buoyancy_flux_from_shoc_in_phy_f3d)]
-  standard_name = kinematic_buoyancy_flux_from_shoc
+  active = (index_of_convective_cloud_area_fraction_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_upward_virtual_potential_temperature_flux_in_xyz_dimensioned_restart_array)]
+  standard_name = upward_virtual_potential_temperature_flux
   long_name = upward kinematic buoyancy flux from the SHOC scheme
   units = K m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_of_kinematic_buoyancy_flux_from_shoc_in_phy_f3d > 0)
-[phy_f3d(:,:,index_of_atmosphere_heat_diffusivity_from_shoc_in_phy_f3d)]
+  active = (index_of_upward_virtual_potential_temperature_flux_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_atmosphere_heat_diffusivity_in_xyz_dimensioned_restart_array)]
   standard_name = atmosphere_heat_diffusivity_from_shoc
   long_name = diffusivity for heat from the SHOC scheme
   units = m2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_of_atmosphere_heat_diffusivity_from_shoc_in_phy_f3d > 0)
-[phy_f3d(:,:,index_of_subgrid_scale_cloud_fraction_from_shoc_in_phy_f3d)]
+  active = (index_of_atmosphere_heat_diffusivity_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_subgrid_cloud_area_fracation_in_atmosphere_layer_in_xyz_dimensioned_restart_array)]
   standard_name = subgrid_scale_cloud_fraction_from_shoc
   long_name = subgrid-scale cloud fraction from the SHOC scheme
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_of_subgrid_scale_cloud_fraction_from_shoc_in_phy_f3d > 0)
-[phy_f3d(:,:,index_for_cloud_fraction_in_3d_arrays_for_microphysics)]
+  active = (index_of_subgrid_cloud_area_fracation_in_atmosphere_layer_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array)]
   standard_name = cloud_fraction_for_MG
   long_name = cloud fraction used by Morrison-Gettelman MP
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_cloud_fraction_in_3d_arrays_for_microphysics > 0)
-[phy_f3d(:,:,index_for_cloud_liquid_water_effective_radius)]
-  standard_name = effective_radius_of_stratiform_cloud_liquid_water_particle_in_um
+  active = (index_of_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_cloud_liquid_water_effective_radius_in_xyz_dimensioned_restart_array)]
+  standard_name = effective_radius_of_stratiform_cloud_liquid_water_particle
   long_name = eff. radius of cloud liquid water particle in micrometer
   units = um
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_cloud_liquid_water_effective_radius > 0)
-[phy_f3d(:,:,index_for_ice_effective_radius)]
-  standard_name = effective_radius_of_stratiform_cloud_ice_particle_in_um
+  active = (index_of_cloud_liquid_water_effective_radius_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_cloud_ice_effective_radius_in_xyz_dimensioned_restart_array)]
+  standard_name = effective_radius_of_stratiform_cloud_ice_particle
   long_name = eff. radius of cloud ice water particle in micrometer
   units = um
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_ice_effective_radius > 0)
-[phy_f3d(:,:,index_for_rain_effective_radius)]
-  standard_name = effective_radius_of_stratiform_cloud_rain_particle_in_um
+  active = (index_of_cloud_ice_effective_radius_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_rain_effective_radius_in_xyz_dimensioned_restart_array)]
+  standard_name = effective_radius_of_stratiform_cloud_rain_particle
   long_name = effective radius of cloud rain particle in micrometers
   units = um
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_rain_effective_radius > 0)
-[phy_f3d(:,:,index_for_snow_effective_radius)]
-  standard_name = effective_radius_of_stratiform_cloud_snow_particle_in_um
+  active = (index_of_rain_effective_radius_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_snow_effective_radius_in_xyz_dimensioned_restart_array)]
+  standard_name = effective_radius_of_stratiform_cloud_snow_particle
   long_name = effective radius of cloud snow particle in micrometers
   units = um
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_snow_effective_radius > 0)
-[phy_f3d(:,:,index_for_graupel_effective_radius)]
-  standard_name = effective_radius_of_stratiform_cloud_graupel_particle_in_um
+  active = (index_of_snow_effective_radius_in_xyz_dimensioned_restart_array > 0)
+[phy_f3d(:,:,index_of_graupel_effective_radius_in_xyz_dimensioned_restart_array)]
+  standard_name = effective_radius_of_stratiform_cloud_graupel_particle
   long_name = eff. radius of cloud graupel particle in micrometer
   units = um
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_graupel_effective_radius > 0)
+  active = (index_of_graupel_effective_radius_in_xyz_dimensioned_restart_array > 0)
 [forcet]
-  standard_name = temperature_tendency_due_to_dynamics
+  standard_name = tendency_of_air_temperature_due_to_nonphysics
   long_name = temperature tendency due to dynamics only
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_mass_flux_deep_convection_scheme == flag_for_gf_deep_convection_scheme .or. flag_for_mass_flux_deep_convection_scheme == flag_for_ntiedtke_deep_convection_scheme)
+  active = (control_for_deep_convection_scheme == identifier_for_grell_freitas_deep_convection .or. control_for_deep_convection_scheme == identifier_for_new_tiedtke_deep_convection)
 [forceq]
-  standard_name = moisture_tendency_due_to_dynamics
+  standard_name = tendendy_of_specific_humidity_due_to_nonphysics
   long_name = moisture tendency due to dynamics only
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_mass_flux_deep_convection_scheme == flag_for_gf_deep_convection_scheme .or. flag_for_mass_flux_deep_convection_scheme == flag_for_ntiedtke_deep_convection_scheme)
+  active = (control_for_deep_convection_scheme == identifier_for_grell_freitas_deep_convection .or. control_for_deep_convection_scheme == identifier_for_new_tiedtke_deep_convection)
 [prevst]
-  standard_name = temperature_from_previous_timestep
+  standard_name = air_temperature_on_previous_timestep
   long_name = temperature from previous time step
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_mass_flux_deep_convection_scheme == flag_for_gf_deep_convection_scheme .or. flag_for_mass_flux_deep_convection_scheme == flag_for_ntiedtke_deep_convection_scheme)
+  active = (control_for_deep_convection_scheme == identifier_for_grell_freitas_deep_convection .or. control_for_deep_convection_scheme == identifier_for_new_tiedtke_deep_convection)
 [prevsq]
-  standard_name = moisture_from_previous_timestep
+  standard_name = specific_humidity_on_previous_timestep
   long_name = moisture from previous time step
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_mass_flux_deep_convection_scheme == flag_for_gf_deep_convection_scheme .or. flag_for_mass_flux_deep_convection_scheme == flag_for_ntiedtke_deep_convection_scheme)
+  active = (control_for_deep_convection_scheme == identifier_for_grell_freitas_deep_convection .or. control_for_deep_convection_scheme == identifier_for_new_tiedtke_deep_convection)
 [cactiv]
-  standard_name = conv_activity_counter
+  standard_name = counter_for_grell_freitas_convection
   long_name = convective activity memory
   units = none
   dimensions = (horizontal_loop_extent)
   type = integer
-  active = (flag_for_mass_flux_deep_convection_scheme == flag_for_gf_deep_convection_scheme)
+  active = (control_for_deep_convection_scheme == identifier_for_grell_freitas_deep_convection)
 [CLDFRA_BL]
-  standard_name = subgrid_cloud_fraction_pbl
+  standard_name = subgrid_scale_cloud_area_fraction_in_atmosphere_layer
   long_name = subgrid cloud fraction from PBL scheme
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [QC_BL]
-  standard_name = subgrid_cloud_water_mixing_ratio_pbl
+  standard_name = subgrid_scale_cloud_liquid_water_mixing_ratio
   long_name = subgrid cloud water mixing ratio from PBL scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [QI_BL]
-  standard_name = subgrid_cloud_ice_mixing_ratio_pbl
+  standard_name = subgrid_scale_cloud_ice_mixing_ratio
   long_name = subgrid cloud ice mixing ratio from PBL scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [el_pbl]
-  standard_name = mixing_length
+  standard_name = turbulent_mixing_length
   long_name = mixing length in meters
   units = m
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [Sh3D]
   standard_name = stability_function_for_heat
   long_name = stability function for heat
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [qke]
-  standard_name = tke_at_mass_points
+  standard_name = nonadvected_turbulent_kinetic_energy_multiplied_by_2
   long_name = 2 x tke at mass points
   units = m2 s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [tsq]
-  standard_name = t_prime_squared
+  standard_name = variance_of_air_temperature
   long_name = temperature fluctuation squared
   units = K2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [qsq]
-  standard_name = q_prime_squared
+  standard_name = variance_of_specific_humidity
   long_name = water vapor fluctuation squared
   units = kg2 kg-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [cov]
-  standard_name = t_prime_q_prime
+  standard_name = covariance_of_air_temperature_and_specific_humidity
   long_name = covariance of temperature and moisture
   units = K kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [phy_myj_qsfc]
   standard_name = surface_specific_humidity_for_MYJ_schemes
   long_name = surface air saturation specific humidity for MYJ schemes
@@ -5827,39 +5827,39 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 [phy_myj_thz0]
-  standard_name = potential_temperature_at_viscous_sublayer_top
+  standard_name = air_potential_temperature_at_top_of_viscous_sublayer
   long_name = potential temperature at viscous sublayer top over water
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 [phy_myj_qz0]
-  standard_name = specific_humidity_at_viscous_sublayer_top
+  standard_name = specific_humidity_at_top_of_viscous_sublayer
   long_name = specific humidity at_viscous sublayer top over water
   units = kg kg-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 [phy_myj_uz0]
-  standard_name = u_wind_component_at_viscous_sublayer_top
+  standard_name = x_wind_at_top_of_viscous_sublayer
   long_name = u wind component at viscous sublayer top over water
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 [phy_myj_vz0]
-  standard_name = v_wind_component_at_viscous_sublayer_top
+  standard_name = y_wind_at_top_of_viscous_sublayer
   long_name = v wind component at viscous sublayer top over water
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 [phy_myj_akhs]
   standard_name = heat_exchange_coefficient_for_MYJ_schemes
   long_name = surface heat exchange_coefficient for MYJ schemes
@@ -5867,7 +5867,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 [phy_myj_akms]
   standard_name = momentum_exchange_coefficient_for_MYJ_schemes
   long_name = surface momentum exchange_coefficient for MYJ schemes
@@ -5875,47 +5875,47 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 [phy_myj_chkqlm]
-  standard_name = surface_layer_evaporation_switch
+  standard_name = control_for_surface_layer_evaporation
   long_name = surface layer evaporation switch
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 [phy_myj_elflx]
-  standard_name = kinematic_surface_latent_heat_flux
+  standard_name = surface_upward_specific_humidity_flux_for_mellor_yamada_janic_surface_layer_scheme
   long_name = kinematic surface latent heat flux
   units = m s-1 kg kg-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 [phy_myj_a1u]
-  standard_name = weight_for_momentum_at_viscous_sublayer_top
+  standard_name = weight_for_momentum_at_top_of_viscous_sublayer
   long_name = weight for momentum at viscous layer top
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 [phy_myj_a1t]
-  standard_name = weight_for_potental_temperature_at_viscous_sublayer_top
+  standard_name = weight_for_potental_temperature_at_top_of_viscous_sublayer
   long_name = weight for potental temperature at viscous layer top
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 [phy_myj_a1q]
-  standard_name = weight_for_specific_humidity_at_viscous_sublayer_top
+  standard_name = weight_for_specific_humidity_at_top_of_viscous_sublayer
   long_name = weight for Specfic Humidity at viscous layer top
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_myjsfc .or. do_myjpbl)
+  active = (flag_for_mellor_yamada_janic_surface_layer_scheme .or. flag_for_mellor_yamada_janic_pbl_scheme)
 
 ########################################################################
 [ccpp-table-properties]
@@ -5927,21 +5927,21 @@
   name = GFS_cldprop_type
   type = ddt
 [cv]
-  standard_name = fraction_of_convective_cloud
+  standard_name = convective_cloud_area_fraction_between_sw_radiation_calls_from_cnvc90
   long_name = fraction of convective cloud
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [cvt]
-  standard_name = pressure_at_top_of_convective_cloud
+  standard_name = pressure_at_convective_cloud_top_between_sw_radiation_calls_from_cnvc90
   long_name = convective cloud top pressure
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [cvb]
-  standard_name = pressure_at_bottom_of_convective_cloud
+  standard_name = pressure_at_convective_cloud_base_between_sw_radiation_calls_from_cnvc90
   long_name = convective cloud bottom pressure
   units = Pa
   dimensions = (horizontal_loop_extent)
@@ -5958,54 +5958,54 @@
   name = GFS_radtend_type
   type = ddt
 [sfcfsw]
-  standard_name = sw_fluxes_sfc
+  standard_name = surface_sw_fluxes_assuming_total_and_clear_sky_on_radiation_timestep
   long_name = sw radiation fluxes at sfc
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = sfcfsw_type
 [sfcflw]
-  standard_name = lw_fluxes_sfc
+  standard_name = surface_lw_fluxes_assuming_total_and_clear_sky_on_radiation_timestep
   long_name = lw radiation fluxes at sfc
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = sfcflw_type
 [htrsw]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
   long_name = total sky sw heating rate
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [htrlw]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
   long_name = total sky lw heating rate
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [sfalb]
-  standard_name = surface_diffused_shortwave_albedo
+  standard_name = surface_albedo_for_diffused_shortwave_on_radiation_timestep
   long_name = mean surface diffused sw albedo
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [coszen]
-  standard_name = cosine_of_zenith_angle
+  standard_name = cosine_of_solar_zenith_angle_for_daytime_points_on_radiation_timestep
   long_name = mean cos of zenith angle over rad call period
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [coszdg]
-  standard_name = daytime_mean_cosz_over_rad_call_period
+  standard_name = cosine_of_solar_zenith_angle_on_radiation_timestep
   long_name = daytime mean cosz over rad call period
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [tsflw]
-  standard_name = surface_midlayer_air_temperature_in_longwave_radiation
+  standard_name = air_temperature_at_surface_adjacent_layer_on_radiation_timestep
   long_name = surface air temp during lw calculation
   units = K
   dimensions = (horizontal_loop_extent)
@@ -6019,24 +6019,24 @@
   type = real
   kind = kind_phys
 [swhc]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_timestep
   long_name = clear sky sw heating rates
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [lwhc]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_timestep
   long_name = clear sky lw heating rates
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [lwhd]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_for_idea
+  standard_name = tendency_of_air_temperature_due_to_integrated_dynamics_through_earths_atmosphere
   long_name = idea sky lw heating rates
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,6)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,6)
   type = real
   kind = kind_phys
 
@@ -6053,7 +6053,7 @@
   standard_name = cumulative_radiation_diagnostic
   long_name = time-accumulated 2D radiation-related diagnostic fields
   units = various
-  dimensions = (horizontal_loop_extent,number_of_radiation_diagnostic_variables)
+  dimensions = (horizontal_loop_extent,number_of_diagnostics_variables_for_radiation)
   type = real
   kind = kind_phys
 [topfsw]
@@ -6226,10 +6226,10 @@
   standard_name = accumulated_change_of_air_temperature_due_to_FA_scheme
   long_name = accumulated change of air temperature due to FA MP scheme
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_fer_hires_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [gflux]
   standard_name = cumulative_surface_ground_heat_flux_multiplied_by_timestep
   long_name = cumulative groud conductive heat flux multiplied by timestep
@@ -6594,7 +6594,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (.not. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (.not. control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [tdomr]
   standard_name = dominant_rain_type
   long_name = dominant rain type
@@ -6627,35 +6627,35 @@
   standard_name = weights_for_stochastic_skeb_perturbation_of_x_wind_flipped
   long_name = weights for stochastic skeb perturbation of x wind, flipped
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [skebv_wts]
   standard_name = weights_for_stochastic_skeb_perturbation_of_y_wind_flipped
   long_name = weights for stochastic skeb perturbation of y wind, flipped
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [sppt_wts]
   standard_name = weights_for_stochastic_sppt_perturbation_flipped
   long_name = weights for stochastic sppt perturbation, flipped
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [shum_wts]
   standard_name = weights_for_stochastic_shum_perturbation_flipped
   long_name = weights for stochastic shum perturbation, flipped
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [sfc_wts]
   standard_name = weights_for_stochastic_surface_physics_perturbation_flipped
   long_name = weights for stochastic surface physics perturbation, flipped
   units = none
-  dimensions = (horizontal_loop_extent,number_of_land_surface_variables_perturbed)
+  dimensions = (horizontal_loop_extent,number_of_perturbed_land_surface_variables)
   type = real
   kind = kind_phys
 [zmtnblck]
@@ -6669,7 +6669,7 @@
   standard_name = cumulative_change_in_x_wind_due_to_PBL
   long_name = cumulative change in x wind due to PBL
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6677,7 +6677,7 @@
   standard_name = cumulative_change_in_x_wind_due_to_orographic_gravity_wave_drag
   long_name = cumulative change in x wind due to orographic gravity wave drag
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6685,7 +6685,7 @@
   standard_name = cumulative_change_in_x_wind_due_to_deep_convection
   long_name = cumulative change in x wind due to deep convection
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6693,7 +6693,7 @@
   standard_name = cumulative_change_in_x_wind_due_to_convective_gravity_wave_drag
   long_name = cumulative change in x wind due to convective gravity wave drag
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6701,7 +6701,7 @@
   standard_name = cumulative_change_in_x_wind_due_to_rayleigh_damping
   long_name = cumulative change in x wind due to Rayleigh damping
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6709,7 +6709,7 @@
   standard_name = cumulative_change_in_x_wind_due_to_shallow_convection
   long_name = cumulative change in x wind due to shallow convection
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6717,7 +6717,7 @@
   standard_name = cumulative_change_in_x_wind_due_to_physics
   long_name = cumulative change in x wind due to physics
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6725,7 +6725,7 @@
   standard_name = cumulative_change_in_x_wind_due_to_non_physics_processes
   long_name = cumulative change in x wind due to non-physics processes
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6733,7 +6733,7 @@
   standard_name = cumulative_change_in_y_wind_due_to_PBL
   long_name = cumulative change in y wind due to PBL
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6741,7 +6741,7 @@
   standard_name = cumulative_change_in_y_wind_due_to_orographic_gravity_wave_drag
   long_name = cumulative change in y wind due to orographic gravity wave drag
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6749,7 +6749,7 @@
   standard_name = cumulative_change_in_y_wind_due_to_deep_convection
   long_name = cumulative change in y wind due to deep convection
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6757,14 +6757,14 @@
   standard_name = cumulative_change_in_y_wind_due_to_convective_gravity_wave_drag
   long_name = cumulative change in y wind due to convective gravity wave drag
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dv3dt(:,:,5)]
   standard_name = cumulative_change_in_y_wind_due_to_rayleigh_damping
   long_name = cumulative change in y wind due to Rayleigh damping
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6772,7 +6772,7 @@
   standard_name = cumulative_change_in_y_wind_due_to_shallow_convection
   long_name = cumulative change in y wind due to shallow convection
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6780,7 +6780,7 @@
   standard_name = cumulative_change_in_y_wind_due_to_physics
   long_name = cumulative change in y wind due to physics
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6788,7 +6788,7 @@
   standard_name = cumulative_change_in_y_wind_due_to_non_physics_processes
   long_name = cumulative change in y wind due to non-physics processes
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6796,7 +6796,7 @@
   standard_name = cumulative_change_in_temperature_due_to_longwave_radiation
   long_name = cumulative change in temperature due to longwave radiation
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6804,7 +6804,7 @@
   standard_name = cumulative_change_in_temperature_due_to_shortwave_radiation
   long_name = cumulative change in temperature due to shortwave radiation
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6812,7 +6812,7 @@
   standard_name = cumulative_change_in_temperature_due_to_PBL
   long_name = cumulative change in temperature due to PBL
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6820,7 +6820,7 @@
   standard_name = cumulative_change_in_temperature_due_to_deep_convection
   long_name = cumulative change in temperature due to deep convection
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6828,7 +6828,7 @@
   standard_name = cumulative_change_in_temperature_due_to_shallow_convection
   long_name = cumulative change in temperature due to shallow convection
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6836,7 +6836,7 @@
   standard_name = cumulative_change_in_temperature_due_to_microphysics
   long_name = cumulative change in temperature due to microphysics
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6844,7 +6844,7 @@
   standard_name = cumulative_change_in_temperature_due_to_orographic_gravity_wave_drag
   long_name = cumulative change in temperature due to orographic gravity wave drag
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6852,7 +6852,7 @@
   standard_name = cumulative_change_in_temperature_due_to_rayleigh_damping
   long_name = cumulative change in temperature due to Rayleigh damping
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6860,7 +6860,7 @@
   standard_name = cumulative_change_in_temperature_due_to_convective_gravity_wave_drag
   long_name = cumulative change in temperature due to convective gravity wave drag
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6868,7 +6868,7 @@
   standard_name = cumulative_change_in_temperature_due_to_physics
   long_name = cumulative change in temperature due to physics
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6876,7 +6876,7 @@
   standard_name = cumulative_change_in_temperature_due_to_non_physics_processes
   long_name = cumulative change in temperature due to non-physics processed
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D)
@@ -6884,7 +6884,7 @@
   standard_name = cumulative_change_in_water_vapor_specific_humidity_due_to_PBL
   long_name = cumulative change in water vapor specific humidity due to PBL
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6892,7 +6892,7 @@
   standard_name = cumulative_change_in_water_vapor_specific_humidity_due_to_deep_convection
   long_name = cumulative change in water vapor specific humidity due to deep convection
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6900,7 +6900,7 @@
   standard_name = cumulative_change_in_water_vapor_specific_humidity_due_to_shallow_convection
   long_name = cumulative change in water vapor specific humidity due to shallow convection
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6908,7 +6908,7 @@
   standard_name = cumulative_change_in_water_vapor_specific_humidity_due_to_microphysics
   long_name = cumulative change in water vapor specific humidity due to microphysics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6916,7 +6916,7 @@
   standard_name = cumulative_change_in_ozone_mixing_ratio_due_to_PBL
   long_name = cumulative change in ozone mixing ratio due to PBL
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6924,7 +6924,7 @@
   standard_name = cumulative_change_in_ozone_concentration_due_to_production_and_loss_rate
   long_name = cumulative change in ozone concentration due to production and loss rate
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6932,7 +6932,7 @@
   standard_name = cumulative_change_in_ozone_concentration_due_to_ozone_mixing_ratio
   long_name = cumulative change in ozone concentration due to ozone mixing ratio
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6940,7 +6940,7 @@
   standard_name = cumulative_change_in_ozone_concentration_due_to_temperature
   long_name = cumulative change in ozone concentration due to temperature
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6948,7 +6948,7 @@
   standard_name = cumulative_change_in_ozone_concentration_due_to_overhead_ozone_column
   long_name = cumulative change in ozone concentration due to overhead ozone column
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6956,7 +6956,7 @@
   standard_name = cumulative_change_in_water_vapor_specific_humidity_due_to_physics
   long_name = cumulative change in water vapor specific humidity due to physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6964,7 +6964,7 @@
   standard_name = cumulative_change_in_ozone_concentration_due_to_physics
   long_name = cumulative change in ozone concentration due to physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6972,7 +6972,7 @@
   standard_name = cumulative_change_in_water_vapor_specific_humidity_due_to_non_physics_processes
   long_name = cumulative change in water vapor specific humidity due to non-physics processes
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -6980,7 +6980,7 @@
   standard_name = cumulative_change_in_ozone_concentration_due_to_non_physics_processes
   long_name = cumulative change in ozone_concentration due to non-physics processes
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_diagnostics_3D .and. flag_tracer_diagnostics_3D)
@@ -7037,42 +7037,42 @@
   standard_name = cumulative_atmosphere_updraft_convective_mass_flux
   long_name = cumulative updraft mass flux
   units = kg m-1 s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dwn_mf]
   standard_name = cumulative_atmosphere_downdraft_convective_mass_flux
   long_name = cumulative downdraft mass flux
   units = kg m-1 s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [det_mf]
   standard_name = cumulative_atmosphere_detrainment_convective_mass_flux
   long_name = cumulative detrainment mass flux
   units = kg m-1 s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [refl_10cm]
   standard_name = radar_reflectivity_10cm
   long_name = instantaneous refl_10cm
   units = dBZ
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dkt]
   standard_name = atmosphere_heat_diffusivity
   long_name = atmospheric heat diffusivity
   units = m2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dku]
   standard_name = atmosphere_momentum_diffusivity
   long_name = atmospheric momentum diffusivity
   units = m2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [cldfra]
@@ -7086,89 +7086,89 @@
   standard_name = emdf_updraft_area
   long_name = updraft area from mass flux scheme
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf .and. (mynn_output_flag .ne. 0))
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. (control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme .ne. 0))
 [edmf_w]
   standard_name = emdf_updraft_vertical_velocity
   long_name = updraft vertical velocity from mass flux scheme
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf .and. (mynn_output_flag .ne. 0))
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. (control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme .ne. 0))
 [edmf_qt]
   standard_name = emdf_updraft_total_water
   long_name = updraft total water from mass flux scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf .and. (mynn_output_flag .ne. 0))
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. (control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme .ne. 0))
 [edmf_thl]
   standard_name = emdf_updraft_theta_l
   long_name = updraft theta-l from mass flux scheme
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf .and. (mynn_output_flag .ne. 0))
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. (control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme .ne. 0))
 [edmf_ent]
   standard_name = emdf_updraft_entrainment_rate
   long_name = updraft entranment rate from mass flux scheme
   units = s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf .and. (mynn_output_flag .ne. 0))
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. (control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme .ne. 0))
 [edmf_qc]
   standard_name = emdf_updraft_cloud_water
   long_name = updraft cloud water from mass flux scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf .and. (mynn_output_flag .ne. 0))
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. (control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme .ne. 0))
 [sub_thl]
   standard_name = theta_subsidence_tendency
   long_name = updraft theta subsidence tendency
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf .and. (mynn_output_flag .ne. 0))
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. (control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme .ne. 0))
 [sub_sqv]
   standard_name = water_vapor_subsidence_tendency
   long_name = updraft water vapor subsidence tendency
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf .and. (mynn_output_flag .ne. 0))
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. (control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme .ne. 0))
 [det_thl]
   standard_name = theta_detrainment_tendency
   long_name = updraft theta detrainment tendency
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf .and. (mynn_output_flag .ne. 0))
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. (control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme .ne. 0))
 [det_sqv]
   standard_name = water_vapor_detrainment_tendency
   long_name = updraft water vapor detrainment tendency
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf .and. (mynn_output_flag .ne. 0))
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. (control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme .ne. 0))
 [nupdraft]
   standard_name = number_of_plumes
   long_name = number of plumes per grid column
   units = count
   dimensions = (horizontal_loop_extent)
   type = integer
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [maxMF]
   standard_name = maximum_mass_flux
   long_name = maximum mass flux within a column
@@ -7176,7 +7176,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [ktop_shallow]
   standard_name = k_level_of_highest_reaching_plume
   long_name = k-level of highest reaching plume
@@ -7189,23 +7189,23 @@
   units = count
   dimensions = (horizontal_loop_extent)
   type = integer
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [exch_h]
   standard_name = atmosphere_heat_diffusivity_for_mynnpbl
   long_name = diffusivity for heat for MYNN PBL (defined for all mass levels)
   units = m2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [exch_m]
   standard_name = atmosphere_momentum_diffusivity_for_mynnpbl
   long_name = diffusivity for momentum for MYNN PBL (defined for all mass levels)
   units = m2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (do_mynnedmf)
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme)
 [zmtb]
   standard_name = time_integral_of_height_of_mountain_blocking
   long_name = time integral of height of mountain blocking drag
@@ -7259,78 +7259,78 @@
   standard_name = time_integral_of_change_in_x_wind_due_to_mountain_blocking_drag
   long_name = time integral of change in x wind due to mountain blocking drag
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (diag_ugwp_flag)
+  active = (flag_for_unified_gravity_wave_physics_diagnostics)
 [du3dt_ogw]
   standard_name = time_integral_of_change_in_x_wind_due_to_orographic_gravity_wave_drag
   long_name = time integral of change in x wind due to orographic gw drag
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (diag_ugwp_flag)
+  active = (flag_for_unified_gravity_wave_physics_diagnostics)
 [du3dt_tms]
   standard_name = time_integral_of_change_in_x_wind_due_to_turbulent_orographic_form_drag
   long_name = time integral of change in x wind due to TOFD
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (diag_ugwp_flag)
+  active = (flag_for_unified_gravity_wave_physics_diagnostics)
 [du3dt_ngw]
   standard_name = time_integral_of_change_in_x_wind_due_to_nonstationary_gravity_wave
   long_name = time integral of change in x wind due to NGW
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (diag_ugwp_flag)
+  active = (flag_for_unified_gravity_wave_physics_diagnostics)
 [dudt_gw]
   standard_name = tendency_of_x_wind_due_to_gravity_wave_drag
   long_name = zonal wind tendency due to all GWs
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dvdt_gw]
   standard_name = tendency_of_y_wind_due_to_gravity_wave_drag
   long_name = meridional wind tendency due to all GWs
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dtdt_gw]
   standard_name = tendency_of_air_temperature_due_to_gravity_wave_drag
   long_name = air temperature tendency due to all GWs
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [kdis_gw]
   standard_name = atmosphere_momentum_diffusivity_due_to_gravity_wave_drag
   long_name = eddy mixing due to all GWs
   units = m2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dudt_ogw]
   standard_name = tendency_of_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = x momentum tendency from meso scale ogw
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dvdt_ogw]
   standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = y momentum tendency from meso scale ogw
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [du_ogwcol]
   standard_name = vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = integrated x momentum flux from meso scale ogw
@@ -7338,7 +7338,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dv_ogwcol]
   standard_name = vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = integrated y momentum flux from meso scale ogw
@@ -7346,23 +7346,23 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dudt_obl]
   standard_name = tendency_of_x_momentum_due_to_blocking_drag
   long_name = x momentum tendency from blocking drag
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dvdt_obl]
   standard_name = tendency_of_y_momentum_due_to_blocking_drag
   long_name = y momentum tendency from blocking drag
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [du_oblcol]
   standard_name = vertically_integrated_x_momentum_flux_due_to_blocking_drag
   long_name = integrated x momentum flux from blocking drag
@@ -7370,7 +7370,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dv_oblcol]
   standard_name = vertically_integrated_y_momentum_flux_due_to_blocking_drag
   long_name = integrated y momentum flux from blocking drag
@@ -7378,23 +7378,23 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dudt_oss]
   standard_name = tendency_of_x_momentum_due_to_small_scale_gravity_wave_drag
   long_name = x momentum tendency from small scale gwd
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dvdt_oss]
   standard_name = tendency_of_y_momentum_due_to_small_scale_gravity_wave_drag
   long_name = y momentum tendency from small scale gwd
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [du_osscol]
   standard_name = vertically_integrated_x_momentum_flux_due_to_small_scale_gravity_wave_drag
   long_name = integrated x momentum flux from small scale gwd
@@ -7402,7 +7402,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dv_osscol]
   standard_name = vertically_integrated_y_momentum_flux_due_to_small_scale_gravity_wave_drag
   long_name = integrated y momentum flux from small scale gwd
@@ -7410,23 +7410,23 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dudt_ofd]
   standard_name = tendency_of_x_momentum_due_to_form_drag
   long_name = x momentum tendency from form drag
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dvdt_ofd]
   standard_name = tendency_of_y_momentum_due_to_form_drag
   long_name = y momentum tendency from form drag
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [du_ofdcol]
   standard_name = vertically_integrated_x_momentum_flux_due_to_form_drag
   long_name = integrated x momentum flux from form drag
@@ -7434,7 +7434,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dv_ofdcol]
   standard_name = vertically_integrated_y_momentum_flux_due_to_form_drag
   long_name = integrated y momentum flux from form drag
@@ -7442,31 +7442,31 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dv3dt_ngw]
   standard_name = time_integral_of_change_in_y_wind_due_to_nonstationary_gravity_wave
   long_name = time integral of change in y wind due to NGW
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (diag_ugwp_flag)
+  active = (flag_for_unified_gravity_wave_physics_diagnostics)
 [aux2d]
   standard_name = auxiliary_2d_arrays
   long_name = auxiliary 2d arrays to output (for debugging)
   units = none
-  dimensions = (horizontal_loop_extent,number_of_3d_auxiliary_arrays)
+  dimensions = (horizontal_loop_extent,number_of_xyz_dimensioned_auxiliary_arrays)
   type = real
   kind = kind_phys
-  active = (number_of_2d_auxiliary_arrays > 0)
+  active = (number_of_xy_dimensioned_auxiliary_arrays > 0)
 [aux3d]
   standard_name = auxiliary_3d_arrays
   long_name = auxiliary 3d arrays to output (for debugging)
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_3d_auxiliary_arrays)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_xyz_dimensioned_auxiliary_arrays)
   type = real
   kind = kind_phys
-  active = (number_of_3d_auxiliary_arrays > 0)
+  active = (number_of_xyz_dimensioned_auxiliary_arrays > 0)
 
 ########################################################################
 [ccpp-table-properties]
@@ -7481,82 +7481,82 @@
   standard_name = humidity_mixing_ratio
   long_name = the ratio of the mass of water vapor to the mass of dry air
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_fer_hires_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [qc_r]
-  standard_name = cloud_liquid_water_mixing_ratio
+  standard_name = cloud_liquid_water_mixing_ratio_interstitial
   long_name = the ratio of the mass of liquid water to the mass of dry air
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_fer_hires_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [qr_r]
   standard_name = cloud_rain_water_mixing_ratio
   long_name = the ratio of the mass rain water to the mass of dry air
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_fer_hires_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [qi_r]
-  standard_name = cloud_ice_mixing_ratio
+  standard_name = cloud_ice_mixing_ratio_interstitial
   long_name = the ratio of the mass of ice to the mass of dry air
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_fer_hires_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [qs_r]
   standard_name = cloud_snow_mixing_ratio
   long_name = the ratio of the mass of snow to mass of dry air
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_fer_hires_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [qg_r]
   standard_name = mass_weighted_rime_factor_mixing_ratio
   long_name = the ratio of the mass of rime factor to mass of dry air
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_fer_hires_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [f_ice]
   standard_name = fraction_of_ice_water_cloud
   long_name = fraction of ice water cloud
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_fer_hires_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [f_rain]
   standard_name = fraction_of_rain_water_cloud
   long_name = fraction of rain water cloud
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_fer_hires_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [f_rimef]
   standard_name = rime_factor
   long_name = rime factor
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_fer_hires_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [cwm]
   standard_name = total_cloud_condensate_mixing_ratio_updated_by_physics
   long_name = total cloud condensate mixing ratio (except water vapor) updated by physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_fer_hires_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [adjsfculw_water]
   standard_name = surface_upwelling_longwave_flux_over_water_interstitial
   long_name = surface upwelling longwave flux at current time over water (temporary use as interstitial)
@@ -7669,7 +7669,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [cd]
   standard_name = surface_drag_coefficient_for_momentum_in_air
   long_name = surface exchange coeff for momentum
@@ -7754,23 +7754,23 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [cf_upi]
   standard_name = convective_cloud_fraction_for_microphysics
   long_name = convective cloud fraction for microphysics
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [clcn]
   standard_name = convective_cloud_volume_fraction
   long_name = convective cloud volume fraction
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [cldf]
   standard_name = cloud_area_fraction
   long_name = fraction of grid box area in which updrafts occur
@@ -7873,33 +7873,33 @@
   standard_name = convective_transportable_tracers
   long_name = array to contain cloud water and other convective trans. tracers
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers_for_convective_transport)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers_for_convective_transport)
   type = real
   kind = kind_phys
 [clw(:,:,1)]
   standard_name = ice_water_mixing_ratio_convective_transport_tracer
   long_name = ratio of mass of ice water to mass of dry air plus vapor (without condensates) in the convectively transported tracer array
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [clw(:,:,2)]
   standard_name = cloud_condensed_water_mixing_ratio_convective_transport_tracer
   long_name = ratio of mass of cloud water to mass of dry air plus vapor (without condensates) in the convectively transported tracer array
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [clw(:,:,index_for_turbulent_kinetic_energy_convective_transport_tracer)]
   standard_name = turbulent_kinetic_energy_convective_transport_tracer
   long_name = turbulent kinetic energy in the convectively transported tracer array
   units = m2 s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [clx]
   standard_name = fraction_of_grid_box_with_subgrid_orography_higher_than_critical_height
-  long_name = frac. of grid box with by subgrid orography higher than critical height
+  long_name = frac. of grid box with by subgrid height_above_mean_sea_level higher than critical height
   units = frac
   dimensions = (horizontal_loop_extent,4)
   type = real
@@ -7911,15 +7911,15 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [clxss]
   standard_name = fraction_of_grid_box_with_subgrid_orography_higher_than_critical_height_small_scale
-  long_name = frac. of grid box with by subgrid orography higher than critical height small scale
+  long_name = frac. of grid box with by subgrid height_above_mean_sea_level higher than critical height small scale
   units = frac
   dimensions = (horizontal_loop_extent,4)
   type = real
   kind = kind_phys
-  active = (gwd_opt == 3 .or. gwd_opt == 33)
+  active = (control_for_drag_suite_gravity_wave_drag == 3 .or. control_for_drag_suite_gravity_wave_drag == 33)
 [cmm_water]
   standard_name = surface_drag_wind_speed_for_momentum_in_air_over_water
   long_name = momentum exchange coefficient over water
@@ -7945,54 +7945,54 @@
   standard_name = tendency_of_cloud_water_due_to_convective_microphysics
   long_name = tendency of cloud water due to convective microphysics
   units = kg m-2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [cnv_fice]
   standard_name = ice_fraction_in_convective_tower
   long_name = ice fraction in convective tower
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [cnv_mfd]
   standard_name = detrained_mass_flux
   long_name = detrained mass flux
   units = kg m-2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [cnv_ndrop]
   standard_name = number_concentration_of_cloud_liquid_water_particles_for_detrainment
   long_name = droplet number concentration in convective detrainment
   units = m-3
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [cnv_nice]
   standard_name = number_concentration_of_ice_crystals_for_detrainment
   long_name = crystal number concentration in convective detrainment
   units = m-3
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [cnvc]
   standard_name = convective_cloud_cover
   long_name = convective cloud cover
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [cnvw]
   standard_name = convective_cloud_water_mixing_ratio
   long_name = moist convective cloud water mixing ratio
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [ctei_r]
@@ -8020,7 +8020,7 @@
   standard_name = instantaneous_atmosphere_downdraft_convective_mass_flux
   long_name = (downdraft mass flux) * delt
   units = kg m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [de_lgth]
@@ -8034,14 +8034,14 @@
   standard_name = air_pressure_difference_between_midlayers
   long_name = air pressure difference between midlayers
   units = Pa
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [del_gz]
   standard_name = geopotential_difference_between_midlayers_divided_by_midlayer_virtual_temperature
   long_name = difference between mid-layer geopotentials divided by mid-layer virtual temperature
   units = m2 s-2 K-1
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
 [delr]
@@ -8059,97 +8059,97 @@
   type = real
   kind = kind_phys
 [dqdt]
-  standard_name = tendency_of_tracers_due_to_model_physics
+  standard_name = process_split_cumulative_tendency_of_tracers
   long_name = updated tendency of the tracers due to model physics
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-[dqdt(:,:,index_for_water_vapor)]
-  standard_name = tendency_of_water_vapor_specific_humidity_due_to_model_physics
+[dqdt(:,:,index_of_specific_humidity_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_specific_humidity
   long_name = water vapor specific humidity tendency due to model physics
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[dqdt(:,:,index_for_liquid_cloud_condensate)]
-  standard_name = tendency_of_liquid_cloud_water_mixing_ratio_due_to_model_physics
+[dqdt(:,:,index_of_cloud_liquid_water_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_cloud_liquid_water_mixing_ratio
   long_name = cloud condensed water mixing ratio tendency due to model physics
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[dqdt(:,:,index_for_ice_cloud_condensate)]
-  standard_name = tendency_of_ice_cloud_water_mixing_ratio_due_to_model_physics
+[dqdt(:,:,index_of_cloud_ice_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_cloud_ice_mixing_ratio
   long_name = cloud condensed water mixing ratio tendency due to model physics
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[dqdt(:,:,index_for_ozone)]
-  standard_name = tendency_of_ozone_mixing_ratio_due_to_model_physics
+[dqdt(:,:,index_of_ozone_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_ozone_mixing_ratio
   long_name = ozone mixing ratio tendency due to model physics
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[dqdt(:,:,index_for_liquid_cloud_number_concentration)]
-  standard_name = tendency_of_cloud_droplet_number_concentration_due_to_model_physics
+[dqdt(:,:,index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_liquid_water_particles_in_air
   long_name = number concentration of cloud droplets (liquid) tendency due to model physics
   units = kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_liquid_cloud_number_concentration > 0)
-[dqdt(:,:,index_for_ice_cloud_number_concentration)]
-  standard_name = tendency_of_ice_number_concentration_due_to_model_physics
+  active = (index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array > 0)
+[dqdt(:,:,index_of_mass_number_concentration_of_cloud_ice_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_ice_water_crystals_in_air
   long_name = number concentration of ice tendency due to model physics
   units = kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[dqdt(:,:,index_for_water_friendly_aerosols)]
-  standard_name = tendency_of_water_friendly_aerosol_number_concentration_due_to_model_physics
+[dqdt(:,:,index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_hygroscopic_aerosols
   long_name = number concentration of water-friendly aerosols tendency due to model physics
   units = kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_water_friendly_aerosols > 0)
-[dqdt(:,:,index_for_ice_friendly_aerosols)]
-  standard_name = tendency_of_ice_friendly_aerosol_number_concentration_due_to_model_physics
+  active = (index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array > 0)
+[dqdt(:,:,index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols
   long_name = number concentration of ice-friendly aerosols tendency due to model physics
   units = kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (index_for_ice_friendly_aerosols > 0)
-[dqdt(:,:,index_for_rain_water)]
-  standard_name = tendency_of_rain_water_mixing_ratio_due_to_model_physics
+  active = (index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array > 0)
+[dqdt(:,:,index_of_rain_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_rain_mixing_ratio
   long_name = ratio of mass of rain water tendency to mass of dry air plus vapor (without condensates) due to model physics
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[dqdt(:,:,index_for_snow_water)]
-  standard_name = tendency_of_snow_water_mixing_ratio_due_to_model_physics
+[dqdt(:,:,index_of_snow_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_snow_mixing_ratio
   long_name = ratio of mass of snow water tendency to mass of dry air plus vapor (without condensates) due to model physics
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[dqdt(:,:,index_for_graupel)]
-  standard_name = tendency_of_graupel_mixing_ratio_due_to_model_physics
+[dqdt(:,:,index_of_graupel_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_graupel_mixing_ratio
   long_name = ratio of mass of graupel tendency to mass of dry air plus vapor (without condensates) due to model physics
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[dqdt(:,:,index_for_turbulent_kinetic_energy)]
-  standard_name = tendency_of_turbulent_kinetic_energy_due_to_model_physics
+[dqdt(:,:,index_of_turbulent_kinetic_energy_in_tracer_concentration_array)]
+  standard_name = process_split_cumulative_tendency_of_turbulent_kinetic_energy
   long_name = turbulent kinetic energy tendency due to model physics
   units = J s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dqsdt2]
@@ -8159,7 +8159,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [dqsfc1]
   standard_name = instantaneous_surface_upward_latent_heat_flux
   long_name = surface upward latent heat flux
@@ -8181,12 +8181,12 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [dtdt]
-  standard_name = tendency_of_air_temperature_due_to_model_physics
+  standard_name = process_split_cumulative_tendency_of_air_temperature
   long_name = air temperature tendency due to model physics
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dtsfc1]
@@ -8207,14 +8207,14 @@
   standard_name = instantaneous_atmosphere_detrainment_convective_mass_flux
   long_name = (detrainment mass flux) * delt
   units = kg m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dudt]
-  standard_name = tendency_of_x_wind_due_to_model_physics
+  standard_name = process_split_cumulative_tendency_of_x_wind
   long_name = zonal wind tendency due to model physics
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dusfcg]
@@ -8235,14 +8235,14 @@
   standard_name = tendency_of_vertically_diffused_tracer_concentration
   long_name = updated tendency of the tracers due to vertical diffusion in PBL scheme
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_vertical_diffusion_tracers)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_vertical_diffusion_tracers)
   type = real
   kind = kind_phys
 [dvdt]
-  standard_name = tendency_of_y_wind_due_to_model_physics
+  standard_name = process_split_cumulative_tendency_of_y_wind
   long_name = meridional wind tendency due to model physics
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dvsfcg]
@@ -8268,7 +8268,7 @@
   kind = kind_phys
 [elvmax]
   standard_name = maximum_subgrid_orography
-  long_name = maximum of subgrid orography
+  long_name = maximum of subgrid height_above_mean_sea_level
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
@@ -8493,14 +8493,14 @@
   units = flag
   dimensions = (horizontal_loop_extent)
   type = logical
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [flag_lsm_glacier]
   standard_name = flag_for_calling_land_surface_model_glacier
   long_name = flag for calling land surface model over glacier
   units = flag
   dimensions = (horizontal_loop_extent)
   type = logical
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [ffmm_water]
   standard_name = Monin_Obukhov_similarity_function_for_momentum_over_water
   long_name = Monin-Obukhov similarity function for momentum over water
@@ -8608,7 +8608,7 @@
   kind = kind_phys
 [gamma]
   standard_name = anisotropy_of_subgrid_orography
-  long_name = anisotropy of subgrid orography
+  long_name = anisotropy of subgrid height_above_mean_sea_level
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
@@ -8628,70 +8628,70 @@
   type = real
   kind = kind_phys
 [gasvmr(:,:,1)]
-  standard_name = volume_mixing_ratio_co2
+  standard_name = volume_mixing_ratio_of_co2
   long_name = volume mixing ratio co2
   units = kg kg-1
   dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [gasvmr(:,:,2)]
-  standard_name = volume_mixing_ratio_n2o
+  standard_name = volume_mixing_ratio_of_n2o
   long_name = volume mixing ratio no2
   units = kg kg-1
   dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [gasvmr(:,:,3)]
-  standard_name = volume_mixing_ratio_ch4
+  standard_name = volume_mixing_ratio_of_ch4
   long_name = volume mixing ratio ch4
   units = kg kg-1
   dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [gasvmr(:,:,4)]
-  standard_name = volume_mixing_ratio_o2
+  standard_name = volume_mixing_ratio_of_o2
   long_name = volume mixing ratio o2
   units = kg kg-1
   dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [gasvmr(:,:,5)]
-  standard_name = volume_mixing_ratio_co
+  standard_name = volume_mixing_ratio_of_co
   long_name = volume mixing ratio co
   units = kg kg-1
   dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [gasvmr(:,:,6)]
-  standard_name = volume_mixing_ratio_cfc11
+  standard_name = volume_mixing_ratio_of_cfc11
   long_name = volume mixing ratio cfc11
   units = kg kg-1
   dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [gasvmr(:,:,7)]
-  standard_name = volume_mixing_ratio_cfc12
+  standard_name = volume_mixing_ratio_of_cfc12
   long_name = volume mixing ratio cfc12
   units = kg kg-1
   dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [gasvmr(:,:,8)]
-  standard_name = volume_mixing_ratio_cfc22
+  standard_name = volume_mixing_ratio_of_cfc22
   long_name = volume mixing ratio cfc22
   units = kg kg-1
   dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [gasvmr(:,:,9)]
-  standard_name = volume_mixing_ratio_ccl4
+  standard_name = volume_mixing_ratio_of_ccl4
   long_name = volume mixing ratio ccl4
   units = kg kg-1
   dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
 [gasvmr(:,:,10)]
-  standard_name = volume_mixing_ratio_cfc113
+  standard_name = volume_mixing_ratio_of_cfc113
   long_name = volume mixing ratio cfc113
   units = kg kg-1
   dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
@@ -8732,19 +8732,19 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_gfdl_microphysics_scheme .or. flag_for_microphysics_scheme == flag_for_thompson_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_gfdl_microphysics_scheme .or. control_for_microphysics_scheme == identifier_for_thompson_microphysics_scheme)
 [gwdcu]
   standard_name = tendency_of_x_wind_due_to_convective_gravity_wave_drag
   long_name = zonal wind tendency due to convective gravity wave drag
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [gwdcv]
   standard_name = tendency_of_y_wind_due_to_convective_gravity_wave_drag
   long_name = meridional wind tendency due to convective gravity wave drag
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [hefac]
@@ -8824,7 +8824,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_gfdl_microphysics_scheme .or. flag_for_microphysics_scheme == flag_for_thompson_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_gfdl_microphysics_scheme .or. control_for_microphysics_scheme == identifier_for_thompson_microphysics_scheme)
 [dry]
   standard_name = flag_nonzero_land_surface_fraction
   long_name = flag indicating presence of some land surface area fraction
@@ -8940,7 +8940,7 @@
   dimensions = ()
   type = integer
 [levi]
-  standard_name = vertical_interface_dimension
+  standard_name = vertical_interface_dimension_interstitial
   long_name = vertical interface dimension
   units = count
   dimensions = ()
@@ -8991,15 +8991,15 @@
   standard_name = local_graupel_number_concentration
   long_name = number concentration of graupel local to physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [ncpi]
   standard_name = local_ice_number_concentration
   long_name = number concentration of ice local to physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_shoc)
@@ -9007,7 +9007,7 @@
   standard_name = local_condesed_water_number_concentration
   long_name = number concentration of condensed water local to physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_shoc)
@@ -9015,18 +9015,18 @@
   standard_name = local_rain_number_concentration
   long_name = number concentration of rain local to physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [ncps]
   standard_name = local_snow_number_concentration
   long_name = number concentration of snow local to physics
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [ncstrac]
   standard_name = number_of_tracers_for_CS
   long_name = number of convectively transported tracers in Chikira-Sugiyama deep convection scheme
@@ -9107,42 +9107,42 @@
   type = integer
 [oa4]
   standard_name = asymmetry_of_subgrid_orography
-  long_name = asymmetry of subgrid orography
+  long_name = asymmetry of subgrid height_above_mean_sea_level
   units = none
   dimensions = (horizontal_loop_extent,4)
   type = real
   kind = kind_phys
 [varss]
   standard_name = standard_deviation_of_subgrid_orography_small_scale
-  long_name = standard deviation of subgrid orography small scale
+  long_name = standard deviation of subgrid height_above_mean_sea_level small scale
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (gwd_opt == 3 .or. gwd_opt == 33)
+  active = (control_for_drag_suite_gravity_wave_drag == 3 .or. control_for_drag_suite_gravity_wave_drag == 33)
 [oa4ss]
   standard_name = asymmetry_of_subgrid_orography_small_scale
-  long_name = asymmetry of subgrid orography small scale
+  long_name = asymmetry of subgrid height_above_mean_sea_level small scale
   units = none
   dimensions = (horizontal_loop_extent,4)
   type = real
   kind = kind_phys
-  active = (gwd_opt == 3 .or. gwd_opt == 33)
+  active = (control_for_drag_suite_gravity_wave_drag == 3 .or. control_for_drag_suite_gravity_wave_drag == 33)
 [oc]
   standard_name = convexity_of_subgrid_orography
-  long_name = convexity of subgrid orography
+  long_name = convexity of subgrid height_above_mean_sea_level
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [ocss]
   standard_name = convexity_of_subgrid_orography_small_scale
-  long_name = convexity of subgrid orography small scale
+  long_name = convexity of subgrid height_above_mean_sea_level small scale
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (gwd_opt == 3 .or. gwd_opt == 33)
+  active = (control_for_drag_suite_gravity_wave_drag == 3 .or. control_for_drag_suite_gravity_wave_drag == 33)
 [olyr]
   standard_name = ozone_concentration_at_layer_for_radiation
   long_name = ozone concentration layer
@@ -9186,7 +9186,7 @@
   standard_name = prandtl_number
   long_name = turbulent Prandtl number
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [q2mp]
@@ -9196,31 +9196,31 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [qgl]
   standard_name = local_graupel_mixing_ratio
   long_name = ratio of mass of graupel to mass of dry air plus vapor (without condensates) local to physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme .or. flag_for_shoc)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme .or. flag_for_shoc)
 [qicn]
   standard_name = mass_fraction_of_convective_cloud_ice
   long_name = mass fraction of convective cloud ice water
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [qlcn]
   standard_name = mass_fraction_of_convective_cloud_liquid_water
   long_name = mass fraction of convective cloud liquid water
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [qlyr]
   standard_name = water_vapor_specific_humidity_at_layer_for_radiation
   long_name = specific humidity layer
@@ -9232,18 +9232,18 @@
   standard_name = local_rain_water_mixing_ratio
   long_name = ratio of mass of rain water to mass of dry air plus vapor (without condensates) local to physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme .or. flag_for_shoc)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme .or. flag_for_shoc)
 [qsnw]
   standard_name = local_snow_water_mixing_ratio
   long_name = ratio of mass of snow water to mass of dry air plus vapor (without condensates) local to physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme .or. flag_for_shoc)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme .or. flag_for_shoc)
 [prcpmp]
   standard_name = lwe_thickness_of_explicit_precipitation_amount
   long_name = explicit precipitation (rain, ice, snow, graupel, ...) on physics timestep
@@ -9279,7 +9279,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [qv1]
   standard_name = bounded_specific_humidity_at_lowest_model_layer_over_land
   long_name = specific humidity at lowest model layer over land bounded between a nonzero epsilon and saturation
@@ -9287,7 +9287,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [radar_reset]
   standard_name = flag_for_resetting_radar_reflectivity_calculation
   long_name = flag for resetting radar reflectivity calculation
@@ -9329,12 +9329,12 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_gfdl_microphysics_scheme .or. flag_for_microphysics_scheme == flag_for_thompson_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_gfdl_microphysics_scheme .or. control_for_microphysics_scheme == identifier_for_thompson_microphysics_scheme)
 [rainp]
   standard_name = tendency_of_rain_water_mixing_ratio_due_to_microphysics
   long_name = tendency of rain water mixing ratio due to microphysics
   units = kg kg-1 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [rb]
@@ -9375,7 +9375,7 @@
   standard_name = critical_relative_humidity
   long_name = critical relative humidity
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [rho1]
@@ -9399,68 +9399,68 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
-[save_q(:,:,index_for_ozone)]
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
+[save_q(:,:,index_of_ozone_mixing_ratio_in_tracer_concentration_array)]
   standard_name = ozone_mixing_ratio_save
   long_name = ozone mixing ratio before entering a physics scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[save_q(:,:,index_for_liquid_cloud_condensate)]
+[save_q(:,:,index_of_cloud_liquid_water_mixing_ratio_in_tracer_concentration_array)]
   standard_name = cloud_condensed_water_mixing_ratio_save
   long_name = ratio of mass of cloud water to mass of dry air plus vapor (without condensates) before entering a physics scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[save_q(:,:,index_for_ice_cloud_condensate)]
+[save_q(:,:,index_of_cloud_ice_mixing_ratio_in_tracer_concentration_array)]
   standard_name = ice_water_mixing_ratio_save
   long_name = cloud ice water mixing ratio before entering a physics scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-[save_q(:,:,index_for_water_vapor)]
+[save_q(:,:,index_of_specific_humidity_in_tracer_concentration_array)]
   standard_name = water_vapor_specific_humidity_save
   long_name = water vapor specific humidity before entering a physics scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [save_q]
   standard_name = tracer_concentration_save
   long_name = tracer concentration before entering a physics scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
 [save_t]
   standard_name = air_temperature_save
   long_name = air temperature before entering a physics scheme
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [save_tcp]
   standard_name = air_temperature_save_from_convective_parameterization
   long_name = air temperature after cumulus parameterization
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [save_u]
   standard_name = x_wind_save
   long_name = x-wind before entering a physics scheme
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [save_v]
   standard_name = y_wind_save
   long_name = y-wind before entering a physics scheme
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [sbsno]
@@ -9513,7 +9513,7 @@
   kind = kind_phys
 [sigma]
   standard_name = slope_of_subgrid_orography
-  long_name = slope of subgrid orography
+  long_name = slope of subgrid height_above_mean_sea_level
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
@@ -9529,14 +9529,14 @@
   standard_name = convective_updraft_area_fraction
   long_name = convective updraft area fraction
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [sigmatot]
   standard_name = convective_updraft_area_fraction_at_model_interfaces
   long_name = convective updraft area fraction at model interfaces
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [skip_macro]
@@ -9549,10 +9549,10 @@
   standard_name = volume_fraction_of_unfrozen_soil_moisture_save
   long_name = liquid soil moisture before entering a physics scheme
   units = frac
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [slopetype]
   standard_name = surface_slope_classification
   long_name = surface slope type at each grid cell
@@ -9566,15 +9566,15 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [smc_save]
   standard_name = volume_fraction_of_soil_moisture_save
   long_name = total soil moisture before entering a physics scheme
   units = frac
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [snowc]
   standard_name = surface_snow_area_fraction
   long_name = surface snow area fraction
@@ -9603,7 +9603,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [snowd_ice]
   standard_name = surface_snow_thickness_water_equivalent_over_ice
   long_name = water equivalent snow depth over ice
@@ -9618,7 +9618,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [snohf]
   standard_name = snow_freezing_rain_upward_latent_heat_flux
   long_name = latent heat flux due to snow and frz rain
@@ -9633,7 +9633,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [snohf_frzgra]
   standard_name = latent_heat_flux_from_freezing_rain
   long_name = latent heat flux due to freezing rain
@@ -9641,7 +9641,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [snohf_snowmelt]
   standard_name = latent_heat_flux_due_to_snowmelt
   long_name = latent heat flux due to snowmelt phase change
@@ -9649,7 +9649,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [snowmp]
   standard_name = lwe_thickness_of_snow_amount
   long_name = explicit snow fall on physics timestep
@@ -9657,7 +9657,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_gfdl_microphysics_scheme .or. flag_for_microphysics_scheme == flag_for_thompson_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_gfdl_microphysics_scheme .or. control_for_microphysics_scheme == identifier_for_thompson_microphysics_scheme)
 [snowmt]
   standard_name = surface_snow_melt
   long_name = snow melt during timestep
@@ -9672,7 +9672,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [soiltype]
   standard_name = soil_type_classification
   long_name = soil type at each grid cell
@@ -9683,10 +9683,10 @@
   standard_name = soil_temperature_save
   long_name = soil temperature before entering a physics scheme
   units = K
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [stress]
   standard_name = surface_wind_stress
   long_name = surface wind stress
@@ -9722,7 +9722,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noahmp_land_surface_scheme)
 [theta]
   standard_name = angle_from_east_of_maximum_subgrid_orographic_variations
   long_name = angle with_respect to east of maximum subgrid orographic variations
@@ -9737,7 +9737,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [tice]
   standard_name = sea_ice_temperature_interstitial
   long_name = sea ice surface skin temperature use as interstitial
@@ -9787,7 +9787,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [tracers_start_index]
   standard_name = start_index_of_other_tracers
   long_name = beginning index of the non-water tracer species
@@ -9848,7 +9848,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [tsfc_ice]
   standard_name = surface_skin_temperature_over_ice_interstitial
   long_name = surface skin temperature over ice   (temporary use as interstitial)
@@ -9894,7 +9894,7 @@
   standard_name = instantaneous_atmosphere_updraft_convective_mass_flux
   long_name = (updraft mass flux) * delt
   units = kg m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [uustar_water]
@@ -9922,7 +9922,7 @@
   standard_name = vertically_diffused_tracer_concentration
   long_name = tracer concentration diffused by PBL scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_vertical_diffusion_tracers)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_vertical_diffusion_tracers)
   type = real
   kind = kind_phys
 [lndp_vgf]
@@ -9949,10 +9949,10 @@
   standard_name = vertical_velocity_for_updraft
   long_name = vertical velocity for updraft
   units = m s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_microphysics_scheme == flag_for_morrison_gettelman_microphysics_scheme)
+  active = (control_for_microphysics_scheme == identifier_for_morrison_gettelman_microphysics_scheme)
 [wcbmax]
   standard_name = maximum_updraft_velocity_at_cloud_base
   long_name = maximum updraft velocity at cloud base
@@ -9981,7 +9981,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
+  active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [weasd_ice]
   standard_name = water_equivalent_accumulated_snow_depth_over_ice
   long_name = water equiv of acc snow depth over ice
@@ -10084,34 +10084,34 @@
   standard_name = tendency_of_x_wind_due_to_nonorographic_gravity_wave_drag
   long_name = zonal wind tendency due to non-stationary GWs
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dvdt_ngw]
   standard_name = tendency_of_y_wind_due_to_nonorographic_gravity_wave_drag
   long_name = meridional wind tendency due to non-stationary GWs
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [dtdt_ngw]
   standard_name = tendency_of_air_temperature_due_to_nonorographic_gravity_wave_drag
   long_name = air temperature tendency due to non-stationary GWs
   units = K s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [kdis_ngw]
   standard_name = atmosphere_momentum_diffusivity_due_to_nonorographic_gravity_wave_drag
   long_name = eddy mixing due to non-stationary GWs
   units = m2 s-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. gwd_opt==33 .or. gwd_opt==22 .or. gwd_opt==3 .or. gwd_opt==2)
+  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
 [zlwb]
   standard_name = height_of_low_level_wave_breaking
   long_name = height of low level wave breaking
@@ -10172,21 +10172,21 @@
   standard_name = instantaneous_change_in_x_wind_due_to_mountain_blocking_drag
   long_name = instantaneous change in x wind due to mountain blocking drag
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [dudt_tms]
   standard_name = tendency_of_x_wind_due_to_turbulent_orographic_form_drag
   long_name = instantaneous change in x wind due to TOFD
   units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [qs_lay]
   standard_name = saturation_vapor_pressure
   long_name = saturation vapor pressure
   units = Pa
-  dimensions = (horizontal_dimension,vertical_dimension)
+  dimensions = (horizontal_dimension,vertical_layer_dimension)
   type = real
   kind = kind_phys
   optional = F
@@ -10195,7 +10195,7 @@
   standard_name = water_vapor_mixing_ratio
   long_name = water vaport mixing ratio
   units = kg/kg
-  dimensions = (horizontal_dimension,vertical_dimension)
+  dimensions = (horizontal_dimension,vertical_layer_dimension)
   type = real
   kind = kind_phys
   optional = F
@@ -10204,7 +10204,7 @@
   standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
   long_name = air pressure layer
   units = hPa
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10212,7 +10212,7 @@
   standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
   long_name = air pressure level
   units = hPa
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10220,7 +10220,7 @@
   standard_name = air_temperature_at_layer_for_RRTMGP
   long_name = air temperature layer
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10228,7 +10228,7 @@
   standard_name = air_temperature_at_interface_for_RRTMGP
   long_name = air temperature layer
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10236,7 +10236,7 @@
   standard_name = virtual_temperature
   long_name = layer virtual temperature
   units = K
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10244,7 +10244,7 @@
   standard_name = relative_humidity
   long_name = layer relative humidity
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10252,7 +10252,7 @@
   standard_name = layer_thickness
   long_name = layer_thickness
   units = m
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10260,7 +10260,7 @@
   standard_name = chemical_tracers
   long_name = chemical tracers
   units = g g-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10268,7 +10268,7 @@
   standard_name = cloud_overlap_param
   long_name = cloud overlap parameter for RRTMGP (but not for RRTMG)
   units = km
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10276,7 +10276,7 @@
   standard_name = precip_overlap_param
   long_name = precipitation overlap parameter
   units = km
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10296,21 +10296,21 @@
   standard_name = RRTMGP_cloud_optical_depth_layers_at_0_55mu_band
   long_name = approx .55mu band layer cloud optical depth
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [cldtaulw]
   standard_name = RRTMGP_cloud_optical_depth_layers_at_10mu_band
   long_name = approx 10mu band layer cloud optical depth
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
 [fluxlwUP_clrsky]
   standard_name = RRTMGP_lw_flux_profile_upward_clrsky
   long_name = RRTMGP upward longwave clr-sky flux profile
   units = W m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10318,7 +10318,7 @@
   standard_name = RRTMGP_lw_flux_profile_downward_clrsky
   long_name = RRTMGP downward longwave clr-sky flux profile
   units = W m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10326,7 +10326,7 @@
   standard_name = RRTMGP_sw_flux_profile_upward_allsky
   long_name = RRTMGP upward shortwave all-sky flux profile
   units = W m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10334,7 +10334,7 @@
   standard_name = RRTMGP_sw_flux_profile_downward_allsky
   long_name = RRTMGP downward shortwave all-sky flux profile
   units = W m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10342,7 +10342,7 @@
   standard_name = RRTMGP_sw_flux_profile_upward_clrsky
   long_name = RRTMGP upward shortwave clr-sky flux profile
   units = W m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10350,7 +10350,7 @@
   standard_name = RRTMGP_sw_flux_profile_downward_clrsky
   long_name = RRTMGP downward shortwave clr-sky flux profile
   units = W m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10358,21 +10358,21 @@
   standard_name = RRTMGP_lw_fluxes
   long_name = lw fluxes total sky / csk and up / down at levels
   units = W m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = proflw_type
   active = (flag_for_rrtmgp_radiation_scheme)
 [flxprf_sw]
   standard_name = RRTMGP_sw_fluxes
   long_name = sw fluxes total sky / csk and up / down at levels
   units = W m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = profsw_type
   active = (flag_for_rrtmgp_radiation_scheme)
 [aerosolslw]
   standard_name = RRTMGP_aerosol_optical_properties_for_longwave_bands_01_16
   long_name = aerosol optical properties for longwave bands 01-16
   units = various
-  dimensions = (horizontal_loop_extent,vertical_dimension, number_of_lw_bands_rrtmgp,number_of_aerosol_output_fields_for_longwave_radiation)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension, number_of_longwave_bands,number_of_aerosol_output_fields_for_longwave_radiation)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10380,28 +10380,28 @@
   standard_name = RRTMGP_aerosol_optical_depth_for_longwave_bands_01_16
   long_name = aerosol optical depth for longwave bands 01-16
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension, number_of_lw_bands_rrtmgp)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension, number_of_longwave_bands)
   type = real
   kind = kind_phys
 [aerosolslw(:,:,:,2)]
   standard_name = RRTMGP_aerosol_single_scattering_albedo_for_longwave_bands_01_16
   long_name = aerosol single scattering albedo for longwave bands 01-16
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension, number_of_lw_bands_rrtmgp)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension, number_of_longwave_bands)
   type = real
   kind = kind_phys
 [aerosolslw(:,:,:,3)]
   standard_name = RRTMGP_aerosol_asymmetry_parameter_for_longwave_bands_01_16
   long_name = aerosol asymmetry parameter for longwave bands 01-16
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension, number_of_lw_bands_rrtmgp)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension, number_of_longwave_bands)
   type = real
   kind = kind_phys
 [aerosolssw]
   standard_name = RRTMGP_aerosol_optical_properties_for_shortwave_bands_01_16
   long_name = aerosol optical properties for shortwave bands 01-16
   units = various
-  dimensions = (horizontal_loop_extent,vertical_dimension, number_of_sw_bands_rrtmgp, number_of_aerosol_output_fields_for_shortwave_radiation)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension, number_of_shortwave_bands, number_of_aerosol_output_fields_for_shortwave_radiation)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10409,21 +10409,21 @@
   standard_name = RRTMGP_aerosol_optical_depth_for_shortwave_bands_01_16
   long_name = aerosol optical depth for shortwave bands 01-16
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension, number_of_sw_bands_rrtmgp)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension, number_of_shortwave_bands)
   type = real
   kind = kind_phys
 [aerosolssw(:,:,:,2)]
   standard_name = RRTMGP_aerosol_single_scattering_albedo_for_shortwave_bands_01_16
   long_name = aerosol single scattering albedo for shortwave bands 01-16
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension, number_of_sw_bands_rrtmgp)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension, number_of_shortwave_bands)
   type = real
   kind = kind_phys
 [aerosolssw(:,:,:,3)]
   standard_name = RRTMGP_aerosol_asymmetry_parameter_for_shortwave_bands_01_16
   long_name = aerosol asymmetry parameter for shortwave bands 01-16
   units = none
-  dimensions = (horizontal_loop_extent,vertical_dimension, number_of_sw_bands_rrtmgp)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension, number_of_shortwave_bands)
   type = real
   kind = kind_phys
 [icseed_lw]
@@ -10444,7 +10444,7 @@
   standard_name = precipitation_fraction_by_layer
   long_name = precipitation fraction in each layer
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10550,7 +10550,7 @@
   standard_name = surface_emissivity_in_each_RRTMGP_LW_band
   long_name = surface emissivity in each RRTMGP LW band
   units = none
-  dimensions = (number_of_lw_bands_rrtmgp,horizontal_loop_extent)
+  dimensions = (number_of_longwave_bands,horizontal_loop_extent)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10558,7 +10558,7 @@
   standard_name = secant_of_diffusivity_angle_each_RRTMGP_LW_band
   long_name = secant of diffusivity angle in each RRTMGP LW band
   units = none
-  dimensions = (number_of_lw_bands_rrtmgp,horizontal_loop_extent)
+  dimensions = (number_of_longwave_bands,horizontal_loop_extent)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10566,7 +10566,7 @@
   standard_name = surface_albedo_nearIR_direct
   long_name = near-IR (direct) surface albedo (sfc_alb_nir_dir)
   units = none
-  dimensions = (number_of_sw_bands_rrtmgp,horizontal_loop_extent)
+  dimensions = (number_of_shortwave_bands,horizontal_loop_extent)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10574,7 +10574,7 @@
   standard_name = surface_albedo_nearIR_diffuse
   long_name = near-IR (diffuse) surface albedo (sfc_alb_nir_dif)
   units = none
-  dimensions = (number_of_sw_bands_rrtmgp,horizontal_loop_extent)
+  dimensions = (number_of_shortwave_bands,horizontal_loop_extent)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10582,7 +10582,7 @@
   standard_name =  surface_albedo_uvvis_dir
   long_name = UVVIS (direct) surface albedo (sfc_alb_uvvis_dir)
   units = none
-  dimensions = (number_of_sw_bands_rrtmgp,horizontal_loop_extent)
+  dimensions = (number_of_shortwave_bands,horizontal_loop_extent)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10590,7 +10590,7 @@
   standard_name =  surface_albedo_uvvis_dif
   long_name = UVVIS (diffuse) surface albedo (sfc_alb_uvvis_dif)
   units = none
-  dimensions = (number_of_sw_bands_rrtmgp,horizontal_loop_extent)
+  dimensions = (number_of_shortwave_bands,horizontal_loop_extent)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10598,7 +10598,7 @@
   standard_name = toa_incident_lw_flux_by_spectral_point
   long_name = TOA longwave incident flux at each spectral points
   units = W m-2
-  dimensions = (horizontal_loop_extent,number_of_lw_spectral_points_rrtmgp)
+  dimensions = (horizontal_loop_extent,number_of_longwave_spectral_points)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10606,7 +10606,7 @@
   standard_name = toa_incident_sw_flux_by_spectral_point
   long_name = TOA shortwave incident flux at each spectral points
   units = W m-2
-  dimensions = (horizontal_loop_extent,number_of_sw_spectral_points_rrtmgp)
+  dimensions = (horizontal_loop_extent,number_of_shortwave_spectral_points)
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
@@ -10893,7 +10893,7 @@
   type = real
   kind = kind_phys
 [con_rd]
-  standard_name = gas_constant_dry_air
+  standard_name = gas_constant_of_dry_air
   long_name = ideal gas constant for dry air
   units = J kg-1 K-1
   dimensions = ()
@@ -10970,7 +10970,7 @@
   type = real
   kind = kind_phys
 [rhowater]
-  standard_name = liquid_water_density
+  standard_name = fresh_liquid_water_density_at_0c
   long_name = density of liquid water
   units = kg m-3
   dimensions = ()


### PR DESCRIPTION
## Description

This pull request only changes CCPP standard names in metadata files for those FV3 variables that are needed by all CCPP physics schemes in the current ccpp-physics repository. There are NO functional code changes and therefore no change in expected answers as a result of this pull request.

The standard names should better correspond to CF conventions (https://cfconventions.org/Data/cf-standard-names/77/build/cf-standard-name-table.html) and the superset of names represented in the CCPPStandardNames repository (https://github.com/ESCOMP/CCPPStandardNames/pull/13). A set of rules (which again relies heavily on CF naming conventions) is added to that same repository by https://github.com/ESCOMP/CCPPStandardNames/pull/14 and is effectively an addendum to the CF conventions (http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html).

Note that this is only a partial update. Standard names for variables in the Diag and Interstitial derived data types as well as physical constants and other miscellaneous variables with metadata will be addressed in a future pull request.

### Issue(s) addressed

- partially fixes https://github.com/NCAR/ccpp-physics/issues/638

## Testing

These changes were tested as part of the existing set of UFS regression tests on Hera and CCPP-SCM regression tests.

## Dependencies

- waiting on https://github.com/NCAR/ccpp-physics/pull/687
- associated with https://github.com/ESCOMP/CCPPStandardNames/pull/13
- associated with https://github.com/NCAR/ccpp-scm/pull/269
