### PR TITLE
Cleanup grandfathered-in constants in CCPP - round 1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = main
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = main
-	url = https://github.com/XiaSun-Atmos/ccpp-physics
-	branch = constant
+	url = https://github.com/NCAR/ccpp-physics
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = main
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = main
+	url = https://github.com/XiaSun-Atmos/ccpp-physics
+	branch = constant

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -9,7 +9,7 @@ module GFS_typedefs
                                            con_epsm1, con_ttp, rlapse, con_jcal, con_rhw0, &
                                            con_sbc, con_tice, cimin, con_p0, rhowater,     &
                                            con_csol, con_epsqs, con_rocp, con_rog,         &
-                                           con_omega, con_rerth
+                                           con_omega, con_rerth, con_psat, karman, rainmin
 
        use module_radsw_parameters,  only: topfsw_type, sfcfsw_type, profsw_type, cmpfsw_type, NBDSW
        use module_radlw_parameters,  only: topflw_type, sfcflw_type, proflw_type, NBDLW

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -10922,3 +10922,24 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[con_psat]
+  standard_name = saturation_pressure_at_triple_point_of_water
+  long_name = saturation pressure at triple point of water
+  units = Pa
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[karman]
+  standard_name = von_karman_constant
+  long_name = Von Karman constant
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[rainmin]
+  standard_name = lwe_thickness_of_minimum_rain_amount
+  long_name = liquid water equivalent thickness of minimum rain amount
+  units = m
+  dimensions = ()
+  type = real
+  kind = kind_phys


### PR DESCRIPTION
## Description

This PR adds metadata for three constants that are required for the changes in PR https://github.com/NCAR/ccpp-physics/pull/525. The motivation behind these changes is that physical parameterizations should receive constants (e.g. gravitational acceleration) from the host model via the argument list instead of importing them from some Fortran module or defining them locally. This ensures consistency and enhances interoperability.

### Issue(s) addressed

These PRs are a step towards resolving issues https://github.com/NCAR/ccpp-physics/issues/104 and https://github.com/NCAR/ccpp-physics/issues/245.

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/726

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/525
https://github.com/NOAA-EMC/fv3atm/pull/360
https://github.com/ufs-community/ufs-weather-model/pull/726