### PR TITLE
fix the grid definition for inline post lambert conformal

### DIFF
--- a/io/post_regional.F90
+++ b/io/post_regional.F90
@@ -296,13 +296,7 @@ module post_regional
         else
           lonstart = nint(lon1*gdsdegr)
         endif
-        if( lon2<0 ) then
-          lonlast = nint((lon2+360.)*gdsdegr)
-        else
-          lonlast = nint(lon2*gdsdegr)
-        endif
         latstart = nint(lat1*gdsdegr)
-        latlast  = nint(lat2*gdsdegr)
 
         truelat1 = nint(stdlat1*gdsdegr)
         truelat2 = nint(stdlat2*gdsdegr)


### PR DESCRIPTION
## Description

Fix the grid definition issue for regional inline post lambert confirmal projection. There is no impact on the current RT as we don't have a RT test with Lambert Conformal projection.

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.

- fixes issue [#364](https://github.com/NOAA-EMC/fv3atm/issues/364)

## Testing

How were these changes tested?  
hera


## Dependencies

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs

- fv3atm [PR#365](https://github.com/NOAA-EMC/fv3atm/pull/365)
- ufs-weather-model [PR#724](https://github.com/ufs-community/ufs-weather-model/pull/724)
