### PR TITLE
CCPP framework update and metadata bug fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,13 +4,9 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	#url = https://github.com/NCAR/ccpp-framework
-	#branch = main
-	url = https://github.com/climbfuji/ccpp-framework
-	branch = merge_feature_capgen_into_main_20210812
+	url = https://github.com/NCAR/ccpp-framework
+	branch = main
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = main
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = merge_feature_capgen_into_main_20210812
+	url = https://github.com/NCAR/ccpp-physics
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,13 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
-	branch = main
+	#url = https://github.com/NCAR/ccpp-framework
+	#branch = main
+	url = https://github.com/climbfuji/ccpp-framework
+	branch = merge_feature_capgen_into_main_20210812
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = main
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = merge_feature_capgen_into_main_20210812

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -15,26 +15,27 @@ HOST_MODEL_IDENTIFIER = "FV3"
 # dependencies of these files to the list.
 VARIABLE_DEFINITION_FILES = [
     # actual variable definition files
+    'framework/src/ccpp_types.F90',
     'physics/physics/machine.F',
     'physics/physics/radsw_param.f',
+    'physics/physics/radlw_param.f',
     'physics/physics/h2o_def.f',
     'physics/physics/ozne_def.f',
-    'physics/physics/radlw_param.f',
     'physics/physics/radiation_surface.f',
-    'data/CCPP_typedefs.F90',
-    'data/GFS_typedefs.F90',
-    'data/CCPP_data.F90',
     'physics/physics/rte-rrtmgp/rrtmgp/mo_gas_optics_rrtmgp.F90',
     'physics/physics/rte-rrtmgp/rrtmgp/mo_gas_concentrations.F90',
     'physics/physics/rte-rrtmgp/rte/mo_optical_props.F90',
     'physics/physics/rte-rrtmgp/extensions/cloud_optics/mo_cloud_optics.F90',
     'physics/physics/rte-rrtmgp/rte/mo_source_functions.F90',
+    'data/CCPP_typedefs.F90',
+    'data/GFS_typedefs.F90',
+    'data/CCPP_data.F90',
     ]
 
 TYPEDEFS_NEW_METADATA = {
     'ccpp_types' : {
-        'ccpp_types' : '',
         'ccpp_t' : 'cdata',
+        'ccpp_types' : '',
         },
     'machine' : {
         'machine' : '',

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -2413,13 +2413,6 @@
   units = none
   dimensions = ()
   type = integer
-[fhzero]
-  standard_name = frequency_for_diagnostic_clearing
-  long_name = frequency for clearing diagnostic fields
-  units = h
-  dimensions = ()
-  type = real
-  kind = kind_phys
 [ldiag3d]
   standard_name = flag_for_diagnostics_3D
   long_name = flag for 3d diagnostic fields
@@ -10225,20 +10218,6 @@
   units = none
   dimensions = ()
   type = integer
-[cldtausw]
-  standard_name = RRTMGP_cloud_optical_depth_layers_at_0_55mu_band
-  long_name = approx .55mu band layer cloud optical depth
-  units = none
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
-  type = real
-  kind = kind_phys
-[cldtaulw]
-  standard_name = RRTMGP_cloud_optical_depth_layers_at_10mu_band
-  long_name = approx 10mu band layer cloud optical depth
-  units = none
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
-  type = real
-  kind = kind_phys
 [fluxlwUP_clrsky]
   standard_name = RRTMGP_lw_flux_profile_upward_clrsky
   long_name = RRTMGP upward longwave clr-sky flux profile


### PR DESCRIPTION
## Description

This PR updates the submodule pointers for ccpp-framework and ccpp-physics and fixes a few small bugs in the CCPP prebuild config (order of variable definition files, derived data type definitions must come first) and `GFS_typedefs.meta` (remove duplicate variables).

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/745.

## Dependencies

https://github.com/NCAR/ccpp-framework/pull/391
https://github.com/earth-system-radiation/rte-rrtmgp/pull/133
https://github.com/NCAR/ccpp-physics/pull/718
https://github.com/NOAA-EMC/fv3atm/pull/367
https://github.com/ufs-community/ufs-weather-model/pull/745
