### PR TITLE
Wrapper PR for #366 (remove redundant surface variables) and #363 (send correct pointers to JEDI)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = main
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = main
+	url = https://github.com/mzhangw/ccpp-physics
+	branch = redund_mzhang

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = main
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = main
-	url = https://github.com/mzhangw/ccpp-physics
-	branch = redund_mzhang
+	url = https://github.com/NCAR/ccpp-physics
+	branch = main

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -2513,6 +2513,7 @@ end subroutine atmos_data_type_chksum
     !--- local variables
     integer                :: i, j, k, idx, ix
     integer                :: isc, iec, jsc, jec
+    integer                :: isc_g, iec_g, jsc_g, jec_g
     integer                :: ib, jb, nb, nsb, nk
     integer                :: sphum, liq_wat, ice_wat, o3mr
     real(GFS_kind_phys)    :: rtime, rtimek
@@ -2585,6 +2586,10 @@ end subroutine atmos_data_type_chksum
       end if
 
       if (isFound) then
+          isc_g = Atm(mygrid)%bd%isc
+          iec_g = Atm(mygrid)%bd%iec
+          jsc_g = Atm(mygrid)%bd%jsc
+          jec_g = Atm(mygrid)%bd%jec
 !$omp parallel do default(shared) private(nb) reduction(max:localrc)
         do nb = 1, Atm_block%nblks
           select case (trim(fieldname))
@@ -2741,35 +2746,35 @@ end subroutine atmos_data_type_chksum
               call block_data_copy_or_fill(datar82d, DYCORE_data(nb)%coupling%z_bot, zeror8, Atm_block, nb, rc=localrc)
             !--- JEDI fields
             case ('u')
-              call block_atmos_copy(datar83d, Atm(mygrid)%u, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%u(isc_g:iec_g,jsc_g:jec_g,:), Atm_block, nb, rc=localrc)
             case ('v')
-              call block_atmos_copy(datar83d, Atm(mygrid)%v, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%v(isc_g:iec_g,jsc_g:jec_g,:), Atm_block, nb, rc=localrc)
             case ('ua')
-              call block_atmos_copy(datar83d, Atm(mygrid)%ua, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%ua(isc_g:iec_g,jsc_g:jec_g,:),Atm_block, nb, rc=localrc)
             case ('va')
-              call block_atmos_copy(datar83d, Atm(mygrid)%va, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%va(isc_g:iec_g,jsc_g:jec_g,:), Atm_block, nb, rc=localrc)
             case ('t')
-              call block_atmos_copy(datar83d, Atm(mygrid)%pt, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%pt(isc_g:iec_g,jsc_g:jec_g,:), Atm_block, nb, rc=localrc)
             case ('delp')
-              call block_atmos_copy(datar83d, Atm(mygrid)%delp, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%delp(isc_g:iec_g,jsc_g:jec_g,:), Atm_block, nb, rc=localrc)
             case ('sphum')
               sphum = get_tracer_index(MODEL_ATMOS, 'sphum')
-              call block_atmos_copy(datar83d, Atm(mygrid)%q, sphum, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc_g:iec_g,jsc_g:jec_g,:,:), sphum, Atm_block, nb, rc=localrc)
             case ('ice_wat')
               ice_wat = get_tracer_index(MODEL_ATMOS, 'ice_wat')
-              call block_atmos_copy(datar83d, Atm(mygrid)%q, ice_wat, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc_g:iec_g,jsc_g:jec_g,:,:), ice_wat, Atm_block, nb, rc=localrc)
             case ('liq_wat')
               liq_wat = get_tracer_index(MODEL_ATMOS, 'liq_wat')
-              call block_atmos_copy(datar83d, Atm(mygrid)%q, liq_wat, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc_g:iec_g,jsc_g:jec_g,:,:), liq_wat, Atm_block, nb, rc=localrc)
             case ('o3mr')
               o3mr = get_tracer_index(MODEL_ATMOS, 'o3mr')
-              call block_atmos_copy(datar83d, Atm(mygrid)%q, o3mr, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc_g:iec_g,jsc_g:jec_g,:,:), o3mr, Atm_block, nb, rc=localrc)
             case ('phis')
-              call block_atmos_copy(datar82d, Atm(mygrid)%phis, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar82d, Atm(mygrid)%phis(isc_g:iec_g,jsc_g:jec_g), Atm_block, nb, rc=localrc)
             case ('u_srf')
-              call block_atmos_copy(datar82d, Atm(mygrid)%u_srf, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar82d, Atm(mygrid)%u_srf(isc_g:iec_g,jsc_g:jec_g), Atm_block, nb, rc=localrc)
             case ('v_srf')
-              call block_atmos_copy(datar82d, Atm(mygrid)%v_srf, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar82d, Atm(mygrid)%v_srf(isc_g:iec_g,jsc_g:jec_g), Atm_block, nb, rc=localrc)
             case ('weasd')
               call block_data_copy(datar82d, GFS_data(nb)%sfcprop%weasd, Atm_block, nb, rc=localrc)
             case ('tsea')
@@ -2797,7 +2802,7 @@ end subroutine atmos_data_type_chksum
           end select
         enddo
         if (ESMF_LogFoundError(rcToCheck=localrc, msg="Failure to populate exported field: "//trim(fieldname), &
-                               line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+          line=__LINE__, file=__FILE__, rcToReturn=rc)) return
       endif
     enddo ! exportFields
 

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -2513,7 +2513,6 @@ end subroutine atmos_data_type_chksum
     !--- local variables
     integer                :: i, j, k, idx, ix
     integer                :: isc, iec, jsc, jec
-    integer                :: isc_g, iec_g, jsc_g, jec_g
     integer                :: ib, jb, nb, nsb, nk
     integer                :: sphum, liq_wat, ice_wat, o3mr
     real(GFS_kind_phys)    :: rtime, rtimek
@@ -2586,10 +2585,6 @@ end subroutine atmos_data_type_chksum
       end if
 
       if (isFound) then
-          isc_g = Atm(mygrid)%bd%isc
-          iec_g = Atm(mygrid)%bd%iec
-          jsc_g = Atm(mygrid)%bd%jsc
-          jec_g = Atm(mygrid)%bd%jec
 !$omp parallel do default(shared) private(nb) reduction(max:localrc)
         do nb = 1, Atm_block%nblks
           select case (trim(fieldname))
@@ -2746,35 +2741,35 @@ end subroutine atmos_data_type_chksum
               call block_data_copy_or_fill(datar82d, DYCORE_data(nb)%coupling%z_bot, zeror8, Atm_block, nb, rc=localrc)
             !--- JEDI fields
             case ('u')
-              call block_atmos_copy(datar83d, Atm(mygrid)%u(isc_g:iec_g,jsc_g:jec_g,:), Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%u(isc:iec,jsc:jec,:), Atm_block, nb, rc=localrc)
             case ('v')
-              call block_atmos_copy(datar83d, Atm(mygrid)%v(isc_g:iec_g,jsc_g:jec_g,:), Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%v(isc:iec,jsc:jec,:), Atm_block, nb, rc=localrc)
             case ('ua')
-              call block_atmos_copy(datar83d, Atm(mygrid)%ua(isc_g:iec_g,jsc_g:jec_g,:),Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%ua(isc:iec,jsc:jec,:),Atm_block, nb, rc=localrc)
             case ('va')
-              call block_atmos_copy(datar83d, Atm(mygrid)%va(isc_g:iec_g,jsc_g:jec_g,:), Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%va(isc:iec,jsc:jec,:), Atm_block, nb, rc=localrc)
             case ('t')
-              call block_atmos_copy(datar83d, Atm(mygrid)%pt(isc_g:iec_g,jsc_g:jec_g,:), Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%pt(isc:iec,jsc:jec,:), Atm_block, nb, rc=localrc)
             case ('delp')
-              call block_atmos_copy(datar83d, Atm(mygrid)%delp(isc_g:iec_g,jsc_g:jec_g,:), Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%delp(isc:iec,jsc:jec,:), Atm_block, nb, rc=localrc)
             case ('sphum')
               sphum = get_tracer_index(MODEL_ATMOS, 'sphum')
-              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc_g:iec_g,jsc_g:jec_g,:,:), sphum, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc:iec,jsc:jec,:,:), sphum, Atm_block, nb, rc=localrc)
             case ('ice_wat')
               ice_wat = get_tracer_index(MODEL_ATMOS, 'ice_wat')
-              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc_g:iec_g,jsc_g:jec_g,:,:), ice_wat, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc:iec,jsc:jec,:,:), ice_wat, Atm_block, nb, rc=localrc)
             case ('liq_wat')
               liq_wat = get_tracer_index(MODEL_ATMOS, 'liq_wat')
-              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc_g:iec_g,jsc_g:jec_g,:,:), liq_wat, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc:iec,jsc:jec,:,:), liq_wat, Atm_block, nb, rc=localrc)
             case ('o3mr')
               o3mr = get_tracer_index(MODEL_ATMOS, 'o3mr')
-              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc_g:iec_g,jsc_g:jec_g,:,:), o3mr, Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar83d, Atm(mygrid)%q(isc:iec,jsc:jec,:,:), o3mr, Atm_block, nb, rc=localrc)
             case ('phis')
-              call block_atmos_copy(datar82d, Atm(mygrid)%phis(isc_g:iec_g,jsc_g:jec_g), Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar82d, Atm(mygrid)%phis(isc:iec,jsc:jec), Atm_block, nb, rc=localrc)
             case ('u_srf')
-              call block_atmos_copy(datar82d, Atm(mygrid)%u_srf(isc_g:iec_g,jsc_g:jec_g), Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar82d, Atm(mygrid)%u_srf(isc:iec,jsc:jec), Atm_block, nb, rc=localrc)
             case ('v_srf')
-              call block_atmos_copy(datar82d, Atm(mygrid)%v_srf(isc_g:iec_g,jsc_g:jec_g), Atm_block, nb, rc=localrc)
+              call block_atmos_copy(datar82d, Atm(mygrid)%v_srf(isc:iec,jsc:jec), Atm_block, nb, rc=localrc)
             case ('weasd')
               call block_data_copy(datar82d, GFS_data(nb)%sfcprop%weasd, Atm_block, nb, rc=localrc)
             case ('tsea')

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -2079,7 +2079,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: tseal(:)           => null()  !<
     real (kind=kind_phys), pointer      :: tsfa(:)            => null()  !<
     real (kind=kind_phys), pointer      :: tsfc_ice(:)        => null()  !<
-!    real (kind=kind_phys), pointer      :: tsfc_land(:)       => null()  !<
     real (kind=kind_phys), pointer      :: tsfc_land_save(:)  => null()  !<
     real (kind=kind_phys), pointer      :: tsfc_water(:)      => null()  !<
     real (kind=kind_phys), pointer      :: tsfg(:)            => null()  !<
@@ -7151,7 +7150,6 @@ module GFS_typedefs
     allocate (Interstitial%tseal           (IM))
     allocate (Interstitial%tsfa            (IM))
     allocate (Interstitial%tsfc_ice        (IM))
-!    allocate (Interstitial%tsfc_land       (IM))
     allocate (Interstitial%tsfc_water      (IM))
     allocate (Interstitial%tsfg            (IM))
     allocate (Interstitial%tsurf_ice       (IM))
@@ -7885,7 +7883,6 @@ module GFS_typedefs
     Interstitial%trans           = clear_val
     Interstitial%tseal           = clear_val
     Interstitial%tsfc_ice        = huge
-!    Interstitial%tsfc_land       = huge
     Interstitial%tsfc_water      = huge
     Interstitial%tsurf_ice       = huge
     Interstitial%tsurf_land      = huge
@@ -8274,7 +8271,6 @@ module GFS_typedefs
     write (0,*) 'sum(Interstitial%tseal           ) = ', sum(Interstitial%tseal           )
     write (0,*) 'sum(Interstitial%tsfa            ) = ', sum(Interstitial%tsfa            )
     write (0,*) 'sum(Interstitial%tsfc_ice        ) = ', sum(Interstitial%tsfc_ice        )
-!    write (0,*) 'sum(Interstitial%tsfc_land       ) = ', sum(Interstitial%tsfc_land       )
     write (0,*) 'sum(Interstitial%tsfc_water      ) = ', sum(Interstitial%tsfc_water      )
     write (0,*) 'sum(Interstitial%tsfg            ) = ', sum(Interstitial%tsfg            )
     write (0,*) 'sum(Interstitial%tsurf_ice       ) = ', sum(Interstitial%tsurf_ice       )

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -2076,7 +2076,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: tseal(:)           => null()  !<
     real (kind=kind_phys), pointer      :: tsfa(:)            => null()  !<
     real (kind=kind_phys), pointer      :: tsfc_ice(:)        => null()  !<
-    real (kind=kind_phys), pointer      :: tsfc_land(:)       => null()  !<
+!    real (kind=kind_phys), pointer      :: tsfc_land(:)       => null()  !<
     real (kind=kind_phys), pointer      :: tsfc_land_save(:)  => null()  !<
     real (kind=kind_phys), pointer      :: tsfc_water(:)      => null()  !<
     real (kind=kind_phys), pointer      :: tsfg(:)            => null()  !<
@@ -7129,7 +7129,7 @@ module GFS_typedefs
     allocate (Interstitial%tseal           (IM))
     allocate (Interstitial%tsfa            (IM))
     allocate (Interstitial%tsfc_ice        (IM))
-    allocate (Interstitial%tsfc_land       (IM))
+!    allocate (Interstitial%tsfc_land       (IM))
     allocate (Interstitial%tsfc_water      (IM))
     allocate (Interstitial%tsfg            (IM))
     allocate (Interstitial%tsurf_ice       (IM))
@@ -7863,7 +7863,7 @@ module GFS_typedefs
     Interstitial%trans           = clear_val
     Interstitial%tseal           = clear_val
     Interstitial%tsfc_ice        = huge
-    Interstitial%tsfc_land       = huge
+!    Interstitial%tsfc_land       = huge
     Interstitial%tsfc_water      = huge
     Interstitial%tsurf_ice       = huge
     Interstitial%tsurf_land      = huge
@@ -8252,7 +8252,7 @@ module GFS_typedefs
     write (0,*) 'sum(Interstitial%tseal           ) = ', sum(Interstitial%tseal           )
     write (0,*) 'sum(Interstitial%tsfa            ) = ', sum(Interstitial%tsfa            )
     write (0,*) 'sum(Interstitial%tsfc_ice        ) = ', sum(Interstitial%tsfc_ice        )
-    write (0,*) 'sum(Interstitial%tsfc_land       ) = ', sum(Interstitial%tsfc_land       )
+!    write (0,*) 'sum(Interstitial%tsfc_land       ) = ', sum(Interstitial%tsfc_land       )
     write (0,*) 'sum(Interstitial%tsfc_water      ) = ', sum(Interstitial%tsfc_water      )
     write (0,*) 'sum(Interstitial%tsfg            ) = ', sum(Interstitial%tsfg            )
     write (0,*) 'sum(Interstitial%tsurf_ice       ) = ', sum(Interstitial%tsurf_ice       )

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -2056,7 +2056,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: t2mmp(:)           => null()  !<
     real (kind=kind_phys), pointer      :: theta(:)           => null()  !<
     real (kind=kind_phys), pointer      :: th1(:)             => null()  !<
-    real (kind=kind_phys), pointer      :: tice(:)            => null()  !<
     real (kind=kind_phys), pointer      :: tlvl(:,:)          => null()  !<
     real (kind=kind_phys), pointer      :: tlyr(:,:)          => null()  !<
     real (kind=kind_phys), pointer      :: tprcp_ice(:)       => null()  !<
@@ -7095,7 +7094,6 @@ module GFS_typedefs
     allocate (Interstitial%stress_land     (IM))
     allocate (Interstitial%stress_water    (IM))
     allocate (Interstitial%theta           (IM))
-    allocate (Interstitial%tice            (IM))
     allocate (Interstitial%tlvl            (IM,Model%levr+1+LTP))
     allocate (Interstitial%tlyr            (IM,Model%levr+LTP))
     allocate (Interstitial%tprcp_ice       (IM))
@@ -7833,7 +7831,6 @@ module GFS_typedefs
     Interstitial%stress_land     = huge
     Interstitial%stress_water    = huge
     Interstitial%theta           = clear_val
-    Interstitial%tice            = clear_val
     Interstitial%tprcp_ice       = huge
     Interstitial%tprcp_land      = huge
     Interstitial%tprcp_water     = huge
@@ -8220,7 +8217,6 @@ module GFS_typedefs
     write (0,*) 'sum(Interstitial%stress_land     ) = ', sum(Interstitial%stress_land     )
     write (0,*) 'sum(Interstitial%stress_water    ) = ', sum(Interstitial%stress_water    )
     write (0,*) 'sum(Interstitial%theta           ) = ', sum(Interstitial%theta           )
-    write (0,*) 'sum(Interstitial%tice            ) = ', sum(Interstitial%tice            )
     write (0,*) 'sum(Interstitial%tlvl            ) = ', sum(Interstitial%tlvl            )
     write (0,*) 'sum(Interstitial%tlyr            ) = ', sum(Interstitial%tlyr            )
     write (0,*) 'sum(Interstitial%tprcp_ice       ) = ', sum(Interstitial%tprcp_ice       )

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -8247,8 +8247,8 @@
   type = real
   kind = kind_phys
 [semis_water]
-  standard_name = surface_longwave_emissivity_over_water_interstitial
-  long_name = surface lw emissivity in fraction over water (temporary use as interstitial)
+  standard_name = surface_longwave_emissivity_over_water
+  long_name = surface lw emissivity in fraction over water
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
@@ -9808,13 +9808,6 @@
 [tsfc_water]
   standard_name = surface_skin_temperature_over_water
   long_name = surface skin temperature over water
-  units = K
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-[tsfc_land]
-  standard_name = surface_skin_temperature_over_land_interstitial
-  long_name = surface skin temperature over land  (temporary use as interstitial)
   units = K
   dimensions = (horizontal_loop_extent)
   type = real

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -9685,13 +9685,6 @@
   type = real
   kind = kind_phys
   active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
-[tice]
-  standard_name = sea_ice_temperature_interstitial
-  long_name = sea ice surface skin temperature use as interstitial
-  units = K
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
 [tlvl]
   standard_name = air_temperature_at_interface_for_radiation
   long_name = air temperature at vertical interface for radiation calculation

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -9768,8 +9768,8 @@
   type = real
   kind = kind_phys
 [tsfc_water]
-  standard_name = surface_skin_temperature_over_water_interstitial
-  long_name = surface skin temperature over water (temporary use as interstitial)
+  standard_name = surface_skin_temperature_over_water
+  long_name = surface skin temperature over water
   units = K
   dimensions = (horizontal_loop_extent)
   type = real

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -7493,22 +7493,22 @@
   kind = kind_phys
   active = (control_for_microphysics_scheme == identifier_for_fer_hires_microphysics_scheme)
 [adjsfculw_water]
-  standard_name = surface_upwelling_longwave_flux_over_water_interstitial
-  long_name = surface upwelling longwave flux at current time over water (temporary use as interstitial)
+  standard_name = surface_upwelling_longwave_flux_over_water
+  long_name = surface upwelling longwave flux at current time over water
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [adjsfculw_land]
-  standard_name = surface_upwelling_longwave_flux_over_land_interstitial
-  long_name = surface upwelling longwave flux at current time over land (temporary use as interstitial)
+  standard_name = surface_upwelling_longwave_flux_over_land
+  long_name = surface upwelling longwave flux at current time over land
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [adjsfculw_ice]
-  standard_name = surface_upwelling_longwave_flux_over_ice_interstitial
-  long_name = surface upwelling longwave flux at current time over ice (temporary use as interstitial)
+  standard_name = surface_upwelling_longwave_flux_over_ice
+  long_name = surface upwelling longwave flux at current time over ice
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -9790,8 +9790,8 @@
   kind = kind_phys
   active = (control_for_land_surface_scheme == identifier_for_noah_wrfv4_land_surface_scheme)
 [tsfc_ice]
-  standard_name = surface_skin_temperature_over_ice_interstitial
-  long_name = surface skin temperature over ice   (temporary use as interstitial)
+  standard_name = surface_skin_temperature_over_ice
+  long_name = surface skin temperature over ice
   units = K
   dimensions = (horizontal_loop_extent)
   type = real

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -9781,8 +9781,8 @@
   type = real
   kind = kind_phys
 [tsfc_land_save]
-  standard_name = surface_skin_temperature_over_land_interstitial_save
-  long_name = surface skin temperature over land before entering a physics scheme (temporary use as interstitial)
+  standard_name = surface_skin_temperature_over_land_save
+  long_name = surface skin temperature over land before entering a physics scheme
   units = K
   dimensions = (horizontal_loop_extent)
   type = real


### PR DESCRIPTION
## Description

This PR is a wrapper for #366 and #363, see these PRs for details on the code changes:
- Remove redundant surface variables (from @mzhangw)
- Updates to send correct pointers to JEDI (from @mark-a-potts)

### Issue(s) addressed

Fixes https://github.com/NOAA-EMC/fv3atm/issues/370.

## Testing

Code change in #363 do not affect the ufs-weather-model runs. Code changes in #366 were tested on orion.intel against the existing baseline by @mzhangw, all tests passed.

See https://github.com/ufs-community/ufs-weather-model/pull/747 for final regression testing.

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/717
https://github.com/NOAA-EMC/fv3atm/pull/368
https://github.com/ufs-community/ufs-weather-model/pull/747
