### PR TITLE
Fix stochastic physics restart runs, remove rayleigh damping from all suite definition files

### DIFF
--- a/ccpp/suites/suite_FV3_CPT_v0.xml
+++ b/ccpp/suites/suite_FV3_CPT_v0.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_coupled.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_coupled.xml
@@ -59,7 +59,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_couplednsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_couplednsst.xml
@@ -61,7 +61,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_csawmg.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_csawmgshoc.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_csawmgshoc.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_fv3wam.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_fv3wam.xml
@@ -58,7 +58,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_noahmp.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_noahmp.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional_c768.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional_c768.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_h2ophys.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_h2ophys.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_myj.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_myj.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_ntiedtke.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_ntiedtke.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_ozphys_2015.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_ozphys_2015.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_sas.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_sas.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_satmedmf.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_satmedmf.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_satmedmf_coupled.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_satmedmf_coupled.xml
@@ -59,7 +59,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_satmedmfq.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_satmedmfq.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_shinhong.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_shinhong.xml
@@ -64,7 +64,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_2017_ysu.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_ysu.xml
@@ -64,7 +64,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_gf.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_gf.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_gf_thompson.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_gf_thompson.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_mynn.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_RRTMGP.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_RRTMGP.xml
@@ -70,7 +70,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
@@ -59,7 +59,6 @@
       <scheme>GFS_GWD_generic_pre</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2_RRTMGP.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2_RRTMGP.xml
@@ -75,7 +75,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2_coupled.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2_coupled.xml
@@ -64,7 +64,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2_couplednsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2_couplednsst.xml
@@ -66,7 +66,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2_no_nsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2_no_nsst.xml
@@ -63,7 +63,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15plus.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15plus.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_RRTMGP.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_RRTMGP.xml
@@ -75,7 +75,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_coupled.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_coupled.xml
@@ -64,7 +64,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_coupled_noahmp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_coupled_noahmp.xml
@@ -64,7 +64,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_coupled_nsstNoahmp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_coupled_nsstNoahmp.xml
@@ -66,7 +66,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_couplednsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_couplednsst.xml
@@ -66,7 +66,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_flake.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_flake.xml
@@ -66,7 +66,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_no_nsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_no_nsst.xml
@@ -63,7 +63,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_noahmp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_noahmp.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_thompson.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_thompson.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_ugwpv1.xml
@@ -65,7 +65,6 @@
       <scheme>ugwpv1_gsldrag</scheme>
       <scheme>ugwpv1_gsldrag_post</scheme>          
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GSD_SAR.xml
+++ b/ccpp/suites/suite_FV3_GSD_SAR.xml
@@ -59,7 +59,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GSD_noah.xml
+++ b/ccpp/suites/suite_FV3_GSD_noah.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GSD_noah_mynnsfc.xml
+++ b/ccpp/suites/suite_FV3_GSD_noah_mynnsfc.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GSD_v0.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0.xml
@@ -59,7 +59,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GSD_v0_RRTMGP.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0_RRTMGP.xml
@@ -69,7 +69,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GSD_v0_drag_suite.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0_drag_suite.xml
@@ -58,7 +58,6 @@
       <scheme>GFS_GWD_generic_pre</scheme>
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GSD_v0_mynnsfc.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0_mynnsfc.xml
@@ -59,7 +59,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GSD_v0_unified_ugwp_suite.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0_unified_ugwp_suite.xml
@@ -59,7 +59,6 @@
       <scheme>unified_ugwp</scheme>
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_GSD_v0_unified_ugwp_suite_noah.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0_unified_ugwp_suite_noah.xml
@@ -60,7 +60,6 @@
       <scheme>unified_ugwp</scheme>
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v0_gfdlmp_tedmf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v0_gfdlmp_tedmf.xml
@@ -65,7 +65,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v0_gfdlmp_tedmf_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v0_gfdlmp_tedmf_nonsst.xml
@@ -63,7 +63,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v0_hwrf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v0_hwrf.xml
@@ -62,7 +62,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v0_hwrf_thompson.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v0_hwrf_thompson.xml
@@ -64,7 +64,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -58,7 +58,6 @@
       <scheme>GFS_GWD_generic_pre</scheme>
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_RAP.xml
+++ b/ccpp/suites/suite_FV3_RAP.xml
@@ -58,7 +58,6 @@
       <scheme>GFS_GWD_generic_pre</scheme>
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1alpha.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1alpha.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1beta.xml
@@ -60,7 +60,6 @@
       <scheme>cires_ugwp</scheme>
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
-      <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>
       <scheme>h2ophys</scheme>

--- a/stochastic_physics/stochastic_physics_wrapper.F90
+++ b/stochastic_physics/stochastic_physics_wrapper.F90
@@ -294,7 +294,7 @@ module stochastic_physics_wrapper_mod
          endif ! lndp block
       end if
 
-    if (GFS_Control%do_ca) then
+      if (GFS_Control%do_ca) then
 
        if(GFS_Control%ca_sgs)then
          ! Allocate contiguous arrays; copy in as needed
@@ -374,8 +374,7 @@ module stochastic_physics_wrapper_mod
           deallocate(ca3_diag)
        endif
 
-
-    endif !do_ca
+      endif !do_ca
 
     endif initalize_stochastic_physics
 

--- a/stochastic_physics/stochastic_physics_wrapper.F90
+++ b/stochastic_physics/stochastic_physics_wrapper.F90
@@ -294,9 +294,7 @@ module stochastic_physics_wrapper_mod
          endif ! lndp block
       end if
 
-    endif initalize_stochastic_physics
-
-    if (GFS_Control%do_ca .and. is_initialized) then
+    if (GFS_Control%do_ca) then
 
        if(GFS_Control%ca_sgs)then
          ! Allocate contiguous arrays; copy in as needed
@@ -378,6 +376,8 @@ module stochastic_physics_wrapper_mod
 
 
     endif !do_ca
+
+    endif initalize_stochastic_physics
 
   end subroutine stochastic_physics_wrapper
 


### PR DESCRIPTION
## Description

This PR combines two changes:
- A fix in `stochastic_physics/stochastic_physics_wrapper.F90` for reproducible restart runs, contributed by @lisa-bengtsson (see https://github.com/ufs-community/ufs-weather-model/discussions/737 for more information)
- Removal of scheme `rayleigh_damp` from all remaining suite definition files in `ccpp/suites/`

### Issue(s) addressed

Fixes https://github.com/NOAA-EMC/fv3atm/issues/340.

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/751.