### PR TITLE
brings in latest release candidate for the FV3 dycore 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/bensonr/GFDL_atmos_cubed_sphere
-	branch = master2emc
+	url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-	branch = dev/emc
+	url = https://github.com/bensonr/GFDL_atmos_cubed_sphere
+	branch = master2emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description

This PR brings in  the latest release candidate for the FV3 dycore for use in the UFS.  It also has an updated .gitmodule pointing to the release candidate repo and branch (bensonr/GFDL_atmos_cubed_sphere::master2emc). 

This PR will change answers for regional tests as well as any test using ICs generated from specific sources to chgres (when data_source_fv3gfs=.TRUE. logical within the dycore external_ic)


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #375 
- fixes noaa-emc/fv3atm/issues/375


## Testing

These changes were tested using UFS-RTS for:
 - gaea.intel
 - hera.gnu
 - attempts were made to run hera.intel, but recent changes to the HPC-Stack installation seems to be causing NEMS errors

No new tests were added or needed.  The control_csawmg test is now turned off for gaea.intel.  This test goes numerically unstable with this update on that particular platform.  The gdas tests required updated ICs which have been propagated to the various HPCs in the UFS RTS tiers.

Code updates will change regression tests baselines due to changes listed above.


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)
- relies on bensonr/GFDL_atmos_cubed_sphere::master2emc

Do PRs in upstream repositories need to be merged first?  YES
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/128
