### PR TITLE
CCPP updates: UGWPv1 decomp bug fixes, remove Julie from CODEOWNERS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,13 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  url = https://github.com/NCAR/ccpp-framework
-  branch = main
+  #url = https://github.com/NCAR/ccpp-framework
+  #branch = main
+  url = https://github.com/julieschramm/ccpp-framework
+  branch = feature/julie_retires
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  #url = https://github.com/NCAR/ccpp-physics
+  #branch = main
+  url = https://github.com/climbfuji/ccpp-physics
+  branch = mike_ugwp_and_julie_codeowner

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,13 +4,9 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  #url = https://github.com/NCAR/ccpp-framework
-  #branch = main
-  url = https://github.com/julieschramm/ccpp-framework
-  branch = feature/julie_retires
+  url = https://github.com/NCAR/ccpp-framework
+  branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/NCAR/ccpp-physics
-  #branch = main
-  url = https://github.com/climbfuji/ccpp-physics
-  branch = mike_ugwp_and_julie_codeowner
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main


### PR DESCRIPTION
## Description

Update and submodule pointers for ccpp-framework and ccpp-physics for the changes described in the associated PRs below:

- Substantial changes in UGWPv1 to fix problem of lack of reproducibility when changing the domain decomposition layout.
- Remove Julie from `CODEOWNERS` files in both ccpp-framework and ccpp-physics.

### Issue(s) addressed

MISSING

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/835

## Dependencies

- waiting on https://github.com/NCAR/ccpp-physics/pull/747
- waiting on https://github.com/NCAR/ccpp-framework/pull/402
