### PR TITLE
production/GEFS_v12: porting ops gefs v12 to wcoss2

### DIFF
--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -534,7 +534,7 @@ module fv3gfs_cap_mod
     if (ESMF_LogFoundError(rcToCheck=urc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
 !
 ! reconcile the fcstComp's import state
-    call ESMF_StateReconcile(fcstState, attreconflag= ESMF_ATTRECONCILE_ON, rc=rc)
+    call ESMF_StateReconcile(fcstState, attreconflag=ESMF_ATTRECONCILE_ON, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 !
 ! determine number elements in fcstState

--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -534,7 +534,7 @@ module fv3gfs_cap_mod
     if (ESMF_LogFoundError(rcToCheck=urc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
 !
 ! reconcile the fcstComp's import state
-    call ESMF_StateReconcile(fcstState, attreconflag=ESMF_ATTRECONCILE_ON, rc=rc)
+    call ESMF_StateReconcile(fcstState, attreconflag= ESMF_ATTRECONCILE_ON, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 !
 ! determine number elements in fcstState

--- a/gfsphysics/GFS_layer/GFS_driver.F90
+++ b/gfsphysics/GFS_layer/GFS_driver.F90
@@ -665,9 +665,7 @@ module GFS_driver
 ! Since IPD_func0d_proc declares all arguments as intent(inout), we
 ! need to do the same here - however, this way we are loosing the
 ! valuable information on the actual intent to this routine. *DH
-!#ifdef __GFORTRAN__
 #if defined(__GFORTRAN__) || defined(__FUJITSU) || defined(__CRAY_X86_ROME)
-! || defined(__INTEL_COMPILER)
     type(GFS_control_type),         intent(inout) :: Model
     type(GFS_statein_type),         intent(inout) :: Statein
     type(GFS_stateout_type),        intent(inout) :: Stateout

--- a/gfsphysics/GFS_layer/GFS_driver.F90
+++ b/gfsphysics/GFS_layer/GFS_driver.F90
@@ -665,7 +665,9 @@ module GFS_driver
 ! Since IPD_func0d_proc declares all arguments as intent(inout), we
 ! need to do the same here - however, this way we are loosing the
 ! valuable information on the actual intent to this routine. *DH
-#ifdef __GFORTRAN__
+!#ifdef __GFORTRAN__
+#if defined(__GFORTRAN__) || defined(__FUJITSU) || defined(__CRAY_X86_ROME)
+! || defined(__INTEL_COMPILER)
     type(GFS_control_type),         intent(inout) :: Model
     type(GFS_statein_type),         intent(inout) :: Statein
     type(GFS_stateout_type),        intent(inout) :: Stateout

--- a/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -452,7 +452,9 @@ module module_physics_driver
 ! Since IPD_func0d_proc declares all arguments as intent(inout), we
 ! need to do the same here - however, this way we are loosing the
 ! valuable information on the actual intent to this routine. *DH
-#ifdef __GFORTRAN__
+!#ifdef __GFORTRAN__
+#if defined(__GFORTRAN__) || defined(__FUJITSU) || defined(__CRAY_X86_ROME)
+! || defined(__INTEL_COMPILER)
       type(GFS_control_type),         intent(inout) :: Model
       type(GFS_statein_type),         intent(inout) :: Statein
       type(GFS_stateout_type),        intent(inout) :: Stateout

--- a/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -452,9 +452,7 @@ module module_physics_driver
 ! Since IPD_func0d_proc declares all arguments as intent(inout), we
 ! need to do the same here - however, this way we are loosing the
 ! valuable information on the actual intent to this routine. *DH
-!#ifdef __GFORTRAN__
 #if defined(__GFORTRAN__) || defined(__FUJITSU) || defined(__CRAY_X86_ROME)
-! || defined(__INTEL_COMPILER)
       type(GFS_control_type),         intent(inout) :: Model
       type(GFS_statein_type),         intent(inout) :: Statein
       type(GFS_stateout_type),        intent(inout) :: Stateout

--- a/gfsphysics/GFS_layer/GFS_radiation_driver.F90
+++ b/gfsphysics/GFS_layer/GFS_radiation_driver.F90
@@ -1031,7 +1031,9 @@
 ! Since IPD_func0d_proc declares all arguments as intent(inout), we
 ! need to do the same here - however, this way we are loosing the
 ! valuable information on the actual intent to this routine. *DH
-#ifdef __GFORTRAN__
+!#ifdef __GFORTRAN__
+#if defined(__GFORTRAN__) || defined(__FUJITSU) || defined(__CRAY_X86_ROME)
+! || defined(__INTEL_COMPILER)
       type(GFS_control_type),         intent(inout) :: Model
       type(GFS_statein_type),         intent(inout) :: Statein
       type(GFS_stateout_type),        intent(inout) :: Stateout

--- a/gfsphysics/GFS_layer/GFS_radiation_driver.F90
+++ b/gfsphysics/GFS_layer/GFS_radiation_driver.F90
@@ -1031,9 +1031,7 @@
 ! Since IPD_func0d_proc declares all arguments as intent(inout), we
 ! need to do the same here - however, this way we are loosing the
 ! valuable information on the actual intent to this routine. *DH
-!#ifdef __GFORTRAN__
 #if defined(__GFORTRAN__) || defined(__FUJITSU) || defined(__CRAY_X86_ROME)
-! || defined(__INTEL_COMPILER)
       type(GFS_control_type),         intent(inout) :: Model
       type(GFS_statein_type),         intent(inout) :: Statein
       type(GFS_stateout_type),        intent(inout) :: Stateout


### PR DESCRIPTION
## Description

This PR is to solve the incompatible function issue (listed the error messsages below) when compile fv3atm on WCOSS2 suggested by Peter Johnsen from GDIT-WCOSS2 Team. Steven also approved this codes changes for GEFS transition to WCOSS2. 

> atmos_model.F90(311): error #8178: The procedure pointer and the procedure target must have matching arguments.
>       Func0d => radiation_step1
> ------^
> atmos_model.F90(336): error #8178: The procedure pointer and the procedure target must have matching arguments.
>       Func0d => physics_step1
> ------^
> atmos_model.F90(361): error #8178: The procedure pointer and the procedure target must have matching arguments.
>       Func0d => physics_step2

### Issue(s) addressed

- fixes #381

## Testing

How were these changes tested?  
> Built fv3atm on WCOSS2 (cactus) and ran tests successfully.

What compilers / HPCs was it tested with?  
> ftn/cc on WCOSS2

Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
> No. Because this changes only modify the condition statements



## Dependencies

Do PRs in upstream repositories need to be merged first?
> No. This is the downstream of GEFS v12 and Global-workflow
