### PR TITLE
Use upp as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
   path = ccpp/physics
   url = https://github.com/NCAR/ccpp-physics
   branch = main
+[submodule "upp"]
+  path = upp
+  url = https://github.com/DusanJovic-NOAA/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,5 @@
   branch = main
 [submodule "upp"]
   path = upp
-  url = https://github.com/DusanJovic-NOAA/UPP
+  url = https://github.com/NOAA-EMC/UPP
+  branch = develop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ add_subdirectory(atmos_cubed_sphere)
 ### fv3atm
 ###############################################################################
 if(INLINE_POST)
+  set(BUILD_POSTEXEC OFF)
+  add_subdirectory(upp)
   set(POST_SRC io/inline_post.F90 io/post_nems_routines.F90 io/post_gfs.F90 io/post_regional.F90)
 else()
   set(POST_SRC io/inline_post_stub.F90)


### PR DESCRIPTION
## Description

This PR adds UPP submodule. It is used in inline post instead of an external upp library.
No change in baseline is expected.


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes https://github.com/ufs-community/ufs-weather-model/issues/905


## Testing

How were these changes tested?  Regression tested on Hera.
What compilers / HPCs was it tested with?  Intel.
Are the changes covered by regression tests? Yes. All tests that run inline-post.
Have the ufs-weather-model regression test been run? Yes. On what platform?  Hera.
- Will the code updates change regression test baseline? No.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on https://github.com/NOAA-EMC/UPP/pull/412
