### PR TITLE
Cloud radiation mp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  #url = https://github.com/NCAR/ccpp-physics
+  #branch = main
+  url = https://github.com/RuiyuSun/ccpp-physics
+  branch = cloud_radiation_mp

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -826,8 +826,6 @@ module GFS_typedefs
     logical              :: sedi_semi_update!< flag for v update in semi Lagrangian sedi of rain
     logical              :: sedi_semi_decfl !< flag for interation with semi Lagrangian sedi of rain
     real(kind=kind_phys) :: crt_sati        !< critical over saturation for ice generation
-    real(kind=kind_phys) :: d0s             !< diameter of ice particle to be converted to snow 
-    real(kind=kind_phys) :: d0g             !< diameter of snow particle to be converted to graupel
 
     !--- GFDL microphysical paramters
     logical              :: lgfdlmprad      !< flag for GFDL mp scheme and radiation consistency
@@ -3199,8 +3197,6 @@ module GFS_typedefs
     logical              :: sedi_semi_update = .false.          !< flag for v update in semi Lagrangian sedi of rain
     logical              :: sedi_semi_decfl = .false.           !< flag for interation with semi Lagrangian sedi of rain
     real(kind=kind_phys) :: crt_sati       = 0.25               !< critical over saturation for ice generation
-    real(kind=kind_phys) :: d0s            =200.E-6             !< diameter of ice particle to be converted to snow in meter
-    real(kind=kind_phys) :: d0g            =250.E-6             !< diameter of snow particle to be converted to graupel in meter
 
     !--- GFDL microphysical parameters
     logical              :: lgfdlmprad     = .false.            !< flag for GFDLMP radiation interaction
@@ -3570,7 +3566,7 @@ module GFS_typedefs
                                ltaerosol, lradar, nsradar_reset, lrefres, ttendlim,         &
                                ext_diag_thompson, dt_inner, lgfdlmprad,                     &
                                sedi_semi, sedi_semi_update, sedi_semi_decfl,                & 
-                               crt_sati, d0s, d0g,                                          &
+                               crt_sati,                                                    &
                           !--- max hourly
                                avg_max_length,                                              &
                           !--- land/surface model control
@@ -4054,18 +4050,6 @@ module GFS_typedefs
       Model%crt_sati       =  0.25
     else 
       Model%crt_sati       = crt_sati
-    endif 
-    if(d0s < 50.e-6) then 
-       Model%d0s           = 50.e-6
-    else if(d0s>500.e-6) then 
-       Model%d0s           = 500.e-6
-    else 
-      Model%d0s            = d0s 
-    endif 
-    if(d0g <= d0s + 50.e-6) then 
-       Model%d0g           = d0s + 50.e-6 
-    else if (d0g > 1000.e-6) then 
-       Model%d0g           = 1000.e-6 
     endif 
      
 !--- F-A MP parameters
@@ -5147,8 +5131,6 @@ module GFS_typedefs
                                           ' sedi_semi_update=',sedi_semi_update, & 
                                           ' sedi_semi_decfl=',sedi_semi_decfl, &
                                           ' crt_sati=',crt_sati, &
-                                          ' d0s=',d0s, &
-                                          ' d0g=',d0g, &
                                           ' effr_in =',Model%effr_in, &
                                           ' lradar =',Model%lradar, &
                                           ' nsradar_reset =',Model%nsradar_reset, &
@@ -5570,8 +5552,6 @@ module GFS_typedefs
         print *, ' sedi_semi_update  : ', Model%sedi_semi_update
         print *, ' sedi_semi_decfl   : ', Model%sedi_semi_decfl
         print *, ' crt_sati          : ', Model%crt_sati
-        print *, ' d0s               : ', Model%d0s 
-        print *, ' d0g               : ', Model%d0g 
         print *, ' '
       endif
       if (Model%imp_physics == Model%imp_physics_mg) then

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -825,7 +825,6 @@ module GFS_typedefs
     logical              :: sedi_semi       !< flag for semi Lagrangian sedi of rain
     logical              :: sedi_semi_update!< flag for v update in semi Lagrangian sedi of rain
     logical              :: sedi_semi_decfl !< flag for interation with semi Lagrangian sedi of rain
-    real(kind=kind_phys) :: crt_sati        !< critical over saturation for ice generation
 
     !--- GFDL microphysical paramters
     logical              :: lgfdlmprad      !< flag for GFDL mp scheme and radiation consistency
@@ -3196,7 +3195,6 @@ module GFS_typedefs
     logical              :: sedi_semi      = .false.            !< flag for semi Lagrangian sedi of rain
     logical              :: sedi_semi_update = .false.          !< flag for v update in semi Lagrangian sedi of rain
     logical              :: sedi_semi_decfl = .false.           !< flag for interation with semi Lagrangian sedi of rain
-    real(kind=kind_phys) :: crt_sati       = 0.25               !< critical over saturation for ice generation
 
     !--- GFDL microphysical parameters
     logical              :: lgfdlmprad     = .false.            !< flag for GFDLMP radiation interaction
@@ -3566,7 +3564,6 @@ module GFS_typedefs
                                ltaerosol, lradar, nsradar_reset, lrefres, ttendlim,         &
                                ext_diag_thompson, dt_inner, lgfdlmprad,                     &
                                sedi_semi, sedi_semi_update, sedi_semi_decfl,                & 
-                               crt_sati,                                                    &
                           !--- max hourly
                                avg_max_length,                                              &
                           !--- land/surface model control
@@ -4044,13 +4041,6 @@ module GFS_typedefs
     Model%sedi_semi        = sedi_semi
     Model%sedi_semi_update = sedi_semi_update
     Model%sedi_semi_decfl  = sedi_semi_decfl
-    if(crt_sati < 0.0) then 
-      Model%crt_sati       =  0.0 
-    else if( crt_sati > 0.25) then 
-      Model%crt_sati       =  0.25
-    else 
-      Model%crt_sati       = crt_sati
-    endif 
      
 !--- F-A MP parameters
     Model%rhgrd            = rhgrd
@@ -5130,7 +5120,6 @@ module GFS_typedefs
                                           ' sedi_semi=',Model%sedi_semi, & 
                                           ' sedi_semi_update=',sedi_semi_update, & 
                                           ' sedi_semi_decfl=',sedi_semi_decfl, &
-                                          ' crt_sati=',crt_sati, &
                                           ' effr_in =',Model%effr_in, &
                                           ' lradar =',Model%lradar, &
                                           ' nsradar_reset =',Model%nsradar_reset, &
@@ -5551,7 +5540,6 @@ module GFS_typedefs
         print *, ' sedi_semi         : ', Model%sedi_semi
         print *, ' sedi_semi_update  : ', Model%sedi_semi_update
         print *, ' sedi_semi_decfl   : ', Model%sedi_semi_decfl
-        print *, ' crt_sati          : ', Model%crt_sati
         print *, ' '
       endif
       if (Model%imp_physics == Model%imp_physics_mg) then

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -3534,20 +3534,6 @@
   dimensions = ()
   type = real
   kind = kind_phys
-[d0s]
-  standard_name = diameter_of_ice_particle_to_be_converted_to_snow
-  long_name =  diameter of ice particle to be converted to snow
-  units = meter
-  dimensions = ()
-  type = real
-  kind = kind_phys
-[d0g]
-  standard_name = diameter_of_snow_particle_to_be_converted_to_graupel
-  long_name =  diameter of snow particle to be converted to graupel
-  units = meter
-  dimensions = ()
-  type = real
-  kind = kind_phys
 [lgfdlmprad]
   standard_name = flag_for_GFDL_microphysics_radiation_interaction
   long_name = flag for GFDL microphysics-radiation interaction

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -3527,13 +3527,6 @@
   dimensions = ()
   type = logical
   intent = in
-[crt_sati]
-  standard_name = critical_over_saturation_for_ice_generation
-  long_name = critical over saturation for ice generation
-  units = none
-  dimensions = ()
-  type = real
-  kind = kind_phys
 [lgfdlmprad]
   standard_name = flag_for_GFDL_microphysics_radiation_interaction
   long_name = flag for GFDL microphysics-radiation interaction

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -3527,6 +3527,27 @@
   dimensions = ()
   type = logical
   intent = in
+[crt_sati]
+  standard_name = critical_over_saturation_for_ice_generation
+  long_name = critical over saturation for ice generation
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[d0s]
+  standard_name = diameter_of_ice_particle_to_be_converted_to_snow
+  long_name =  diameter of ice particle to be converted to snow
+  units = meter
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[d0g]
+  standard_name = diameter_of_snow_particle_to_be_converted_to_graupel
+  long_name =  diameter of snow particle to be converted to graupel
+  units = meter
+  dimensions = ()
+  type = real
+  kind = kind_phys
 [lgfdlmprad]
   standard_name = flag_for_GFDL_microphysics_radiation_interaction
   long_name = flag for GFDL microphysics-radiation interaction


### PR DESCRIPTION
## Description

In the gfsv17 based Thompson MP experiments, there is significantly less cloud cover (low and high) compared with CERES data. The radiative flux biases (dsw at surface and OLR) are larger in the Thompson MP experiments than in the gfsv17 control. The purpose of the PR is to increase the cloud cover and reduce the radiative flux bias at the surface and TOA. The cloud cover formulation was modified and namelist options were added to three parameters (related to the supersaturation requirement for ice generation and D0s and D0g) in the Thompson MP to control the ice and high cloud.
This PR will change the results.   


Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
A RT test of this PR has been tested on Hera.  
The code will change the RT baseline because the code changes modify the results. 

## Dependencies

related PR: 
https://github.com/NCAR/ccpp-physics/pull/778