### PR TITLE
add semi-lagrangian sedimentation of graupel and update the namelist …

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  #url = https://github.com/NCAR/ccpp-physics
+  #branch = main
+  url = https://github.com/RuiyuSun/ccpp-physics
+  branch = semi-lagrangian_sedi_graupel

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/NCAR/ccpp-physics
-  #branch = main
-  url = https://github.com/RuiyuSun/ccpp-physics
-  branch = semi-lagrangian_sedi_graupel
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -823,8 +823,7 @@ module GFS_typedefs
     integer              :: thompson_ext_ndiag3d=37 !< number of 3d arrays for extended diagnostic output from Thompson
     real(kind=kind_phys) :: dt_inner        !< time step for the inner loop in s
     logical              :: sedi_semi       !< flag for semi Lagrangian sedi of rain
-    logical              :: sedi_semi_update!< flag for v update in semi Lagrangian sedi of rain
-    logical              :: sedi_semi_decfl !< flag for interation with semi Lagrangian sedi of rain
+    integer              :: decfl           !< deformed CFL factor
 
     !--- GFDL microphysical paramters
     logical              :: lgfdlmprad      !< flag for GFDL mp scheme and radiation consistency
@@ -3193,8 +3192,7 @@ module GFS_typedefs
     logical              :: ext_diag_thompson = .false.         !< flag for extended diagnostic output from Thompson
     real(kind=kind_phys) :: dt_inner       = -999.0             !< time step for the inner loop 
     logical              :: sedi_semi      = .false.            !< flag for semi Lagrangian sedi of rain
-    logical              :: sedi_semi_update = .false.          !< flag for v update in semi Lagrangian sedi of rain
-    logical              :: sedi_semi_decfl = .false.           !< flag for interation with semi Lagrangian sedi of rain
+    integer              :: decfl          = 8                  !< deformed CFL factor
 
     !--- GFDL microphysical parameters
     logical              :: lgfdlmprad     = .false.            !< flag for GFDLMP radiation interaction
@@ -3563,7 +3561,7 @@ module GFS_typedefs
                                mg_alf,   mg_qcmin, mg_do_ice_gmao, mg_do_liq_liu,           &
                                ltaerosol, lradar, nsradar_reset, lrefres, ttendlim,         &
                                ext_diag_thompson, dt_inner, lgfdlmprad,                     &
-                               sedi_semi, sedi_semi_update, sedi_semi_decfl,                &
+                               sedi_semi, decfl,                                            &
                           !--- max hourly
                                avg_max_length,                                              &
                           !--- land/surface model control
@@ -4039,8 +4037,7 @@ module GFS_typedefs
       Model%dt_inner       = Model%dtp
     endif
     Model%sedi_semi        = sedi_semi
-    Model%sedi_semi_update = sedi_semi_update
-    Model%sedi_semi_decfl  = sedi_semi_decfl
+    Model%decfl            = decfl
 !--- F-A MP parameters
     Model%rhgrd            = rhgrd
     Model%spec_adv         = spec_adv
@@ -5117,8 +5114,7 @@ module GFS_typedefs
                                           ' ext_diag_thompson =',Model%ext_diag_thompson, &
                                           ' dt_inner =',Model%dt_inner, &
                                           ' sedi_semi=',Model%sedi_semi, & 
-                                          ' sedi_semi_update=',sedi_semi_update, & 
-                                          ' sedi_semi_decfl=',sedi_semi_decfl, &
+                                          ' decfl=',decfl, &
                                           ' effr_in =',Model%effr_in, &
                                           ' lradar =',Model%lradar, &
                                           ' nsradar_reset =',Model%nsradar_reset, &
@@ -5537,8 +5533,7 @@ module GFS_typedefs
         print *, ' ext_diag_thompson : ', Model%ext_diag_thompson
         print *, ' dt_inner          : ', Model%dt_inner
         print *, ' sedi_semi         : ', Model%sedi_semi
-        print *, ' sedi_semi_update  : ', Model%sedi_semi_update
-        print *, ' sedi_semi_decfl  : ', Model%sedi_semi_decfl
+        print *, ' decfl             : ', Model%decfl
         print *, ' '
       endif
       if (Model%imp_physics == Model%imp_physics_mg) then

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -3513,19 +3513,12 @@
   dimensions = ()
   type = logical
   intent = in
-[sedi_semi_update]
-  standard_name = flag_for_v_update_in_semi_Lagrangian_sedi
-  long_name = flag for v update in semi Lagrangian sedi of rain
-  units = flag
+[decfl]
+  standard_name = deformed_CFL_factor
+  long_name = deformed CFL factor
+  units = count
   dimensions = ()
-  type = logical
-  intent = in
-[sedi_semi_decfl]
-  standard_name = flag_for_iteration_with_semi_Lagrangian_sedi
-  long_name = flag for interation with semi Lagrangian sedi of rain
-  units = flag
-  dimensions = ()
-  type = logical
+  type = integer
   intent = in
 [lgfdlmprad]
   standard_name = flag_for_GFDL_microphysics_radiation_interaction


### PR DESCRIPTION
…variables to control semi-lagrangian sedimentation

## Description

The semi-Lagrangian sedimentation of graupel is added. The  namelist variables controlling the semi-Lagrangian sedimentation of precipitation (rain and graupel) are modified. Now SEDI_SEMI and DECFL is the switch.  DECFL is the  deformed CFL factor. 

Semi-Lagrangian sedimentation of precipitation is added as an option and does not change results before it is turned on. 

### Issue(s) addressed
This is part of issue: https://github.com/NCAR/ccpp-physics/issues/765

## Testing
An RT experiment has been conducted on Hera and passed. The RT baseline will not be changed. 

## Dependencies
https://github.com/NCAR/ccpp-physics/pull/770
