### PR TITLE
Feature/ccpp codeowners

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
+  branch = feature/CCPP-CODEOWNERS
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
-  branch = feature/CODEOWNERS
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/SamuelTrahanNOAA/ccpp-physics
-  branch = feature/CCPP-CODEOWNERS
+  branch = feature/CODEOWNERS
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

Add codeowners in ccpp/physics for files that have known Points of Contact

### Issue(s) addressed

https://github.com/NCAR/ccpp-physics/pull/804


## Testing

Some test PRs were run to ensure the CODEOWNERS functionality worked as intended via test files. Also, the points of contact were alerted to this impending change.

It is impossible for this to change the regression test results, so those tests were not run.


## Dependencies

None.
