### PR TITLE
point fv3atm to wrapper_806_807_813 for regression testing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+#  url = https://github.com/NCAR/ccpp-physics
+#  branch = main
+  url = https://github.com/grantfirl/ccpp-physics
+  branch = wrapper_806_807_813
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This pull requests updates the ccpp-physics submodule pointer for the wrapper PR: https://github.com/NCAR/ccpp-physics/pull/817

The physics changes include:
https://github.com/NCAR/ccpp-physics/pull/806 (only diagnostic changes for RRTMGP - small diag-only RT impact for tests involving RRTMGP)
https://github.com/NCAR/ccpp-physics/pull/807 (only aborting model if sfc emis file not present when needed - no RT impact)
https://github.com/NCAR/ccpp-physics/pull/813  (only SCM-specific physics changes - no RT impact)


### Issue(s) addressed

- fixes https://github.com/NCAR/ccpp-physics/issues/805



## Testing

See PLACEHOLDER for regression testing


## Dependencies

https://github.com/NCAR/ccpp-physics/pull/817
