### PR TITLE
Wrapper for ccpp-physics #808 and 816 (roughness length over ice and NoahMP tsurf bugfix)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  #url = https://github.com/NCAR/ccpp-physics
+  #branch = main
+  url = https://github.com/grantfirl/ccpp-physics
+  branch = wrapper_808_816
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/NCAR/ccpp-physics
-  #branch = main
-  url = https://github.com/grantfirl/ccpp-physics
-  branch = wrapper_808_816
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This PR combines:

-   https://github.com/NCAR/ccpp-physics/pull/808
-   https://github.com/NCAR/ccpp-physics/pull/816

808 addresses an error in the momentum roughness length over tiles with ice. 816 fixes an occasional segfault bug related to the tsurf variable in NoahMP and updates to "improve snow simulation in NoahMP for P8".



### Issue(s) addressed

No GitHub issues are addressed, but https://github.com/NCAR/ccpp-physics/pull/816 addresses occasional segfaults when using NoahMP. See that PR for details.



## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/971 for regression testing.

The PR originator tested on hera/intel. A long list of tests require a changed baseline due to changes in sfc_diff.f from https://github.com/NCAR/ccpp-physics/pull/808. Although https://github.com/NCAR/ccpp-physics/pull/816 was originally not supposed to change the answer (when 808 and 816 were combined), commits were added to 816 that change the result for tests using NoahMP.

## Dependencies

- waiting on https://github.com/NCAR/ccpp-physics/pull/818

