### PR TITLE
 Fix allocation temp2d in FV3GFS_io.F90

### DIFF
--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -196,7 +196,7 @@ module FV3GFS_io_mod
      nsfcprop2d = nsfcprop2d + 16
    endif
 
-   allocate (temp2d(isc:iec,jsc:jec,nsfcprop2d+Model%ntot3d+Model%nctp))
+   allocate (temp2d(isc:iec,jsc:jec,nsfcprop2d+Model%ntot2d+Model%nctp))
    allocate (temp3d(isc:iec,jsc:jec,1:lev,14+Model%ntot3d+2*ntr))
    allocate (temp3dlevsp1(isc:iec,jsc:jec,1:lev+1,3))
 


### PR DESCRIPTION
## Description

Bug fix in FV3GFS_io.F90 for allocation of temp2d, which used the ntot3d instead of ntot2d

### Issue(s) addressed

The incorrect allocation could cause out of bounds error depending on LSM options.

## Testing

NOAA/Jet (Intel compilers)
Mac (GCC-10)

## Dependencies

none

Submitted by Ted Mansell <ted.mansell@noaa.gov> NOAA/NSSL