### PR TITLE
Revisions to repair iovr=5 cloud overlap option

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/grantfirl/ccpp-physics
+  branch = mjiacono_iovr5_repair
+  #url = https://github.com/NCAR/ccpp-physics
+  #branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/grantfirl/ccpp-physics
-  branch = mjiacono_iovr5_repair
-  #url = https://github.com/NCAR/ccpp-physics
-  #branch = main
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -3930,7 +3930,7 @@ module GFS_typedefs
     if (levr < 0) then
       Model%levr           = levs
     else if (levr > levs) then
-      write(0,*) "Logic error, number of radiatiton levels (levr) cannot exceed number of model levels (levs)"
+      write(0,*) "Logic error, number of radiation levels (levr) cannot exceed number of model levels (levs)"
       stop
     else
       Model%levr           = levr


### PR DESCRIPTION

## Description

This PR addresses part 2 of issue [#748](https://github.com/NCAR/ccpp-physics/issues/748) to activate the exponential-random cloud overlap method (iovr=5) in RRTMG. These changes should not affect existing regression tests, but allow the use of iovr=5.

### Issue(s) addressed

part 2 of issue [#748](https://github.com/NCAR/ccpp-physics/issues/748)


## Testing

These changes were tested using the full rt.conf on Hera/Intel and passed all RTs. New RTs were added to use iovr=4 and iovr=5. These changes don't affect existing RTs, but new baselines for the new RTs will need to be created.

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/830
