### PR TITLE
Add lsm_cold_start variable for RUC LSM SCM support and gwdps bugfix (combined)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/grantfirl/ccpp-physics
-  branch = RUC_LSM_SCM_support
-  #url = https://github.com/NCAR/ccpp-physics
-  #branch = main
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/grantfirl/ccpp-physics
+  branch = RUC_LSM_SCM_support
+  #url = https://github.com/NCAR/ccpp-physics
+  #branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1293,6 +1293,7 @@ module GFS_typedefs
     integer              :: kdt             !< current forecast iteration
     logical              :: first_time_step !< flag signaling first time step for time integration routine
     logical              :: restart         !< flag whether this is a coldstart (.false.) or a warmstart/restart (.true.)
+    logical              :: lsm_cold_start
     logical              :: hydrostatic     !< flag whether this is a hydrostatic or non-hydrostatic run
     integer              :: jdat(1:8)       !< current forecast date and time
                                             !< (yr, mon, day, t-zone, hr, min, sec, mil-sec)
@@ -4819,6 +4820,7 @@ module GFS_typedefs
     Model%kdt              = nint(Model%fhour*con_hr/Model%dtp)
     Model%first_time_step  = .true.
     Model%restart          = restart
+    Model%lsm_cold_start   = .not. restart
     Model%hydrostatic      = hydrostatic
     Model%jdat(1:8)        = jdat(1:8)
     allocate(Model%si(Model%levs+1))
@@ -5963,6 +5965,7 @@ module GFS_typedefs
       print *, ' sec               : ', Model%sec
       print *, ' first_time_step   : ', Model%first_time_step
       print *, ' restart           : ', Model%restart
+      print *, ' lsm_cold_start    : ', Model%lsm_cold_start
       print *, ' hydrostatic       : ', Model%hydrostatic
     endif
 

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -5230,6 +5230,12 @@
   units = flag
   dimensions = ()
   type = logical
+[lsm_cold_start]
+  standard_name = do_lsm_cold_start
+  long_name = flag to signify LSM is cold-started
+  units = flag
+  dimensions = ()
+  type = logical
 [hydrostatic]
   standard_name = flag_for_hydrostatic_solver
   long_name = flag for hydrostatic solver from dynamics


### PR DESCRIPTION
## Description

This pull request only adds a new lsm_cold_start variable that is necessary to add to the CCPP version of RUC LSM in order for it to be used with the CCPP SCM. This change should have no effect on FV3/UFS.

(Update)
This PR also includes @SMoorthi-emc 's bugfix for gwdps.f. After the combination, several regression tests need new baselines (see, e.g. the associated ufs-weather-model PR)

### Issue(s) addressed

https://github.com/NCAR/ccpp-physics/issues/833
#473

## Testing

The lsm_cold_start changes were tested using the full rt.conf on Hera/Intel and passed all RTs. The gwdps.f bugfixes were tested on Hera/Intel and passed the expected tests and required several new baselines for those suites using gwdps_run.

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/834