### PR TITLE
lateral boundary fix for regional runs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+#  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+#  branch = dev/emc
+  url = https://github.com/MatthewPyle-NOAA/GFDL_atmos_cubed_sphere
+  branch = feature/devemc_lbcfix
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-#  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-#  branch = dev/emc
-  url = https://github.com/MatthewPyle-NOAA/GFDL_atmos_cubed_sphere
-  branch = feature/devemc_lbcfix
+  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description

This PR is just to point at a fix in atmos_cubed_sphere. https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/173


### Issue(s) addressed

- fixes #<[1038](https://github.com/ufs-community/ufs-weather-model/issues/1038)>
- fixes #<[169](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/issues/169)>

## Testing

How were these changes tested?  

Tests of the fix were conducted on various WCOSS machines to ensure that it was working as expected.  A full ufs-weather-model regression test was run on Orion.  As expected, regional regression run answers were changed, but other tests were not impacted. 


## Dependencies


- To be merged with [NOAA-GFDL/GFDL_atmos_cubed_sphere/pulls/<173>](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/173)
