### PR TITLE
 Update inline_post_stub.F90 subroutine interfaces to match inline_post.F90

### DIFF
--- a/io/inline_post_stub.F90
+++ b/io/inline_post_stub.F90
@@ -13,7 +13,7 @@ module inline_post
 
   contains
 
-  subroutine inline_post_run(wrt_int_state,mypei,mpicomp,lead_write,      &
+  subroutine inline_post_run(wrt_int_state,grid_id,mypei,mpicomp,lead_write,      &
              mynfhr,mynfmin,mynfsec)
 !
 !  revision history:
@@ -28,6 +28,7 @@ module inline_post
 !
       type(wrt_internal_state),intent(in)       :: wrt_int_state
       integer,intent(in)                        :: mypei
+      integer,intent(in)                        :: grid_id
       integer,intent(in)                        :: mpicomp
       integer,intent(in)                        :: lead_write
       integer,intent(in)                        :: mynfhr
@@ -40,11 +41,12 @@ module inline_post
 !
 !-----------------------------------------------------------------------
 !
-    subroutine inline_post_getattr(wrt_int_state)
+    subroutine inline_post_getattr(wrt_int_state,grid_id)
 !
       implicit none
 !
       type(wrt_internal_state),intent(inout)    :: wrt_int_state
+      integer,intent(in)                        :: grid_id
 !
 !
       print *,'in stub inline_post_getattr - not supported on this machine, return'


### PR DESCRIPTION
## Description

Fixes compile error when INLINE_POST = OFF, which switches compilation from inline_post.F90 to inline_post_stub.F90 Updates no-op subroutines to match changes that were made in #480  

It seems the only way to trigger this (i.e., to have INLINE_POST = OFF) is to not have CMAKE_Platform set. Otherwise, all the platform defaults set it to ON.

## Testing

Tested on Mac and compiled on Jet

No changes in results expected.