### PR TITLE
Add 'valid time' variable using ISO string format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/grantfirl/ccpp-physics
+  branch = sfc_flux_spec_update
+  #url = https://github.com/NCAR/ccpp-physics
+  #branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/grantfirl/ccpp-physics
-  branch = sfc_flux_spec_update
-  #url = https://github.com/NCAR/ccpp-physics
-  #branch = main
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/io/inline_post_stub.F90
+++ b/io/inline_post_stub.F90
@@ -13,7 +13,7 @@ module inline_post
 
   contains
 
-  subroutine inline_post_run(wrt_int_state,mypei,mpicomp,lead_write,      &
+  subroutine inline_post_run(wrt_int_state,grid_id,mypei,mpicomp,lead_write,      &
              mynfhr,mynfmin,mynfsec)
 !
 !  revision history:
@@ -28,6 +28,7 @@ module inline_post
 !
       type(wrt_internal_state),intent(in)       :: wrt_int_state
       integer,intent(in)                        :: mypei
+      integer,intent(in)                        :: grid_id
       integer,intent(in)                        :: mpicomp
       integer,intent(in)                        :: lead_write
       integer,intent(in)                        :: mynfhr
@@ -40,11 +41,12 @@ module inline_post
 !
 !-----------------------------------------------------------------------
 !
-    subroutine inline_post_getattr(wrt_int_state)
+    subroutine inline_post_getattr(wrt_int_state,grid_id)
 !
       implicit none
 !
       type(wrt_internal_state),intent(inout)    :: wrt_int_state
+      integer,intent(in)                        :: grid_id
 !
 !
       print *,'in stub inline_post_getattr - not supported on this machine, return'

--- a/io/module_write_internal_state.F90
+++ b/io/module_write_internal_state.F90
@@ -79,8 +79,6 @@
 !-------------------------------------
 !
       type(ESMF_Time)         :: io_basetime
-      type(ESMF_TimeInterval) :: io_currtimediff
-      real                    :: nfhour
       integer                 :: idate(7)
       integer                 :: fdate(7)
 !
@@ -89,7 +87,6 @@
 !-----------------------------------------
 !
       logical :: output_history
-      logical :: write_netcdfflag
 !
 !-----------------------------------------
 !***  POST flags and required variables

--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -80,8 +80,8 @@ module module_write_netcdf
     integer :: ncerr,ierr
     integer :: ncid
     integer :: oldMode
-    integer :: im_dimid, jm_dimid, tile_dimid, pfull_dimid, phalf_dimid, time_dimid
-    integer :: im_varid, jm_varid, tile_varid, lon_varid, lat_varid
+    integer :: im_dimid, jm_dimid, tile_dimid, pfull_dimid, phalf_dimid, time_dimid, ch_dimid
+    integer :: im_varid, jm_varid, tile_varid, lon_varid, lat_varid, validtime_varid
     integer, dimension(:), allocatable :: dimids_2d, dimids_3d
     integer, dimension(:), allocatable :: varids
     logical shuffle
@@ -213,6 +213,7 @@ module module_write_netcdf
        ! define dimensions [grid_xt, grid_yta ,(pfull/phalf), (tile), time]
        ncerr = nf90_def_dim(ncid, "grid_xt", im, im_dimid); NC_ERR_STOP(ncerr)
        ncerr = nf90_def_dim(ncid, "grid_yt", jm, jm_dimid); NC_ERR_STOP(ncerr)
+       ncerr = nf90_def_dim(ncid, "nchars", 20, ch_dimid); NC_ERR_STOP(ncerr)
        if (lm > 1) then
          call add_dim(ncid, "pfull", pfull_dimid, wrtgrid, rc)
          call add_dim(ncid, "phalf", phalf_dimid, wrtgrid, rc)
@@ -229,8 +230,12 @@ module module_write_netcdf
        ncerr = nf90_put_att(ncid, jm_varid, "cartesian_axis", "Y"); NC_ERR_STOP(ncerr)
        if (is_cubed_sphere) then
           ncerr = nf90_def_var(ncid, "tile", NF90_INT, tile_dimid, tile_varid); NC_ERR_STOP(ncerr)
-          ncerr = nf90_put_att(ncid, tile_varid, "long_name", "cubed-spehere face"); NC_ERR_STOP(ncerr)
+          ncerr = nf90_put_att(ncid, tile_varid, "long_name", "cubed-sphere face"); NC_ERR_STOP(ncerr)
        end if
+
+       ncerr = nf90_def_var(ncid, "valid_time", NF90_CHAR, [ch_dimid,time_dimid], validtime_varid); NC_ERR_STOP(ncerr)
+       ncerr = nf90_put_att(ncid, validtime_varid, "long_name", "valid time"); NC_ERR_STOP(ncerr)
+       ncerr = nf90_put_att(ncid, validtime_varid, "units", "ISO 8601 datetime string"); NC_ERR_STOP(ncerr)
 
        ! coordinate variable attributes based on output_grid type
        if (trim(output_grid(grid_id)) == 'gaussian_grid' .or. &
@@ -275,6 +280,7 @@ module module_write_netcdf
           ncerr = nf90_var_par_access(ncid, lon_varid, NF90_INDEPENDENT); NC_ERR_STOP(ncerr)
           ncerr = nf90_var_par_access(ncid, jm_varid, NF90_INDEPENDENT); NC_ERR_STOP(ncerr)
           ncerr = nf90_var_par_access(ncid, lat_varid, NF90_INDEPENDENT); NC_ERR_STOP(ncerr)
+          ncerr = nf90_var_par_access(ncid, validtime_varid, NF90_INDEPENDENT); NC_ERR_STOP(ncerr)
           if (is_cubed_sphere) then
              ncerr = nf90_var_par_access(ncid, tile_varid, NF90_INDEPENDENT); NC_ERR_STOP(ncerr)
           end if
@@ -558,6 +564,13 @@ module module_write_netcdf
     ! write tile (tile_varid)
     if (do_io .and. is_cubed_sphere) then
        ncerr = nf90_put_var(ncid, tile_varid, values=[1,2,3,4,5,6]); NC_ERR_STOP(ncerr)
+    end if
+
+    ! write valid_time (validtime_varid)
+    if (do_io) then
+       call ESMF_AttributeGet(wrtgrid, convention="NetCDF", purpose="FV3", &
+                              name="valid_time", value=varcval, rc=rc); ESMF_ERR_RETURN(rc)
+       ncerr = nf90_put_var(ncid, validtime_varid, values=[trim(varcval)]); NC_ERR_STOP(ncerr)
     end if
 
     ! write variables (fields)

--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -81,7 +81,7 @@ module module_write_netcdf
     integer :: ncid
     integer :: oldMode
     integer :: im_dimid, jm_dimid, tile_dimid, pfull_dimid, phalf_dimid, time_dimid, ch_dimid
-    integer :: im_varid, jm_varid, tile_varid, lon_varid, lat_varid, validtime_varid
+    integer :: im_varid, jm_varid, tile_varid, lon_varid, lat_varid, timeiso_varid
     integer, dimension(:), allocatable :: dimids_2d, dimids_3d
     integer, dimension(:), allocatable :: varids
     logical shuffle
@@ -233,9 +233,9 @@ module module_write_netcdf
           ncerr = nf90_put_att(ncid, tile_varid, "long_name", "cubed-sphere face"); NC_ERR_STOP(ncerr)
        end if
 
-       ncerr = nf90_def_var(ncid, "valid_time", NF90_CHAR, [ch_dimid,time_dimid], validtime_varid); NC_ERR_STOP(ncerr)
-       ncerr = nf90_put_att(ncid, validtime_varid, "long_name", "valid time"); NC_ERR_STOP(ncerr)
-       ncerr = nf90_put_att(ncid, validtime_varid, "units", "ISO 8601 datetime string"); NC_ERR_STOP(ncerr)
+       ncerr = nf90_def_var(ncid, "time_iso", NF90_CHAR, [ch_dimid,time_dimid], timeiso_varid); NC_ERR_STOP(ncerr)
+       ncerr = nf90_put_att(ncid, timeiso_varid, "long_name", "valid time"); NC_ERR_STOP(ncerr)
+       ncerr = nf90_put_att(ncid, timeiso_varid, "description", "ISO 8601 datetime string"); NC_ERR_STOP(ncerr)
 
        ! coordinate variable attributes based on output_grid type
        if (trim(output_grid(grid_id)) == 'gaussian_grid' .or. &
@@ -280,7 +280,7 @@ module module_write_netcdf
           ncerr = nf90_var_par_access(ncid, lon_varid, NF90_INDEPENDENT); NC_ERR_STOP(ncerr)
           ncerr = nf90_var_par_access(ncid, jm_varid, NF90_INDEPENDENT); NC_ERR_STOP(ncerr)
           ncerr = nf90_var_par_access(ncid, lat_varid, NF90_INDEPENDENT); NC_ERR_STOP(ncerr)
-          ncerr = nf90_var_par_access(ncid, validtime_varid, NF90_INDEPENDENT); NC_ERR_STOP(ncerr)
+          ncerr = nf90_var_par_access(ncid, timeiso_varid, NF90_INDEPENDENT); NC_ERR_STOP(ncerr)
           if (is_cubed_sphere) then
              ncerr = nf90_var_par_access(ncid, tile_varid, NF90_INDEPENDENT); NC_ERR_STOP(ncerr)
           end if
@@ -566,11 +566,11 @@ module module_write_netcdf
        ncerr = nf90_put_var(ncid, tile_varid, values=[1,2,3,4,5,6]); NC_ERR_STOP(ncerr)
     end if
 
-    ! write valid_time (validtime_varid)
+    ! write time_iso (timeiso_varid)
     if (do_io) then
        call ESMF_AttributeGet(wrtgrid, convention="NetCDF", purpose="FV3", &
-                              name="valid_time", value=varcval, rc=rc); ESMF_ERR_RETURN(rc)
-       ncerr = nf90_put_var(ncid, validtime_varid, values=[trim(varcval)]); NC_ERR_STOP(ncerr)
+                              name="time_iso", value=varcval, rc=rc); ESMF_ERR_RETURN(rc)
+       ncerr = nf90_put_var(ncid, timeiso_varid, values=[trim(varcval)]); NC_ERR_STOP(ncerr)
     end if
 
     ! write variables (fields)

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -1431,7 +1431,7 @@
 !
       character(esmf_maxstr)                :: filename,compname
       character(40)                         :: cfhour, cform
-      character(20)                         :: valid_time_iso
+      character(20)                         :: time_iso
       real(ESMF_KIND_R8)                    :: time
 !
       real(kind=8)  :: MPI_Wtime
@@ -1484,7 +1484,7 @@
 
       wrt_int_state%fdate(7) = 1
       wrt_int_state%fdate(1:6) = date(1:6)
-      write(valid_time_iso,'(I4,"-",I2.2,"-",I2.2,"T",I2.2,":",I2.2,":",I2.2,"Z")') date(1:6)
+      write(time_iso,'(I4,"-",I2.2,"-",I2.2,"T",I2.2,":",I2.2,":",I2.2,"Z")') date(1:6)
 
       call ESMF_TimeGet(time=wrt_int_state%IO_BASETIME,yy=date(1),mm=date(2),dd=date(3),h=date(4), &
                         m=date(5),s=date(6),rc=rc)
@@ -1652,7 +1652,7 @@
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
           call ESMF_AttributeSet(fbgrid, convention="NetCDF", purpose="FV3", &
-                               name="valid_time", value=trim(valid_time_iso), rc=rc)
+                               name="time_iso", value=trim(time_iso), rc=rc)
 
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -1427,7 +1427,6 @@
       character(esmf_maxstr)                :: filename,compname
       character(40)                         :: cfhour, cform
       character(20)                         :: time_iso
-      real(ESMF_KIND_R8)                    :: time
 !
       real(kind=8)  :: MPI_Wtime
       real(kind=8)  :: tbeg
@@ -1503,14 +1502,7 @@
         write(cfhour, cform) nf_hours
       endif
 !
-       if(lprnt) print *,'in wrt run, nf_hours=',nf_hours,nf_minutes,nf_seconds, &
-                ' FBCount=',FBCount,' cfhour=',trim(cfhour)
-
-! access the time Attribute which is updated by the driver each time
-      call ESMF_AttributeGet(imp_state_write, convention="NetCDF", purpose="FV3", &
-                              name="time", value=time, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
+       if(lprnt) print *,'in wrt run, nfhour=',nfhour,' cfhour=',trim(cfhour)
 !
 !-----------------------------------------------------------------------
 !*** loop on the files that need to write out

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -1431,6 +1431,7 @@
 !
       character(esmf_maxstr)                :: filename,compname
       character(40)                         :: cfhour, cform
+      character(20)                         :: valid_time_iso
       real(ESMF_KIND_R8)                    :: time
 !
       real(kind=8)  :: MPI_Wtime
@@ -1475,25 +1476,22 @@
 !*** get current time and elapsed forecast time
 
       call ESMF_ClockGet(clock=CLOCK, currTime=CURRTIME, rc=rc)
-
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
       call ESMF_TimeGet(time=currTime,yy=date(1),mm=date(2),dd=date(3),h=date(4), &
                         m=date(5),s=date(6),rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
       wrt_int_state%fdate(7) = 1
       wrt_int_state%fdate(1:6) = date(1:6)
+      write(valid_time_iso,'(I4,"-",I2.2,"-",I2.2,"T",I2.2,":",I2.2,":",I2.2,"Z")') date(1:6)
 
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-!    if(mype == lead_write_task) print *,'in wrt run, curr time=',date
-!
       call ESMF_TimeGet(time=wrt_int_state%IO_BASETIME,yy=date(1),mm=date(2),dd=date(3),h=date(4), &
                         m=date(5),s=date(6),rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-!    print *,'in wrt run, io_baseline time=',date
-!
       wrt_int_state%IO_CURRTIMEDIFF = CURRTIME-wrt_int_state%IO_BASETIME
-!
+
       call ESMF_TimeIntervalGet(timeinterval=wrt_int_state%IO_CURRTIMEDIFF &
                                    ,h           =nf_hours               &  !<-- Hours of elapsed time
                                    ,m           =nf_minutes             &  !<-- Minutes of elapsed time
@@ -1650,6 +1648,11 @@
 
           call ESMF_AttributeSet(fbgrid, convention="NetCDF", purpose="FV3", &
                                name="time", value=real(wrt_int_state%nfhour,ESMF_KIND_R8), rc=rc)
+
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+          call ESMF_AttributeSet(fbgrid, convention="NetCDF", purpose="FV3", &
+                               name="valid_time", value=trim(valid_time_iso), rc=rc)
 
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -832,7 +832,26 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
       call ESMF_AttributeSet(exportState, convention="NetCDF", purpose="FV3", &
                                name="time:calendar", value=uppercase(trim(calendar)), rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-!
+
+! Add valid_time Attribute to the exportState
+      call ESMF_AttributeAdd(exportState, convention="NetCDF", purpose="FV3", &
+        attrList=(/ "valid_time               ", &
+                    "valid_time:long_name     ", &
+                    "valid_time:units         " /), rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+      call ESMF_AttributeSet(exportState, convention="NetCDF", purpose="FV3", &
+                               name="valid_time", value="yyyy-mm-ddThh:mm:ssZ", rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+      call ESMF_AttributeSet(exportState, convention="NetCDF", purpose="FV3", &
+                               name="valid_time:units", value="ISO 8601 Date String", rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+      call ESMF_AttributeSet(exportState, convention="NetCDF", purpose="FV3", &
+                               name="valid_time:long_name", value="valid time", rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
 ! Create FieldBundle for Fields that need to be regridded bilinear
       if( quilting ) then
 

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -328,7 +328,6 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 
     integer,dimension(6)                   :: date, date_end
 !
-    character(len=9) :: month
     integer :: initClock, unit, total_inttime
     integer :: mype
     character(4) dateSY
@@ -590,17 +589,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 ! if there is restart writing during integration
     intrm_rst         = 0
     if (frestart(1)>0) intrm_rst = 1
-!
-!----- write time stamps (for start time and end time) ------
 
-     call mpp_open( unit, 'time_stamp.out', nohdrs=.TRUE. )
-     month = month_name(date(2))
-     if ( mpp_pe() == mpp_root_pe() ) write (unit,20) date, month(1:3)
-     month = month_name(date_end(2))
-     if ( mpp_pe() == mpp_root_pe() ) write (unit,20) date_end, month(1:3)
-     call mpp_close (unit)
- 20  format (6i4,2x,a3)
-!
 !------ initialize component models ------
 
      call  atmos_model_init (Atmos, Time_init, Time, Time_step)

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -833,23 +833,23 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
                                name="time:calendar", value=uppercase(trim(calendar)), rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-! Add valid_time Attribute to the exportState
+! Add time_iso Attribute to the exportState
       call ESMF_AttributeAdd(exportState, convention="NetCDF", purpose="FV3", &
-        attrList=(/ "valid_time               ", &
-                    "valid_time:long_name     ", &
-                    "valid_time:units         " /), rc=rc)
+        attrList=(/ "time_iso               ", &
+                    "time_iso:long_name     ", &
+                    "time_iso:description   " /), rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
       call ESMF_AttributeSet(exportState, convention="NetCDF", purpose="FV3", &
-                               name="valid_time", value="yyyy-mm-ddThh:mm:ssZ", rc=rc)
+                               name="time_iso", value="yyyy-mm-ddThh:mm:ssZ", rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
       call ESMF_AttributeSet(exportState, convention="NetCDF", purpose="FV3", &
-                               name="valid_time:units", value="ISO 8601 Date String", rc=rc)
+                               name="time_iso:description", value="ISO 8601 Date String", rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
       call ESMF_AttributeSet(exportState, convention="NetCDF", purpose="FV3", &
-                               name="valid_time:long_name", value="valid time", rc=rc)
+                               name="time_iso:long_name", value="valid time", rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
 ! Create FieldBundle for Fields that need to be regridded bilinear


### PR DESCRIPTION
## Description
Add 'valid time' variable using ISO string format to netcdf history files.
Use double precision variable to set value of 'time' attribute in wrt comp import state
Update ccpp/physics (setting surface-related interstitial variables for SCM prescribed-surface-flux mode)
Update inline_post_stub.F90 subroutine interfaces to match inline_post.F90

### Issue(s) addressed

- fixes https://github.com/ufs-community/ufs-weather-model/issues/1052

## Testing

How were these changes tested?  Used one ufs regression test to verify that the actual data are identical.
What compilers / HPCs was it tested with?  Intel
Are the changes covered by regression tests? Yes.
Have the ufs-weather-model regression test been run? Not yet.
- Will the code updates change regression test baseline? Yes.
- If yes, why? New netcdf variable is added, so all netcdf history files will be different. 
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on https://github.com/NCAR/ccpp-physics/pull/870
