### PR TITLE
Feature/post 2d decomp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,5 @@
   branch = main
 [submodule "upp"]
   path = upp
-  url = https://github.com/NOAA-EMC/UPP
-  branch = develop
+  url = https://github.com/WenMeng-NOAA/UPP
+  branch = post_2d_decomp

--- a/io/module_write_internal_state.F90
+++ b/io/module_write_internal_state.F90
@@ -49,8 +49,8 @@
       integer :: lat_start, lon_start
       integer :: lat_end, lon_end
       real    :: latstart, latlast, lonstart, lonlast
-      integer,dimension(:),allocatable :: lat_start_wrtgrp
-      integer,dimension(:),allocatable :: lat_end_wrtgrp
+      integer,dimension(:),allocatable :: lat_start_wrtgrp, lon_start_wrtgrp
+      integer,dimension(:),allocatable :: lat_end_wrtgrp, lon_end_wrtgrp
       real,dimension(:,:),allocatable  :: lonPtr, latPtr
 !
 !--------------------------

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -23,6 +23,7 @@
 !     Jul 2017:  J. Wang/G. Theurich  - initial code for fv3 write grid component
 !     Mar 2018:  S  Moorthi           - changing cfhour to accommodate up to 99999 hours
 !     Aug 2019:  J. Wang              - add inline post
+!     Feb 2022:  J. Meng/B. Cui       - create interface to run inline post with upp_2d_decomp
 !
 !---------------------------------------------------------------------------------
 !

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -125,6 +125,7 @@
 !***  INITIALIZE THE WRITE GRIDDED COMPONENT.
 !-----------------------------------------------------------------------
 !
+      use ctlblk_mod, only: numx
       type(esmf_GridComp)               :: wrt_comp
       type(ESMF_State)                  :: imp_state_write, exp_state_write
       type(esmf_Clock)                  :: clock
@@ -364,6 +365,8 @@
         itasks = 1
         jtasks = ntasks
       endif
+      numx = itasks
+      if (lprnt) print *,'jtasks=',jtasks,' itasks=',itasks,' numx=',numx
 
       if(trim(output_grid(n)) == 'gaussian_grid' .or. trim(output_grid(n)) == 'global_latlon') then
         call ESMF_ConfigGetAttribute(config=cf_output_grid, value=imo(n), label ='imo:',rc=rc)

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -23,7 +23,7 @@
 !     Jul 2017:  J. Wang/G. Theurich  - initial code for fv3 write grid component
 !     Mar 2018:  S  Moorthi           - changing cfhour to accommodate up to 99999 hours
 !     Aug 2019:  J. Wang              - add inline post
-!     Feb 2022:  J. Meng/B. Cui       - create interface to run inline post with upp_2d_decomp
+!     Feb 2022:  J. Meng/B. Cui       - create interface to run inline post with post_2d_decomp
 !
 !---------------------------------------------------------------------------------
 !

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -484,10 +484,16 @@
         wrt_int_state%lon_end   = ubound(lonPtr,1)
         allocate( wrt_int_state%lat_start_wrtgrp(wrt_int_state%petcount))
         allocate( wrt_int_state%lat_end_wrtgrp  (wrt_int_state%petcount))
+        allocate( wrt_int_state%lon_start_wrtgrp(wrt_int_state%petcount))
+        allocate( wrt_int_state%lon_end_wrtgrp  (wrt_int_state%petcount))
         call mpi_allgather(wrt_int_state%lat_start,1,MPI_INTEGER,    &
                            wrt_int_state%lat_start_wrtgrp, 1, MPI_INTEGER, wrt_mpi_comm, rc)
         call mpi_allgather(wrt_int_state%lat_end,  1,MPI_INTEGER,    &
                            wrt_int_state%lat_end_wrtgrp,   1, MPI_INTEGER, wrt_mpi_comm, rc)
+        call mpi_allgather(wrt_int_state%lon_start,1,MPI_INTEGER,    &
+                           wrt_int_state%lon_start_wrtgrp, 1, MPI_INTEGER, wrt_mpi_comm, rc)
+        call mpi_allgather(wrt_int_state%lon_end,  1,MPI_INTEGER,    &
+                           wrt_int_state%lon_end_wrtgrp,   1, MPI_INTEGER, wrt_mpi_comm, rc)
         if( lprnt ) print *,'aft wrtgrd, Gaussian, dimj_start=',wrt_int_state%lat_start_wrtgrp, &
           'dimj_end=',wrt_int_state%lat_end_wrtgrp, 'wrt_group=',n_group, &
           'lon_start,end=',wrt_int_state%lon_start,wrt_int_state%lon_end, &
@@ -568,10 +574,16 @@
         wrt_int_state%lon_end   = ubound(lonPtr,1)
         allocate( wrt_int_state%lat_start_wrtgrp(wrt_int_state%petcount))
         allocate( wrt_int_state%lat_end_wrtgrp  (wrt_int_state%petcount))
+        allocate( wrt_int_state%lon_start_wrtgrp(wrt_int_state%petcount))
+        allocate( wrt_int_state%lon_end_wrtgrp  (wrt_int_state%petcount))
         call mpi_allgather(wrt_int_state%lat_start,1,MPI_INTEGER,    &
                            wrt_int_state%lat_start_wrtgrp, 1, MPI_INTEGER, wrt_mpi_comm, rc)
         call mpi_allgather(wrt_int_state%lat_end,  1,MPI_INTEGER,    &
                            wrt_int_state%lat_end_wrtgrp,   1, MPI_INTEGER, wrt_mpi_comm, rc)
+        call mpi_allgather(wrt_int_state%lon_start,1,MPI_INTEGER,    &
+                           wrt_int_state%lon_start_wrtgrp, 1, MPI_INTEGER, wrt_mpi_comm, rc)
+        call mpi_allgather(wrt_int_state%lon_end,  1,MPI_INTEGER,    &
+                           wrt_int_state%lon_end_wrtgrp,   1, MPI_INTEGER, wrt_mpi_comm, rc)
         if( lprnt ) print *,'aft wrtgrd, latlon, dimj_start=',wrt_int_state%lat_start_wrtgrp, &
           'dimj_end=',wrt_int_state%lat_end_wrtgrp, 'wrt_group=',n_group
         allocate( wrt_int_state%latPtr(wrt_int_state%lon_start:wrt_int_state%lon_end, &
@@ -655,10 +667,16 @@
         wrt_int_state%lon_end   = ubound(lonPtr,1)
         allocate( wrt_int_state%lat_start_wrtgrp(wrt_int_state%petcount))
         allocate( wrt_int_state%lat_end_wrtgrp  (wrt_int_state%petcount))
+        allocate( wrt_int_state%lon_start_wrtgrp(wrt_int_state%petcount))
+        allocate( wrt_int_state%lon_end_wrtgrp  (wrt_int_state%petcount))
         call mpi_allgather(wrt_int_state%lat_start,1,MPI_INTEGER,    &
-                       wrt_int_state%lat_start_wrtgrp, 1, MPI_INTEGER, wrt_mpi_comm, rc)
+                           wrt_int_state%lat_start_wrtgrp, 1, MPI_INTEGER, wrt_mpi_comm, rc)
         call mpi_allgather(wrt_int_state%lat_end,  1,MPI_INTEGER,    &
                            wrt_int_state%lat_end_wrtgrp,   1, MPI_INTEGER, wrt_mpi_comm, rc)
+        call mpi_allgather(wrt_int_state%lon_start,1,MPI_INTEGER,    &
+                           wrt_int_state%lon_start_wrtgrp, 1, MPI_INTEGER, wrt_mpi_comm, rc)
+        call mpi_allgather(wrt_int_state%lon_end,  1,MPI_INTEGER,    &
+                           wrt_int_state%lon_end_wrtgrp,   1, MPI_INTEGER, wrt_mpi_comm, rc)
         allocate( wrt_int_state%latPtr(wrt_int_state%lon_start:wrt_int_state%lon_end, &
                   wrt_int_state%lat_start:wrt_int_state%lat_end))
         allocate( wrt_int_state%lonPtr(wrt_int_state%lon_start:wrt_int_state%lon_end, &

--- a/io/post_gfs.F90
+++ b/io/post_gfs.F90
@@ -116,7 +116,6 @@ module post_gfs
 !
         call read_postnmlt(kpo,kth,kpv,po,th,pv,wrt_int_state%post_nlunit, &
                            wrt_int_state%post_namelist)
-        print*,'BOCUI in post_gfs numx= ',numx
 !
 !-----------------------------------------------------------------------
 !*** allocate post variables

--- a/io/post_gfs.F90
+++ b/io/post_gfs.F90
@@ -23,6 +23,7 @@ module post_gfs
 !  revision history:
 !     Jul 2019    J. Wang      create interface to run inline post for FV3
 !     Apr 2021    R. Sun       Added variables for Thomspon MP
+!     Feb 2022    J. Meng/B. Cui create interface to run inline post with upp_2d_decomp
 !
 !-----------------------------------------------------------------------
 !*** run post on write grid comp

--- a/io/post_gfs.F90
+++ b/io/post_gfs.F90
@@ -23,7 +23,7 @@ module post_gfs
 !  revision history:
 !     Jul 2019    J. Wang      create interface to run inline post for FV3
 !     Apr 2021    R. Sun       Added variables for Thomspon MP
-!     Feb 2022    J. Meng/B. Cui create interface to run inline post with upp_2d_decomp
+!     Feb 2022    J. Meng/B. Cui create interface to run inline post with post_2d_decomp
 !
 !-----------------------------------------------------------------------
 !*** run post on write grid comp

--- a/io/post_nems_routines.F90
+++ b/io/post_nems_routines.F90
@@ -9,7 +9,7 @@
 !
 !   revision history:
 !    Jul 2019 Jun Wang: allocate arrays for post processing
-!    Feb 2022 J. Meng/B. Cui: create interface to run inline post with upp_2d_decomp
+!    Feb 2022 J. Meng/B. Cui: create interface to run inline post with post_2d_decomp
 !
 !-----------------------------------------------------------------------
 !*** allocate post variables

--- a/io/post_nems_routines.F90
+++ b/io/post_nems_routines.F90
@@ -90,7 +90,7 @@
          jsta_m2 = 3
       end if
 !      if ( mype == last_write_task ) then
-      if ( mype>=(last_write_task-numx) ) then
+      if ( mype>(last_write_task-numx) ) then
          jend_m  = jm - 1
          jend_m2 = jm - 2
       end if

--- a/io/post_nems_routines.F90
+++ b/io/post_nems_routines.F90
@@ -177,7 +177,7 @@
       print 901,'GWVX mype/me=',mype,me,'im=',im,'ista   =',ista   ,'iend   =',iend   ,'lm=',lm
       print 901,'GWVX mype/me=',mype,me,'im=',im,'ista_m =',ista_m ,'iend_m =',iend_m ,'lm=',lm
       print 901,'GWVX mype/me=',mype,me,'im=',im,'ista_2l=',ista_2l,'iend_2u=',iend_2u,'lm=',lm
-  901 format(15a,2i4,4(1x,a8,i4))
+  901 format(a15,2i4,4(1x,a8,i4))
 !       NEW neighbors
       ileft = me - 1
       iright = me + 1

--- a/io/post_nems_routines.F90
+++ b/io/post_nems_routines.F90
@@ -9,7 +9,7 @@
 !
 !   revision history:
 !    Jul 2019 Jun Wang: allocate arrays for post processing
-!
+!    Feb 2022 J. Meng/B. Cui: create interface to run inline post with upp_2d_decomp
 !
 !-----------------------------------------------------------------------
 !*** allocate post variables
@@ -25,13 +25,8 @@
                             jend_m, jend_m2, jvend_2u, jsta_2l, jend_2u, iup, idn, &
                             icnt, idsp, mpi_comm_comp, num_servers,     &
                             numx, ista, iend, ista_m, ista_m2, &
-                            iend_m, iend_m2, ista_2l, iend_2u, idsp2, icnt2, &
+                            iend_m, iend_m2, ista_2l, iend_2u, &
                             ileft,iright,ileftb,irightb, &
-                            ibsize,ibsum,                                             &
-                            isxa,iexa,jsxa,jexa,  &
-                            icoords,ibcoords,bufs,ibufs, &   ! GWV TMP
-                            rbufs                      , &   ! GWV TMP
-                            rcoords,rbcoords, &   ! GWV TMP
                             num_procs
 !
 !-----------------------------------------------------------------------
@@ -55,21 +50,11 @@
 !
       integer i,j,l
       integer last_write_task
-
-      integer                          :: ierr,jsx,jex,isx,iex
-      integer ii,jj,isum,isumm,isumm2
-      integer , allocatable            :: ibuff(:)
-      real    , allocatable            :: rbuff(:)
-      integer,  allocatable            :: ipole(:),ipoles(:,:)
-      real   ,  allocatable            :: rpole(:),rpoles(:,:)
 !
 !-----------------------------------------------------------------------
 !*** get dims from int_state
 !-----------------------------------------------------------------------
 !
-      isumm=0
-      isumm2=0
-
       im = imi
       jm = jmi
       lm = lmi
@@ -100,12 +85,12 @@
       jend_m  = jend
       jend_m2 = jend
 !      if ( mype == lead_write ) then
-      if ( mype<numx ) then
+      if ( mype<(lead_write+numx) ) then
          jsta_m  = 2
          jsta_m2 = 3
       end if
 !      if ( mype == last_write_task ) then
-      if ( mype>=(num_procs-numx) ) then
+      if ( mype>=(last_write_task-numx) ) then
          jend_m  = jm - 1
          jend_m2 = jm - 2
       end if

--- a/io/post_nems_routines.F90
+++ b/io/post_nems_routines.F90
@@ -27,7 +27,7 @@
                             modelname, numx, ista, iend, ista_m, ista_m2, &
                             iend_m, iend_m2, ista_2l, iend_2u, &
                             ileft,iright,ileftb,irightb, &
-                            icnt2, idsp2, &
+                            icnt2, idsp2,isxa,iexa,jsxa,jexa, &
                             num_procs
 !
 !-----------------------------------------------------------------------
@@ -128,6 +128,11 @@
 !
       isumm=0
       isumm2=0
+      allocate(isxa(0:num_procs-1) )
+      allocate(jsxa(0:num_procs-1) )
+      allocate(iexa(0:num_procs-1) )
+      allocate(jexa(0:num_procs-1) )
+
       do i = 1, num_procs
 !       icnt(i-1) = (jtegrp(i)-jtsgrp(i)+1)*im
 !       idsp(i-1) = (jtsgrp(i)-1)*im
@@ -135,6 +140,10 @@
 !           print *, ' i, icnt(i),idsp(i) = ',i-1,icnt(i-1),idsp(i-1)
 !       end if
        icnt(i-1) = (jtegrp(i)-jtsgrp(i)+1)*(itegrp(i)-itsgrp(i)+1)
+       isxa(i-1) = itsgrp(i)
+       iexa(i-1) = itegrp(i)
+       jsxa(i-1) = jtsgrp(i)
+       jexa(i-1) = jtegrp(i)
        idsp(i-1) = isumm
        isumm=isumm+icnt(i-1)
        if(jtsgrp(i)==1 .or. jtegrp(i)==jm) then
@@ -162,10 +171,13 @@
 ! special for c-grid v
       jvend_2u = min(jend + 2, jm+1 )
       if(mype==0)print *,'im=',im,'jsta_2l=',jsta_2l,'jend_2u=',jend_2u,'lm=',lm
-      print *,'GWVX mype/me=',mype,me,'im=',im,'jsta   =',jsta   ,'jend   =',jend   ,'lm=',lm
-      print *,'GWVX mype/me=',mype,me,'im=',im,'jsta_2l=',jsta_2l,'jend_2u=',jend_2u,'lm=',lm
-      print *,'GWVX mype/me=',mype,me,'im=',im,'ista   =',ista   ,'iend   =',iend   ,'lm=',lm
-      print *,'GWVX mype/me=',mype,me,'im=',im,'ista_2l=',ista_2l,'iend_2u=',iend_2u,'lm=',lm
+      print 901,'GWVX mype/me=',mype,me,'im=',im,'jsta   =',jsta   ,'jend   =',jend   ,'lm=',lm
+      print 901,'GWVX mype/me=',mype,me,'im=',im,'jsta_m =',jsta_m ,'jend_m =',jend_m ,'lm=',lm
+      print 901,'GWVX mype/me=',mype,me,'im=',im,'jsta_2l=',jsta_2l,'jend_2u=',jend_2u,'lm=',lm
+      print 901,'GWVX mype/me=',mype,me,'im=',im,'ista   =',ista   ,'iend   =',iend   ,'lm=',lm
+      print 901,'GWVX mype/me=',mype,me,'im=',im,'ista_m =',ista_m ,'iend_m =',iend_m ,'lm=',lm
+      print 901,'GWVX mype/me=',mype,me,'im=',im,'ista_2l=',ista_2l,'iend_2u=',iend_2u,'lm=',lm
+  901 format(15a,2i4,4(1x,a8,i4))
 !       NEW neighbors
       ileft = me - 1
       iright = me + 1

--- a/io/post_nems_routines.F90
+++ b/io/post_nems_routines.F90
@@ -24,7 +24,7 @@
                             ioform, jsta, jend, jsta_m, jsta_m2, &
                             jend_m, jend_m2, jvend_2u, jsta_2l, jend_2u, iup, idn, &
                             icnt, idsp, mpi_comm_comp, num_servers,     &
-                            numx, ista, iend, ista_m, ista_m2, &
+                            modelname, numx, ista, iend, ista_m, ista_m2, &
                             iend_m, iend_m2, ista_2l, iend_2u, &
                             ileft,iright,ileftb,irightb, &
                             num_procs
@@ -136,13 +136,13 @@
 !
       jsta_2l = max(jsta - 2,  1 )
       jend_2u = min(jend + 2, jm )
-!      if(modelname=='GFS') then
+      if(modelname=='GFS') then
         ista_2l=max(ista-2,0)
         iend_2u=min(iend+2,im+1)
-!      else
-!        ista_2l = max(ista - 2,  1 )
-!        iend_2u = min(iend + 2, im )
-!      endif
+      else
+        ista_2l = max(ista - 2,  1 )
+        iend_2u = min(iend + 2, im )
+      endif
 ! special for c-grid v
       jvend_2u = min(jend + 2, jm+1 )
       if(mype==0)print *,'im=',im,'jsta_2l=',jsta_2l,'jend_2u=',jend_2u,'lm=',lm

--- a/io/post_regional.F90
+++ b/io/post_regional.F90
@@ -34,9 +34,8 @@ module post_regional
 !
       use ctlblk_mod, only : komax,ifhr,ifmin,modelname,datapd,fld_info, &
                              npset,grib,gocart_on,icount_calmict, jsta,  &
-                             jend,im, nsoil, filenameflat, ista, iend
-      use gridspec_mod, only : maptype, gridtype,latstart,latlast,       &
-                               lonstart,lonlast
+                             jend,ista,iend, im, nsoil, filenameflat,numx
+      use gridspec_mod, only : maptype, gridtype
       use grib2_module, only : gribit2,num_pset,nrecout,first_grbtbl
       use xml_perl_data,only : paramset
 !

--- a/io/post_regional.F90
+++ b/io/post_regional.F90
@@ -26,7 +26,7 @@ module post_regional
 !  revision history:
 !     Jul 2019    J. Wang             create interface to run inline post for FV3
 !     Sep 2020    J. Dong/J. Wang     create interface to run inline post for FV3-LAM
-!     Feb 2022    J. Meng/B. Cui      create interface to run inline post with upp_2d_decomp
+!     Feb 2022    J. Meng/B. Cui      create interface to run inline post with post_2d_decomp
 !
 !-----------------------------------------------------------------------
 !*** run post on write grid comp

--- a/io/post_regional.F90
+++ b/io/post_regional.F90
@@ -580,6 +580,9 @@ module post_regional
         enddo
       enddo
 
+      call exch(gdlat)
+      call exch(gdlon)
+
 !$omp parallel do default(none),private(i,j,ip1), &
 !$omp&  shared(jsta,jend_m,im,dx,gdlat,gdlon,dy,ista,iend_m)
       do j = jsta, jend_m

--- a/io/post_regional.F90
+++ b/io/post_regional.F90
@@ -34,8 +34,9 @@ module post_regional
 !
       use ctlblk_mod, only : komax,ifhr,ifmin,modelname,datapd,fld_info, &
                              npset,grib,gocart_on,icount_calmict, jsta,  &
-                             jend,ista,iend, im, nsoil, filenameflat,numx
-      use gridspec_mod, only : maptype, gridtype
+                             jend,im, nsoil, filenameflat, ista, iend
+      use gridspec_mod, only : maptype, gridtype,latstart,latlast,       &
+                               lonstart,lonlast
       use grib2_module, only : gribit2,num_pset,nrecout,first_grbtbl
       use xml_perl_data,only : paramset
 !


### PR DESCRIPTION
## Description
The community upp is currently decomposed on latitudes (y-direction) only. As the ufs-weather-model is making 2D decomposition in both latitudes and longitudes (Y and X), one of the upp refactoring tasks is to support ufs-weather-model inline post 2D decomposition functionality.

A ufs-weather-model feature post_2d_decomp is created for this test with inline post turned on in the control_2dwrtdecomp and regional_control_2dwrtdecomp tests,
https://github.com/JesseMeng-NOAA/ufs-weather-model/tree/feature/post_2d_decomp

A fv3atm feature post_2d_decomp is created with modified io drivers to call upp/post_2d_decomp,
https://github.com/JesseMeng-NOAA/fv3atm/tree/feature/post_2d_decomp

The upp/post_2d_decomp branch can be found at
https://github.com/WenMeng-NOAA/UPP/tree/post_2d_decomp


### Issue(s) addressed

https://github.com/ufs-community/ufs-weather-model/issues/1078

## Testing

ufs-weather-model  rt tests with inline post turned on in the control_2dwrtdecomp and regional_control_2dwrtdecomp tests.

## Dependencies

The upp/post_2d_decomp branch,
https://github.com/WenMeng-NOAA/UPP/tree/post_2d_decomp
