### PR TITLE
Fix Lambert Conformal Conic mapping in the write component on the southern hemisphere

### DIFF
--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -3600,7 +3600,7 @@
       rho0 = de/(tan((45+0.5*c_lat)*dtor)**en)                         ! (15-1a)
 
       if (inv == 1) then          ! FORWARD TRANSFORMATION
-         rho = de*(tan((45-0.5*glat)*dtor)**en)                        ! (15-1)
+         rho = de/(tan((45+0.5*glat)*dtor)**en)                        ! (15-1)
          dlon = modulo(glon-c_lon+180.0+3600.0,360.0)-180.0
          theta = en*dlon*dtor                                          ! (14-4)
          x = rho*sin(theta)                                            ! (14-1)

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -3566,7 +3566,7 @@
          en = log(cos(stlat1*dtor)/cos(stlat2*dtor)) / &
               log(tan((45+0.5*stlat2)*dtor)/tan((45+0.5*stlat1)*dtor)) ! (15-3)
       endif
-      h = sign(1.0,en)
+      h = sign(1.0_ESMF_KIND_R8,en)
 
       de = a*(cos(stlat1*dtor)*tan((45+0.5*stlat1)*dtor)**en)/en       ! (15-2)
       rho0 = de/(tan((45+0.5*c_lat)*dtor)**en)                         ! (15-1a)


### PR DESCRIPTION
## Description

Subroutine `lambert` in the write component has been fixed to do the mapping on the southern hemisphere correctly.

Is a change of answers expected from this PR?  Yes. due to changes in formulas used for lambert projection 4 tests that output history files on lambert conformal conic grid will be changed.

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes https://github.com/ufs-community/ufs-weather-model/issues/838

## Testing

How were these changes tested?   Yes
What compilers / HPCs was it tested with? Intel/Hera  
Are the changes covered by regression tests? Yes.
Have the ufs-weather-model regression test been run? Yes.
On what platform?  Hera
- Will the code updates change regression test baseline? Yes.
- If yes, why? 4 tests that output history files on Lambret projection are different.