### PR TITLE
Added capability for cdmbgwd(1) to scale GSL blocking drag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/mdtoyNOAA/ccpp-physics
-  branch = main_new_cdmbgwd
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/mdtoyNOAA/ccpp-physics
+  branch = main_new_cdmbgwd
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

Made a minor change to physics/drag_suite.F90, which activates the namelist variable cdmbgwd(1) and allows it to scale the calculation of the surface stress due to the GSL blocking drag.
 
Is a change of answers expected from this PR?  Yes.



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
- fixes [#874](https://github.com/NCAR/ccpp-physics/issues/874)




## Testing

These changes were tested on Hera with the Intel compiler.  Regression test log is available at:
/scratch1/BMC/wrfruc/mtoy/git_local/ufs-weather-model/tests/RegressionTests_hera.intel.log

Baseline test results are on Hera at:
/scratch1/BMC/wrfruc/mtoy/git_local/ufs-weather-model/REGRESSION_TEST_INTEL.2022_03_11/

