### PR TITLE
add "_Encoding" attribute to time_iso history file variable

### DIFF
--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -236,6 +236,7 @@ module module_write_netcdf
        ncerr = nf90_def_var(ncid, "time_iso", NF90_CHAR, [ch_dimid,time_dimid], timeiso_varid); NC_ERR_STOP(ncerr)
        ncerr = nf90_put_att(ncid, timeiso_varid, "long_name", "valid time"); NC_ERR_STOP(ncerr)
        ncerr = nf90_put_att(ncid, timeiso_varid, "description", "ISO 8601 datetime string"); NC_ERR_STOP(ncerr)
+       ncerr = nf90_put_att(ncid, timeiso_varid, "_Encoding", "ascii"); NC_ERR_STOP(ncerr)
 
        ! coordinate variable attributes based on output_grid type
        if (trim(output_grid(grid_id)) == 'gaussian_grid' .or. &

--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -236,7 +236,7 @@ module module_write_netcdf
        ncerr = nf90_def_var(ncid, "time_iso", NF90_CHAR, [ch_dimid,time_dimid], timeiso_varid); NC_ERR_STOP(ncerr)
        ncerr = nf90_put_att(ncid, timeiso_varid, "long_name", "valid time"); NC_ERR_STOP(ncerr)
        ncerr = nf90_put_att(ncid, timeiso_varid, "description", "ISO 8601 datetime string"); NC_ERR_STOP(ncerr)
-       ncerr = nf90_put_att(ncid, timeiso_varid, "_Encoding", "ascii"); NC_ERR_STOP(ncerr)
+       ncerr = nf90_put_att(ncid, timeiso_varid, "_Encoding", "UTF-8"); NC_ERR_STOP(ncerr)
 
        ! coordinate variable attributes based on output_grid type
        if (trim(output_grid(grid_id)) == 'gaussian_grid' .or. &


### PR DESCRIPTION
The 'time_iso' variable is an array of characters.  The "_Encoding" attribute allows netcdf clients (like python) to automatically convert the array of characters to a fixed-length string (see https://github.com/Unidata/netcdf4-python/issues/654#issuecomment-298735562).  

Before this patch,
```python
>>> nc = Dataset('test.nc')
>>> nc['time_iso'][:]
masked_array(data=[[b'2', b'0', b'2', b'1', b'-', b'0', b'8', b'-', b'3',
                    b'0', b'T', b'0', b'0', b':', b'0', b'0', b':', b'0',
                    b'0', b'Z']],
             mask=False,
       fill_value=b'N/A',
            dtype='|S1')
>>> 
```

After this patch,
```python
>>> nc['time_iso'][:]
array(['2016-01-04T06:00:00Z'], dtype='<U20')
>>>
```

See also https://github.com/Unidata/netcdf-c/issues/402

Since this patch is tiny it might make sense to merge it into another larger update.