### PR TITLE
Added hailcast code in atmos_cubed_sphere

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  url = https://github.com/ywangwof/GFDL_atmos_cubed_sphere
+  branch = feature/HAILCAST
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description

Added hail size forecasting diagnostic output in atmos_cubed_sphere, [PR #164](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/164).

### Issue(s) addressed

See atmos_cubed_sphere, [PR #164](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/164).

## Testing

It was tested on Jet and a NSSL machine - Odin with Intel compiler.
No regression tests need since it will not change the model, but a diagnostic output.

## Dependencies

- waiting on NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/164
