### PR TITLE
Point to release branch of CCPP physics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  branch = release/public-v6
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -213,10 +213,6 @@ SCHEME_FILES = [
     'physics/physics/sfc_sice.f',
     # HAFS FER_HIRES
     'physics/physics/mp_fer_hires.F90',
-    # SMOKE
-    'physics/smoke/rrfs_smoke_wrapper.F90',
-    'physics/smoke/rrfs_smoke_postpbl.F90',
-    'physics/smoke/rrfs_smoke_lsdep_wrapper.F90',
     # RRTMGP
     'physics/physics/rrtmgp_lw_gas_optics.F90',
     'physics/physics/rrtmgp_lw_cloud_optics.F90',


### PR DESCRIPTION

## Description

This PR updates the release branch of fv3atm to point to the release/public-v6 branch of ccpp-physics. This effectively points the release branch "behind" where it is currently pointing and adds the latest CCPP scientific documentation. 



### Issue(s) addressed



## Testing

None yet.


## Dependencies

