### PR TITLE
moninshoc.meta missing mfpbl.f dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
+  branch = bugfix/sam-broke-moorthi
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

A recent addition of "module" statements at the top of some files broke moninshoc. This adds a dependency so moninshoc will compile. 

### Issue(s) addressed

Fixes https://github.com/NCAR/ccpp-physics/issues/935


## Testing

Current ufs-weather-model gnu tests on hera, with an adaptation of a "COMPILE" line:

```
COMPILE| -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp ...
```

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/934
