### PR TITLE
production/GFS.v16: fix the frozen precip density issue

### DIFF
--- a/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -1822,6 +1822,7 @@ module module_physics_driver
             Radtend%sfalb, flag_iter, flag_guess, Model%lheatstrg,       &
             Model%isot, Model%ivegsrc,                                   &
             bexp1d, xlai1d, vegf1d, Model%pertvegf,                      &
+            Sfcprop%dgraupelprv, Sfcprop%diceprv,                        &
 !  ---  input/output:
             weasd3(:,1), snowd3(:,1), tsfc3(:,1), tprcp3(:,1),           &
             Sfcprop%srflag, smsoil, stsoil, slsoil, Sfcprop%canopy,      &
@@ -5246,7 +5247,7 @@ module module_physics_driver
       
 !  ---  get the amount of different precip type for Noah MP
 !  ---  convert from m/dtp to mm/s
-      if (Model%lsm==Model%lsm_noahmp) then
+      if (Model%lsm==Model%lsm_noahmp .or. Model%lsm==Model%lsm_noah) then
         if (Model%imp_physics == Model%imp_physics_mg .or. &
             Model%imp_physics == Model%imp_physics_gfdl) then
           !GJF: Should all precipitation rates have the same denominator below? 
@@ -5266,7 +5267,7 @@ module module_physics_driver
           Sfcprop%dgraupelprv(:) = 0.0
           Sfcprop%diceprv(:)     = 0.0
         endif
-      end if !  if (Model%lsm == Model%lsm_noahmp)
+      end if !  if (Model%lsm == Model%lsm_noahmp .or. Model%lsm==Model%lsm_noah)
       
       if (Model%cal_pre) then       ! hchuang: add dominant precipitation type algorithm
 !

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -2308,6 +2308,10 @@ module GFS_typedefs
     Sfcprop%smoiseq    = clear_val
     Sfcprop%zsnsoxy    = clear_val
     
+   endif
+
+    if (Model%lsm == Model%lsm_noahmp .or. Model%lsm == Model%lsm_noah) then
+
     allocate(Sfcprop%draincprv  (IM))
     allocate(Sfcprop%drainncprv (IM))
     allocate(Sfcprop%diceprv    (IM))

--- a/gfsphysics/physics/sfc_drv.f
+++ b/gfsphysics/physics/sfc_drv.f
@@ -145,6 +145,7 @@
      &       shdmin, shdmax, snoalb, sfalb, flag_iter, flag_guess,      &
      &       lheatstrg, isot, ivegsrc,                                  &
      &       bexppert, xlaipert, vegfpert,pertvegf,                     &  ! sfc perts, mgehne
+     &       graupel_mp, ice_mp,                                        &
 !  ---  in/outs:
      &       weasd, snwdph, tskin, tprcp, srflag, smc, stc, slc,        &
      &       canopy, trans, tsurf, zorl,                                &
@@ -190,6 +191,9 @@
      &       snoalb, sfalb, zf,
      &       bexppert, xlaipert, vegfpert
 
+      real (kind=kind_phys), dimension(im), intent(in) ::               &
+     &       graupel_mp, ice_mp                                         &
+
       real (kind=kind_phys),  intent(in) :: delt
 
       logical, dimension(im), intent(in) :: flag_iter, flag_guess, land
@@ -230,6 +234,8 @@
      &       snomlt, sncovr, soilw, soilm, ssoil, tsea, th2, tbot,      &
      &       xlai, zlvl, swdn, tem, z0, bexpp, xlaip, vegfp,            &
      &       mv,sv,alphav,betav,vegftmp
+
+      real (kind=kind_phys) :: graupel_prcp, ice_prcp
 
       integer :: couple, ice, nsoil, nroot, slope, stype, vtype
       integer :: i, k, iflag
@@ -320,6 +326,10 @@
 !            ffrozp = 0.0
 !          endif
           ffrozp = srflag(i)
+
+          graupel_prcp  = graupel_mp(i)   ! grpl part of MP precip [mm/s]
+          ice_prcp      = ice_mp(i)       ! ice part of MP precip [mm/s]
+
           ice = 0
 
           zlvl = zf(i)
@@ -451,6 +461,7 @@
      &       vtype, stype, slope, shdmin1d, alb, snoalb1d,              &
      &       bexpp, xlaip,                                              & ! sfc-perts, mgehne
      &       lheatstrg,                                                 &
+     &       graupel_prcp, ice_prcp,                                    &
 !  ---  input/outputs:
      &       tbot, cmc, tsea, stsoil, smsoil, slsoil, sneqv, chx, cmx,  &
      &       z0,                                                        &


### PR DESCRIPTION
## Description

The snow density is used for all frozen precip types in the current operational GFS. With this assumption the density for sleet or freezing rain is too small and the snow depth is overestimated in this situation. This fix will give the different density to snow, graupel, and freezing rain in the Noah LSM driver.

The fix will change the result.





### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  

Extensive forecast tests have been made in WCOSS.
 
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  



## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
No
