### PR TITLE
Add valid time to the 6 tile cubed sphere grid history files

### DIFF
--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -236,6 +236,7 @@ module module_write_netcdf
        ncerr = nf90_def_var(ncid, "time_iso", NF90_CHAR, [ch_dimid,time_dimid], timeiso_varid); NC_ERR_STOP(ncerr)
        ncerr = nf90_put_att(ncid, timeiso_varid, "long_name", "valid time"); NC_ERR_STOP(ncerr)
        ncerr = nf90_put_att(ncid, timeiso_varid, "description", "ISO 8601 datetime string"); NC_ERR_STOP(ncerr)
+       ncerr = nf90_put_att(ncid, timeiso_varid, "_Encoding", "UTF-8"); NC_ERR_STOP(ncerr)
 
        ! coordinate variable attributes based on output_grid type
        if (trim(output_grid(grid_id)) == 'gaussian_grid' .or. &

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -3296,6 +3296,8 @@
           if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
           ncerr = nf90_put_att(ncid, timeiso_varid, "description", "ISO 8601 datetime string")
           if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+          ncerr = nf90_put_att(ncid, timeiso_varid, "_Encoding", "UTF-8")
+          if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
 
           ncerr = nf90_enddef(ncid=ncid)
 

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -3127,6 +3127,8 @@
     real(ESMF_KIND_R4)               :: valueR4
     real(ESMF_KIND_R8)               :: valueR8
     logical                          :: thereAreVerticals
+    integer                          :: ch_dimid, timeiso_varid
+    character(len=ESMF_MAXSTR)       :: time_iso
 
     rc = ESMF_SUCCESS
 
@@ -3268,6 +3270,10 @@
                                  name="time", value=time, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
+          call ESMF_AttributeGet(grid, convention="NetCDF", purpose="FV3", &
+                                 name="time_iso", value=time_iso, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
           ncerr = nf90_redef(ncid=ncid)
           if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
 
@@ -3282,11 +3288,24 @@
                                dimids=(/dimid/), varid=varid)
           if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
 
+          ncerr = nf90_def_dim(ncid, "nchars", 20, ch_dimid)
+          if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+          ncerr = nf90_def_var(ncid, "time_iso", NF90_CHAR, [ch_dimid,dimid], timeiso_varid)
+          if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+          ncerr = nf90_put_att(ncid, timeiso_varid, "long_name", "valid time")
+          if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+          ncerr = nf90_put_att(ncid, timeiso_varid, "description", "ISO 8601 datetime string")
+          if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+
           ncerr = nf90_enddef(ncid=ncid)
 
           if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
 
           ncerr = nf90_put_var(ncid, varid, values=time)
+
+          if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+
+          ncerr = nf90_put_var(ncid, timeiso_varid, values=[trim(time_iso)])
 
           if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
 


### PR DESCRIPTION
## Description

Add 'time_iso' variable to cubed sphere grid output when ESMF write routines are used. This variable has already been added to the parallel version of the netcdf write routine.
This PR includes changes from https://github.com/NOAA-EMC/fv3atm/pull/515

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes https://github.com/ufs-community/ufs-weather-model/issues/1252

## Testing

How were these changes tested?  Yes.
What compilers / HPCs was it tested with?  Intel. Hera
Are the changes covered by regression tests? Yes.
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? Yes. New netcdf variable has been added to the history files.

## Dependencies

N/A
