### PR TITLE
Emergency fix: exponentiation instead of multiplication caused bad 2m temperatures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
+  branch = catastrophic-typo
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
-  branch = catastrophic-typo
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

Emergency bugfix for the MYNN surface layer scheme:

```
 TH1D(I)=T1D(I)**(100000./P1D(I))**ROVCP !(Theta, K)
```

The first `**` should be a `*`

```
 TH1D(I)=T1D(I)*(100000./P1D(I))**ROVCP !(Theta, K)
```

### Issue(s) addressed

https://github.com/NCAR/ccpp-physics/issues/941
https://github.com/ufs-community/ufs-weather-model/issues/1260



## Testing

How were these changes tested?  **Full regression test suite and more in NOAA-GSL fork**
What compilers / HPCs was it tested with?  **hera.intel, hera.gnu, jet.intel**
Have the ufs-weather-model regression test been run? On what platform?  **hera.intel, hera.gnu, jet.intel**
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.  **Yes, anything that uses module_sf_mynn**

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/940
