### PR TITLE
Fix RAP (Grell Freitas) decomp b4b issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
+  branch = bugfix/sam-broke-moorthi
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
   path = ccpp/physics
   #url = https://github.com/NCAR/ccpp-physics
   #branch = main
-  url = https://github.com/climbfuji/ccpp-physics
+  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
   branch = bugfix/gf_decomp_b4b
 [submodule "upp"]
   path = upp

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  #url = https://github.com/NCAR/ccpp-physics
+  #branch = main
+  url = https://github.com/climbfuji/ccpp-physics
+  branch = bugfix/gf_decomp_b4b
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,17 +1,15 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  #url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  #branch = dev/emc
-  url = https://github.com/MicroTed/GFDL_atmos_cubed_sphere
-  branch = regional_bc_test
+  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
-  branch = bugfix/gf_decomp_b4b
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  #url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  #branch = dev/emc
+  url = https://github.com/MicroTed/GFDL_atmos_cubed_sphere
+  branch = regional_bc_test
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
This replaces https://github.com/NOAA-EMC/fv3atm/pull/543, which is identical, but comes from another fork. All of this work comes from @climbfuji 

## Description
Update .gitmodules and submodule pointer for ccpp-physics for code review and testing of the changes described in https://github.com/NCAR/ccpp-physics/pull/933.

## Issue(s) addressed
See https://github.com/ufs-community/ufs-weather-model/pull/1243.

## Testing
See https://github.com/ufs-community/ufs-weather-model/pull/1243.

## Dependencies
waiting on https://github.com/NCAR/ccpp-physics/pull/933
https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/194