### PR TITLE
fix for Aerosols (4d vars) causing PET log errors. Update CCPP Framework to support IAP model

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  url = https://github.com/NCAR/ccpp-framework
-  branch = main
+  url = https://github.com/climbfuji/ccpp-framework
+  branch = feature/iap_dom
+  #url = https://github.com/NCAR/ccpp-framework
+  #branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/NCAR/ccpp-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  url = https://github.com/climbfuji/ccpp-framework
-  branch = feature/iap_dom
-  #url = https://github.com/NCAR/ccpp-framework
-  #branch = main
+  url = https://github.com/NCAR/ccpp-framework
+  branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/NCAR/ccpp-physics

--- a/cpl/module_cap_cpl.F90
+++ b/cpl/module_cap_cpl.F90
@@ -186,6 +186,7 @@ module module_cap_cpl
     type(ESMF_StateItem_Flag)   :: itemType
     real(ESMF_KIND_R8), pointer :: dataPtr2d(:,:)
     real(ESMF_KIND_R8), pointer :: dataPtr3d(:,:,:)
+    real(ESMF_KIND_R8), pointer :: dataPtr4d(:,:,:,:)
     integer                     :: lrc, localDeCount, dimCount
     character(len=*),parameter  :: subname='(FV3: state_diagnose)'
 
@@ -222,13 +223,22 @@ module module_cap_cpl
            write(tmpstr,'(A,3g14.7)') trim(subname)//' '//trim(lstring)//':'//trim(itemNameList(n))//'  ', &
              minval(dataPtr2d),maxval(dataPtr2d),sum(dataPtr2d)
            call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=lrc)
-         else
+         else if(dimcount == 3) then
            call ESMF_FieldGet(lfield, farrayPtr=dataPtr3d, rc=lrc)
            if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
            write(tmpstr,'(A,3g14.7)') trim(subname)//' '//trim(lstring)//':'//trim(itemNameList(n))//'  ', &
              minval(dataPtr3d),maxval(dataPtr3d),sum(dataPtr3d)
            call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=lrc)
+         else if(dimcount == 4) then
+           call ESMF_FieldGet(lfield, farrayPtr=dataPtr4d, rc=lrc)
+           if (ESMF_LogFoundError(rcToCheck=lrc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+           write(tmpstr,'(A,3g14.7)') trim(subname)//' '//trim(lstring)//':'//trim(itemNameList(n))//'  ', &
+             minval(dataPtr4d),maxval(dataPtr4d),sum(dataPtr4d)
+           call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=lrc)
+         else
+           call ESMF_LogWrite('dimcount of >4 currently unsupported', ESMF_LOGMSG_INFO, rc=lrc)
          end if
        end if
      end if


### PR DESCRIPTION
## Description
using `cpld_dbug_flag=6` in default_vars for cpld tests causes a PET error for too many variables 

The error does not block regression testing or model execution.

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #563
- Fixes https://github.com/NCAR/ccpp-framework/issues/454
- closes NOAA-EMC/fv3atm/pull/562

## Testing

How were these changes tested?
What compilers / HPCs was it tested with? RDHPCS:Hera.intel
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) No and no new tests needed. 
Have the ufs-weather-model regression test been run? (reference issue for which RT's were used in testing)
- Will the code updates change regression test baseline? No
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies
- depends on NCAR/ccpp-framework/pull/452