### PR TITLE
Revert calculation of T2m in NOAH-MP 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/NCAR/ccpp-physics
-  #branch = main
-  url = https://github.com/JessicaMeixner-NOAA/ccpp-physics
-  branch = feature/p8
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  #url = https://github.com/NCAR/ccpp-physics
+  #branch = main
+  url = https://github.com/JessicaMeixner-NOAA/ccpp-physics
+  branch = feature/p8
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This reverts the calculation of T2m in NOAH-MP as it was found in p8c that it tends to result in overly low t2min and overly high t2max values.

### Issue(s) addressed

- https://github.com/ufs-community/ufs-weather-model/issues/1350



## Testing

How were these changes tested?   (In progress with ufs-weather-model regression testing) 
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline?  Yes, because t2m will change.  There will also be answer changes do to parameter setting updates for stability and improving aerosols. 


## Dependencies

- waiting on  https://github.com/NCAR/ccpp-physics/pull/948