### PR TITLE
CCPP/physics v6 documentation updates + empty CCPP phase subroutine cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/mzhangw/ccpp-physics
+  branch = v6_to_main
+  #url = https://github.com/NCAR/ccpp-physics
+  #branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/mzhangw/ccpp-physics
-  branch = v6_to_main
-  #url = https://github.com/NCAR/ccpp-physics
-  #branch = main
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description
This pull request only updated the ccpp-physics submodule pointer in accordance with https://github.com/NCAR/ccpp-physics/pull/944 which updates the main ccpp-physics branch with documentation updates from the version 6 release and cleans up unnecessary empty CCPP phase subroutines.

### Issue(s) addressed

fixes https://github.com/NCAR/ccpp-physics/issues/949



## Testing

Hera UFS RTs passed


## Dependencies

https://github.com/NCAR/ccpp-physics/pull/944
