### PR TITLE
inline post updates for P8 and ESMF -managed threading

### DIFF
--- a/io/post_fv3.F90
+++ b/io/post_fv3.F90
@@ -74,7 +74,7 @@ module post_fv3
       integer,allocatable  :: istagrp(:),iendgrp(:)
       integer,save         :: kpo,kth,kpv
       logical,save         :: log_postalct=.false.
-      real,dimension(komax),save :: po, th, pv
+      real(4),dimension(komax),save :: po, th, pv
       logical        :: Log_runpost
       character(255) :: post_fname*255
 
@@ -2996,29 +2996,29 @@ module post_fv3
 
             ! model level cloud fraction
             if(imp_physics == 11) then !GFDL MP
-            if(trim(fieldname)=='cld_amt') then
-              !$omp parallel do default(none) private(i,j,l) shared(lm,jsta,jend,ista,iend,cfr,arrayr43d,fillvalue,spval)
-              do l=1,lm
-                do j=jsta,jend
-                  do i=ista, iend
-                    cfr(i,j,l) = arrayr43d(i,j,l)
-                    if(abs(arrayr43d(i,j,l)-fillvalue)<small) cfr(i,j,l) = spval
+              if(trim(fieldname)=='cld_amt') then
+                !$omp parallel do default(none) private(i,j,l) shared(lm,jsta,jend,ista,iend,cfr,arrayr43d,fillvalue,spval)
+                do l=1,lm
+                  do j=jsta,jend
+                    do i=ista, iend
+                      cfr(i,j,l) = arrayr43d(i,j,l)
+                      if(abs(arrayr43d(i,j,l)-fillvalue)<small) cfr(i,j,l) = spval
+                    enddo
                   enddo
                 enddo
-              enddo
-            endif
+              endif
             else !Other MP
-            if(trim(fieldname)=='cldfra') then
-              !$omp parallel do default(none) private(i,j,l) shared(lm,jsta,jend,ista,iend,cfr,arrayr43d,fillvalue,spval)
-              do l=1,lm
-                do j=jsta,jend
-                  do i=ista, iend
-                    cfr(i,j,l) = arrayr43d(i,j,l)
-                    if(abs(arrayr43d(i,j,l)-fillvalue)<small) cfr(i,j,l) = spval
+              if(trim(fieldname)=='cldfra') then
+                !$omp parallel do default(none) private(i,j,l) shared(lm,jsta,jend,ista,iend,cfr,arrayr43d,fillvalue,spval)
+                do l=1,lm
+                  do j=jsta,jend
+                    do i=ista, iend
+                      cfr(i,j,l) = arrayr43d(i,j,l)
+                      if(abs(arrayr43d(i,j,l)-fillvalue)<small) cfr(i,j,l) = spval
+                    enddo
                   enddo
                 enddo
-              enddo
-            endif
+              endif
             endif
           
 !3d fields

--- a/io/post_nems_routines.F90
+++ b/io/post_nems_routines.F90
@@ -231,7 +231,7 @@
 !---
       character (len=*), intent(in) :: post_namelist
       integer,intent(out) :: kpo,kth,kpv
-      real,dimension(komax),intent(out) :: po,th,pv
+      real(4),dimension(komax),intent(out) :: po,th,pv
       integer :: nlunit
       real :: untcnvt
       logical :: popascal


### PR DESCRIPTION
## Description

Changes in the this PR includes:
1) With the ESMF -managed threading, the number of mpi tasks for UPP needs to be consistent with the traditional threading. To do that the write tasks per group used in UPP needs to set correctly considering the ESMF threading.  
2) Inline post interface update to resolve issues with missing post fields on pv and sigma levels when running in 32BIT=NO.
3) Update upp to the latest develop branch to fix the pressure level TCDC fields when the cldfra/cld_amt is not in the history output.
 
### Issue(s) addressed

- Fixes issue https://github.com/ufs-community/ufs-weather-model/issues/1304
- Fixes issue https://github.com/ufs-community/ufs-weather-model/issues/1320

## Testing

How were these changes tested? Tested on hera 
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

https://github.com/ufs-community/ufs-weather-model/pull/1305