### PR TITLE
Moving nest inline post fix

### DIFF
--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -1875,6 +1875,8 @@
             do ii=lbound(lonPtr,1),ubound(lonPtr,1)
               lonPtr(ii,jj) = lon1(n) + (lon2(n)-lon1(n))/(imo(n)-1) * (ii-1)
               latPtr(ii,jj) = lat1(n) + (lat2(n)-lat1(n))/(jmo(n)-1) * (jj-1)
+              wrt_int_state%out_grid_info(n)%latPtr(ii,jj) = latPtr(ii,jj)
+              wrt_int_state%out_grid_info(n)%lonPtr(ii,jj) = lonPtr(ii,jj)
             enddo
             enddo
           else if (trim(output_grid(grid_id)) == 'rotated_latlon_moving') then
@@ -1890,6 +1892,8 @@
               if (geo_lon < 0.0) geo_lon = geo_lon + 360.0
               lonPtr(ii,jj) = geo_lon
               latPtr(ii,jj) = geo_lat
+              wrt_int_state%out_grid_info(n)%latPtr(ii,jj) = latPtr(ii,jj)
+              wrt_int_state%out_grid_info(n)%lonPtr(ii,jj) = lonPtr(ii,jj)
             enddo
             enddo
           endif


### PR DESCRIPTION
## Description
  
What bug does it fix, or what feature does it add?
  This PR fixes the inline post for moving domain (nests). The lat/lon coordinates must be updated in the run phase of the write grid component ever time inline post is executed.
Is a change of answers expected from this PR?
  Yes, hafs_regional_specified_moving_1nest_atm tests will need new baselines. The grib files are changed, other history files are identical compared to the current baseline.


### Issue(s) addressed
https://github.com/ufs-community/ufs-weather-model/issues/1409

## Testing

How were these changes tested?  Yes.
What compilers / HPCs was it tested with?  Inte;/hera
Are the changes covered by regression tests? Yes
Have the ufs-weather-model regression test been run? Yes. On what platform?  Hera.