### PR TITLE
Officially changed the ccpp-physics pointer to ufs-community/ccpp-physics ufs/dev branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
This PR aims to officially change the ccpp-physics pointer from NCAR/ccpp-physics main branch to ufs-community/ccpp-physics ufs/dev branch.  ufs-community/ccpp-physics is forked from NCAR/ccpp-physics main branch.  All ccpp-physics related PRs that will be used in the UFS applications in the short term will be merged into [ufs-community/ccpp-physics](https://github.com/ufs-community/ccpp-physics) ufs/dev branch. 