### PR TITLE
Fix boundary issues and numerical precision trouble in RUC LSM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
   url = https://github.com/SamuelTrahanNOAA/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  branch = bugfix/rrfs-debug-mode
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework
@@ -9,7 +9,7 @@
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/SamuelTrahanNOAA/ccpp-physics
-  branch = main
+  branch = bugfix/rrfs-debug-mode-no-smoke
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  url = https://github.com/SamuelTrahanNOAA/GFDL_atmos_cubed_sphere
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
@@ -8,7 +8,7 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
+  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
   branch = main
 [submodule "upp"]
   path = upp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/SamuelTrahanNOAA/GFDL_atmos_cubed_sphere
-  branch = bugfix/rrfs-debug-mode
+  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
-  branch = bugfix/rrfs-debug-mode-no-smoke
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/driver/GFS_restart.F90
+++ b/ccpp/driver/GFS_restart.F90
@@ -124,6 +124,9 @@ module GFS_restart
     if (Model%do_cap_suppress .and. Model%num_dfi_radar>0) then
       Restart%num2d = Restart%num2d + Model%num_dfi_radar
     endif
+    if (Model%rrfs_smoke) then
+      Restart%num2d = Restart%num2d + 13
+    endif
 
     Restart%num3d = Model%ntot3d
     if (Model%num_dfi_radar>0) then
@@ -147,6 +150,9 @@ module GFS_restart
     !Prognostic area fraction
     if (Model%progsigma) then
        Restart%num3d = Restart%num3d + 2
+    endif
+    if (Model%rrfs_smoke) then
+      Restart%num3d = Restart%num3d + 8
     endif
 
     if (Model%num_dfi_radar > 0) then
@@ -419,6 +425,74 @@ module GFS_restart
       enddo
     endif
 
+    if (Model%rrfs_smoke) then
+      num = num+1
+      Restart%name2d(num) = 'emdust'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%emdust(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'emseas'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%emseas(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'emanoc'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%emanoc(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'ebb_smoke_hr'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%ebb_smoke_hr(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'frp_hr'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%frp_hr(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'frp_std_hr'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%frp_std_hr(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'fhist'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%fhist(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'coef_bb_dc'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%coef_bb_dc(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'min_fplume'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%min_fplume(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'max_fplume'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%max_fplume(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'rrfs_hwp'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%rrfs_hwp(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'ushfsfci'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%ushfsfci(:)
+      enddo
+      num = num+1
+      Restart%name2d(num) = 'rainc_cpl'
+      do nb=1,nblks
+        Restart%data(nb,num)%var2p => Coupling(nb)%rainc_cpl(:)
+      enddo
+    endif
+
     !--- phy_f3d variables
     do num = 1,Model%ntot3d
        !--- set the variable name
@@ -548,6 +622,49 @@ module GFS_restart
               :,:,Model%ix_dfi_radar(itime))
           enddo
         endif
+      enddo
+    endif
+
+    if (Model%rrfs_smoke) then
+      num = num+1
+      Restart%name3d(num) = 'ebu_smoke'
+      do nb=1,nblks
+        Restart%data(nb,num)%var3p => Coupling(nb)%ebu_smoke(:,:)
+      enddo
+      num = num+1
+      Restart%name3d(num) = 'smoke_ext'
+      do nb=1,nblks
+        Restart%data(nb,num)%var3p => Coupling(nb)%smoke_ext(:,:)
+      enddo
+      num = num+1
+      Restart%name3d(num) = 'dust_ext'
+      do nb=1,nblks
+        Restart%data(nb,num)%var3p => Coupling(nb)%dust_ext(:,:)
+      enddo
+      num = num+1
+      Restart%name3d(num) = 'dqdti'
+      do nb=1,nblks
+        Restart%data(nb,num)%var3p => Coupling(nb)%dqdti(:,:)
+      enddo
+      num = num+1
+      Restart%name3d(num) = 'chem3d1'
+      do nb=1,nblks
+        Restart%data(nb,num)%var3p => Coupling(nb)%chem3d(:,:,1)
+      enddo
+      num = num+1
+      Restart%name3d(num) = 'chem3d2'
+      do nb=1,nblks
+        Restart%data(nb,num)%var3p => Coupling(nb)%chem3d(:,:,2)
+      enddo
+      num = num+1
+      Restart%name3d(num) = 'pfi_lsan'
+      do nb=1,nblks
+        Restart%data(nb,num)%var3p => Coupling(nb)%pfi_lsan(:,:)
+      enddo
+      num = num+1
+      Restart%name3d(num) = 'pfl_lsan'
+      do nb=1,nblks
+        Restart%data(nb,num)%var3p => Coupling(nb)%pfl_lsan(:,:)
       enddo
     endif
 

--- a/ccpp/driver/GFS_restart.F90
+++ b/ccpp/driver/GFS_restart.F90
@@ -124,9 +124,6 @@ module GFS_restart
     if (Model%do_cap_suppress .and. Model%num_dfi_radar>0) then
       Restart%num2d = Restart%num2d + Model%num_dfi_radar
     endif
-    if (Model%rrfs_smoke) then
-      Restart%num2d = Restart%num2d + 13
-    endif
 
     Restart%num3d = Model%ntot3d
     if (Model%num_dfi_radar>0) then
@@ -150,9 +147,6 @@ module GFS_restart
     !Prognostic area fraction
     if (Model%progsigma) then
        Restart%num3d = Restart%num3d + 2
-    endif
-    if (Model%rrfs_smoke) then
-      Restart%num3d = Restart%num3d + 8
     endif
 
     if (Model%num_dfi_radar > 0) then
@@ -425,74 +419,6 @@ module GFS_restart
       enddo
     endif
 
-    if (Model%rrfs_smoke) then
-      num = num+1
-      Restart%name2d(num) = 'emdust'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%emdust(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'emseas'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%emseas(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'emanoc'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%emanoc(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'ebb_smoke_hr'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%ebb_smoke_hr(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'frp_hr'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%frp_hr(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'frp_std_hr'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%frp_std_hr(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'fhist'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%fhist(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'coef_bb_dc'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%coef_bb_dc(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'min_fplume'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%min_fplume(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'max_fplume'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%max_fplume(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'rrfs_hwp'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%rrfs_hwp(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'ushfsfci'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%ushfsfci(:)
-      enddo
-      num = num+1
-      Restart%name2d(num) = 'rainc_cpl'
-      do nb=1,nblks
-        Restart%data(nb,num)%var2p => Coupling(nb)%rainc_cpl(:)
-      enddo
-    endif
-
     !--- phy_f3d variables
     do num = 1,Model%ntot3d
        !--- set the variable name
@@ -622,49 +548,6 @@ module GFS_restart
               :,:,Model%ix_dfi_radar(itime))
           enddo
         endif
-      enddo
-    endif
-
-    if (Model%rrfs_smoke) then
-      num = num+1
-      Restart%name3d(num) = 'ebu_smoke'
-      do nb=1,nblks
-        Restart%data(nb,num)%var3p => Coupling(nb)%ebu_smoke(:,:)
-      enddo
-      num = num+1
-      Restart%name3d(num) = 'smoke_ext'
-      do nb=1,nblks
-        Restart%data(nb,num)%var3p => Coupling(nb)%smoke_ext(:,:)
-      enddo
-      num = num+1
-      Restart%name3d(num) = 'dust_ext'
-      do nb=1,nblks
-        Restart%data(nb,num)%var3p => Coupling(nb)%dust_ext(:,:)
-      enddo
-      num = num+1
-      Restart%name3d(num) = 'dqdti'
-      do nb=1,nblks
-        Restart%data(nb,num)%var3p => Coupling(nb)%dqdti(:,:)
-      enddo
-      num = num+1
-      Restart%name3d(num) = 'chem3d1'
-      do nb=1,nblks
-        Restart%data(nb,num)%var3p => Coupling(nb)%chem3d(:,:,1)
-      enddo
-      num = num+1
-      Restart%name3d(num) = 'chem3d2'
-      do nb=1,nblks
-        Restart%data(nb,num)%var3p => Coupling(nb)%chem3d(:,:,2)
-      enddo
-      num = num+1
-      Restart%name3d(num) = 'pfi_lsan'
-      do nb=1,nblks
-        Restart%data(nb,num)%var3p => Coupling(nb)%pfi_lsan(:,:)
-      enddo
-      num = num+1
-      Restart%name3d(num) = 'pfl_lsan'
-      do nb=1,nblks
-        Restart%data(nb,num)%var3p => Coupling(nb)%pfl_lsan(:,:)
       enddo
     endif
 


### PR DESCRIPTION
## Description

This adds changes needed for the RRFS regression tests to run in debug and 2threads mode on hera.gnu, hera.intel, and jet.intel. See the linked PRs for details

### Issue(s) addressed

Boundary problems listed in https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/issues/218 fixed by https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/219

Numerical precision issues listed in https://github.com/ufs-community/ccpp-physics/issues/5 fixed by https://github.com/ufs-community/ccpp-physics/pull/6

## Testing

How were these changes tested?
 _RRFS debug mode cases on hera.intel, hera.gnu, and jet.intel, using gdb, ncview, and other tools, for many hours of debugging._

What compilers / HPCs was it tested with?
_hera.intel, hera.gnu, jet.intel_

Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
_Yes; the RRFS will need 2threads and debug tests_

Have the ufs-weather-model regression test been run? On what platform? 
_Yes, on hera.intel, hera.gnu, and jet.intel_

Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
_Yes; anything using boundary conditions or the ruclsm may change results. All regression tests at the ufs-weather-model level should match new baselines._

Please commit the regression test log files in your ufs-weather-model branch
_Done._

## Dependencies

https://github.com/ufs-community/ccpp-physics/pull/6
https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/219
