### PR TITLE
Add a new SDF named FV3_WoFS_v0 for SRW_v2.1 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = ufs/dev
-  url = https://github.com/mzhangw/ccpp-physics
-  branch = delta_srw210
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/mzhangw/ccpp-physics
+  branch = delta_srw210
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/CCPP_typedefs.F90
+++ b/ccpp/data/CCPP_typedefs.F90
@@ -222,6 +222,7 @@ module CCPP_typedefs
     integer                             :: nday                          !<
     integer                             :: nf_aelw                       !<
     integer                             :: nf_aesw                       !<
+    integer                             :: nf_albd                       !<
     integer                             :: nn                            !<
     integer                             :: nsamftrac                     !<
     integer                             :: nscav                         !<
@@ -988,6 +989,7 @@ contains
     Interstitial%nbdsw            = NBDSW
     Interstitial%nf_aelw          = NF_AELW
     Interstitial%nf_aesw          = NF_AESW
+    Interstitial%nf_albd          = NF_ALBD
     Interstitial%nspc1            = NSPC1
     if (Model%oz_phys .or. Model%oz_phys_2015) then
       Interstitial%oz_coeffp5     = oz_coeff+5

--- a/ccpp/data/CCPP_typedefs.meta
+++ b/ccpp/data/CCPP_typedefs.meta
@@ -1460,6 +1460,12 @@
   units = count
   dimensions = ()
   type = integer
+[nf_albd]
+  standard_name = number_of_components_for_surface_albedo
+  long_name = number of IR/VIS/UV compinents for surface albedo
+  units = count
+  dimensions = ()
+  type = integer
 [nn]
   standard_name = number_of_tracers_for_convective_transport
   long_name = number of tracers for convective transport

--- a/ccpp/suites/suite_FV3_WoFS_v0.xml
+++ b/ccpp/suites/suite_FV3_WoFS_v0.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="FV3_WoFS_v0"  version="1">
+  <!-- <init></init> -->
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>GFS_radiation_surface</scheme>
+      <scheme>rad_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw_pre</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>sgscloud_radpost</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_surface_composites_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_surface_composites_inter</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+    </subcycle>
+    <!-- Surface iteration loop -->
+    <subcycle loop="2">
+      <scheme>mynnsfc_wrapper</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_nst_pre</scheme>
+      <scheme>sfc_nst</scheme>
+      <scheme>sfc_nst_post</scheme>
+      <scheme>lsm_noah</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
+    </subcycle>
+    <!-- End of surface iteration loop -->
+    <subcycle loop="1">
+      <scheme>GFS_surface_composites_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <scheme>mynnedmf_wrapper</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>cires_ugwp</scheme>
+      <scheme>cires_ugwp_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>ozphys_2015</scheme>
+      <scheme>h2ophys</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>mp_nssl</scheme>
+      <scheme>GFS_MP_generic_post</scheme>
+      <scheme>maximum_hourly_diagnostics</scheme>
+      <scheme>phys_tend</scheme>
+    </subcycle>
+  </group>
+  <group name="stochastics">
+    <subcycle loop="1">
+      <scheme>GFS_stochastics</scheme>
+    </subcycle>
+  </group>
+  <!-- <finalize></finalize> -->
+</suite>


### PR DESCRIPTION
## Description
This PR includes two main tasks: 
1) In favor of [PR#514](https://github.com/NOAA-EMC/fv3atm/pull/514).  All credit for code changes and description to @MicroTed.  It adds an SDF for SRW app v2.1 release for WoFS (Warn on Forecast System). It is the same as the RRFS_v1nssl SDF except for using Noah LSM instead of NoahMP. This SDF was planned for use in the 2022 Spring Forecast Experiment. It will also be used for an option in the regional workflow.
2)  CCPP Scientific Documentation updates for UFS-SRW v2.1.0 [#14](https://github.com/ufs-community/ccpp-physics/pull/14). Note that it includes a minor bug fix to include variable nf_albd in the host model (CCPP_typedefs). 



## Testing
The description of the regression test is provided in the ufs-weather-model level PR[#1460](https://github.com/ufs-community/ufs-weather-model/pull/1460).

## Dependencies
waiting on ufs-community/ccpp-physics/pull/[#14](https://github.com/ufs-community/ccpp-physics/pull/14)
