### PR TITLE
Adjust GFS diagnostic Aerosol Optical Depth (AOD) output to the exact 550nm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = ufs/dev
-  url = https://github.com/ChunxiZhang-NOAA/ccpp-physics
-  branch = bug/aod550
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/ChunxiZhang-NOAA/ccpp-physics
+  branch = bug/aod550
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description
This PR is created to adjust the GFS diagnostic Aerosol Optical Depth (AD) output to the exact 550nm in 
 ccpp/physics/physics/radiation_aerosols.f. 

### Issue(s) addressed

- fixes #<[15](https://github.com/ufs-community/ccpp-physics/issues/15)>

## Testing
Please see the report for testing in the ufs-weather-model PR.


## Dependencies

- waiting on [ufs-community/ccpp-physics/pull/<[16](https://github.com/ufs-community/ccpp-physics/pull/16)>
