### PR TITLE
Update Regression Test to include gfsv17 prototypes that are after prototype 8, and turn on prognostic closure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = ufs/dev
-  url = https://github.com/lisa-bengtsson/ccpp-physics
-  branch = progc_update
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/lisa-bengtsson/ccpp-physics
+  branch = progc_update
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

These PR’s in ufs-weather-model, fv3atm and ccpp/physics does the following:
Creates a set of _gfsv17 RT’s to reflect tests that are beyond prototype 8 targeted for GFSv17
Activates prognostic closure by setting namelist progsigma = true in *gfsv17 and pointing to new field_table in the RT’s
Addresses additional parametric tuning in progclosure_calc.F90
Adds a new gfsv17 field_table and diag_table

### Issue(s) addressed
https://github.com/ufs-community/ufs-weather-model/issues/1477




## Testing

New ufs-weather-model RT tests have been carried out on Hera


## Dependencies

https://github.com/ufs-community/ufs-weather-model/pull/1480
https://github.com/ufs-community/ccpp-physics/pull/18
