### PR TITLE
Develop ugwp improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/mdtoyNOAA/ccpp-physics
+  branch = ufs/dev_ugwp_improvements
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/mdtoyNOAA/ccpp-physics
-  branch = ufs/dev_ugwp_improvements
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/CCPP_typedefs.F90
+++ b/ccpp/data/CCPP_typedefs.F90
@@ -922,7 +922,8 @@ contains
     allocate (Interstitial%zngw            (IM)           )
 
 ! CIRES UGWP v1
-    if (Model%do_ugwp_v1) then
+    if (Model%ldiag_ugwp .or. Model%do_ugwp_v0 .or. Model%do_ugwp_v0_nst_only &
+        .or. Model%do_ugwp_v1) then
       allocate (Interstitial%dudt_ngw        (IM,Model%levs))
       allocate (Interstitial%dvdt_ngw        (IM,Model%levs))
       allocate (Interstitial%dtdt_ngw        (IM,Model%levs))
@@ -1550,7 +1551,8 @@ contains
     Interstitial%zngw            = clear_val
 
 ! CIRES UGWP v1
-    if (Model%do_ugwp_v1) then
+    if (Model%ldiag_ugwp .or. Model%do_ugwp_v0 .or. Model%do_ugwp_v0_nst_only &
+        .or. Model%do_ugwp_v1) then
       Interstitial%dudt_ngw        = clear_val
       Interstitial%dvdt_ngw        = clear_val
       Interstitial%dtdt_ngw        = clear_val

--- a/ccpp/data/CCPP_typedefs.meta
+++ b/ccpp/data/CCPP_typedefs.meta
@@ -2324,7 +2324,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
+  active = (flag_for_unified_gravity_wave_physics_diagnostics .or. flag_for_ugwp_version_0 .or. flag_for_ugwp_version_0_nonorographic_gwd .or. flag_for_ugwp_version_1)
 [dvdt_ngw]
   standard_name = tendency_of_y_wind_due_to_nonorographic_gravity_wave_drag
   long_name = meridional wind tendency due to non-stationary GWs
@@ -2332,7 +2332,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
+  active = (flag_for_unified_gravity_wave_physics_diagnostics .or. flag_for_ugwp_version_0 .or. flag_for_ugwp_version_0_nonorographic_gwd .or. flag_for_ugwp_version_1)
 [dtdt_ngw]
   standard_name = tendency_of_air_temperature_due_to_nonorographic_gravity_wave_drag
   long_name = air temperature tendency due to non-stationary GWs
@@ -2340,7 +2340,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
+  active = (flag_for_unified_gravity_wave_physics_diagnostics .or. flag_for_ugwp_version_0 .or. flag_for_ugwp_version_0_nonorographic_gwd .or. flag_for_ugwp_version_1)
 [kdis_ngw]
   standard_name = atmosphere_momentum_diffusivity_due_to_nonorographic_gravity_wave_drag
   long_name = eddy mixing due to non-stationary GWs
@@ -2348,7 +2348,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22 .or. control_for_drag_suite_gravity_wave_drag==3 .or. control_for_drag_suite_gravity_wave_drag==2)
+  active = (flag_for_unified_gravity_wave_physics_diagnostics .or. flag_for_ugwp_version_0 .or. flag_for_ugwp_version_0_nonorographic_gwd .or. flag_for_ugwp_version_1)
 [zlwb]
   standard_name = height_of_low_level_wave_breaking
   long_name = height of low level wave breaking

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -688,6 +688,7 @@ module GFS_typedefs
 !vay 2018  GW physics switches
 
     logical              :: ldiag_ugwp
+    logical              :: ugwp_seq_update ! flag to update winds between UGWP steps
     logical              :: do_ugwp         ! do mesoscale UGWP + TOFD + RF
     logical              :: do_tofd         ! tofd flag in gwdps.f
     logical              :: do_gwd          ! logical for gravity wave drag (gwd)
@@ -977,7 +978,7 @@ module GFS_typedefs
     logical              :: do_ugwp_v0           !< flag for version 0 ugwp GWD
     logical              :: do_ugwp_v0_orog_only !< flag for version 0 ugwp GWD (orographic drag only)
     logical              :: do_ugwp_v0_nst_only  !< flag for version 0 ugwp GWD (non-stationary GWD only)
-    logical              :: do_gsl_drag_ls_bl    !< flag for GSL drag (large-scale GWD and blocking only)
+    logical              :: do_gsl_drag_ls_bl    !< flag for GSL drag (mesoscale GWD and blocking only)
     logical              :: do_gsl_drag_ss       !< flag for GSL drag (small-scale GWD only)
     logical              :: do_gsl_drag_tofd     !< flag for GSL drag (turbulent orog form drag only)
     logical              :: do_ugwp_v1           !< flag for version 1 ugwp GWD
@@ -1834,14 +1835,22 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: dudt_ofd(:,:)  => null()  !<
     real (kind=kind_phys), pointer :: dvdt_ofd(:,:)  => null()  !<
 
-    real (kind=kind_phys), pointer :: du_ogwcol(:)   => null()  !<
-    real (kind=kind_phys), pointer :: dv_ogwcol(:)   => null()  !<
-    real (kind=kind_phys), pointer :: du_oblcol(:)   => null()  !<
-    real (kind=kind_phys), pointer :: dv_oblcol(:)   => null()  !<
-    real (kind=kind_phys), pointer :: du_osscol(:)   => null()  !<
-    real (kind=kind_phys), pointer :: dv_osscol(:)   => null()  !<
-    real (kind=kind_phys), pointer :: du_ofdcol(:)   => null()  !<
-    real (kind=kind_phys), pointer :: dv_ofdcol(:)   => null()  !<
+    real (kind=kind_phys), pointer :: du_ogwcol(:)   => null()  !< instantaneous sfc u-momentum flux from OGW
+    real (kind=kind_phys), pointer :: dv_ogwcol(:)   => null()  !< instantaneous sfc v-momentum flux from OGW
+    real (kind=kind_phys), pointer :: du_oblcol(:)   => null()  !< instantaneous sfc u-momentum flux from blocking
+    real (kind=kind_phys), pointer :: dv_oblcol(:)   => null()  !< instantaneous sfc v-momentum flux from blocking
+    real (kind=kind_phys), pointer :: du_osscol(:)   => null()  !< instantaneous sfc u-momentum flux from SSGWD
+    real (kind=kind_phys), pointer :: dv_osscol(:)   => null()  !< instantaneous sfc v-momentum flux from SSGWD
+    real (kind=kind_phys), pointer :: du_ofdcol(:)   => null()  !< instantaneous sfc u-momentum flux from TOFD
+    real (kind=kind_phys), pointer :: dv_ofdcol(:)   => null()  !< instantaneous sfc v-momentum flux from TOFD
+    real (kind=kind_phys), pointer :: du3_ogwcol(:)  => null()  !< time-averaged sfc u-momentum flux from OGW
+    real (kind=kind_phys), pointer :: dv3_ogwcol(:)  => null()  !< time-averaged sfc v-momentum flux from OGW
+    real (kind=kind_phys), pointer :: du3_oblcol(:)  => null()  !< time-averaged sfc u-momentum flux from blocking
+    real (kind=kind_phys), pointer :: dv3_oblcol(:)  => null()  !< time-averaged sfc v-momentum flux from blocking
+    real (kind=kind_phys), pointer :: du3_osscol(:)  => null()  !< time-averaged sfc u-momentum flux from SSGWD
+    real (kind=kind_phys), pointer :: dv3_osscol(:)  => null()  !< time-averaged sfc v-momentum flux from SSGWD
+    real (kind=kind_phys), pointer :: du3_ofdcol(:)  => null()  !< time-averaged sfc u-momentum flux from TOFD
+    real (kind=kind_phys), pointer :: dv3_ofdcol(:)  => null()  !< time-averaged sfc v-momentum flux from TOFD
 !
 !---vay-2018 UGWP-diagnostics daily mean
 !
@@ -1856,6 +1865,11 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: du3dt_ogw(:,:) => null()  !< daily aver GFS_phys tend for WE-U OGW
     real (kind=kind_phys), pointer :: dv3dt_ogw(:,:) => null()  !< daily aver GFS_phys tend for SN-V OGW
     real (kind=kind_phys), pointer :: dt3dt_ogw(:,:) => null()  !< daily aver GFS_phys tend for Temp OGW
+!
+    real (kind=kind_phys), pointer :: ldu3dt_ogw(:,:) => null()  !< time aver GFS_phys tend for WE-U OGW
+    real (kind=kind_phys), pointer :: ldu3dt_obl(:,:) => null()  !< time aver GFS_phys tend for WE-U OBL
+    real (kind=kind_phys), pointer :: ldu3dt_oss(:,:) => null()  !< time aver GFS_phys tend for WE-U OSS
+    real (kind=kind_phys), pointer :: ldu3dt_ofd(:,:) => null()  !< time aver GFS_phys tend for WE-U OFD
 !
     real (kind=kind_phys), pointer :: du3dt_mtb(:,:) => null()  !< daily aver GFS_phys tend for WE-U MTB
     real (kind=kind_phys), pointer :: dv3dt_mtb(:,:) => null()  !< daily aver GFS_phys tend for SN-V MTB
@@ -1876,6 +1890,15 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: du3dt_moist(:,:) => null()  !< daily aver GFS_phys tend for WE-U MOIST
     real (kind=kind_phys), pointer :: dv3dt_moist(:,:) => null()  !< daily aver GFS_phys tend for SN-V MOIST
     real (kind=kind_phys), pointer :: dt3dt_moist(:,:) => null()  !< daily aver GFS_phys tend for Temp MOIST
+!
+    real (kind=kind_phys), pointer :: dws3dt_ogw(:,:) => null()  !< time aver GFS_phys tend for windspeed OGW
+    real (kind=kind_phys), pointer :: dws3dt_obl(:,:) => null()  !< time aver GFS_phys tend for windspeed OBL
+    real (kind=kind_phys), pointer :: dws3dt_oss(:,:) => null()  !< time aver GFS_phys tend for windspeed OSS
+    real (kind=kind_phys), pointer :: dws3dt_ofd(:,:) => null()  !< time aver GFS_phys tend for windspeed OFD
+!
+    real (kind=kind_phys), pointer :: ldu3dt_ngw(:,:) => null()  !< time aver GFS_phys tend for u wind NGW
+    real (kind=kind_phys), pointer :: ldv3dt_ngw(:,:) => null()  !< time aver GFS_phys tend for v wind NGW
+    real (kind=kind_phys), pointer :: ldt3dt_ngw(:,:) => null()  !< time aver GFS_phys tend for temperature NGW
 !
 !--- Instantaneous UGWP-diagnostics  16-variables
 !       Diag%gwp_ax, Diag%gwp_axo, Diag%gwp_axc, Diag%gwp_axf,       &
@@ -3162,16 +3185,17 @@ module GFS_typedefs
     logical              :: do_ugwp_v0           = .true.       !< flag for version 0 ugwp GWD
     logical              :: do_ugwp_v0_orog_only = .false.      !< flag for version 0 ugwp GWD (orographic drag only)
     logical              :: do_ugwp_v0_nst_only  = .false.      !< flag for version 0 ugwp GWD (non-stationary GWD only)
-    logical              :: do_gsl_drag_ls_bl    = .false.      !< flag for GSL drag (large-scale GWD and blocking only)
+    logical              :: do_gsl_drag_ls_bl    = .false.      !< flag for GSL drag (mesoscale GWD and blocking only)
     logical              :: do_gsl_drag_ss       = .false.      !< flag for GSL drag (small-scale GWD only)
     logical              :: do_gsl_drag_tofd     = .false.      !< flag for GSL drag (turbulent orog form drag only)
     logical              :: do_ugwp_v1           = .false.      !< flag for version 1 ugwp GWD
     logical              :: do_ugwp_v1_orog_only = .false.      !< flag for version 1 ugwp GWD (orographic drag only)
     logical              :: do_ugwp_v1_w_gsldrag = .false.      !< flag for version 1 ugwp GWD (orographic drag only)
 !--- vay-2018
-    logical              :: ldiag_ugwp     = .false.                  !< flag for UGWP diag fields
-    logical              :: do_ugwp        = .false.                  !< flag do UGWP+RF
-    logical              :: do_tofd        = .false.                  !< flag do Turb oro Form Drag
+    logical              :: ldiag_ugwp      = .false.                 !< flag for UGWP diag fields
+    logical              :: ugwp_seq_update = .false.                 !< flag for updating winds between UGWP steps
+    logical              :: do_ugwp         = .false.                 !< flag do UGWP+RF
+    logical              :: do_tofd         = .false.                 !< flag do Turb oro Form Drag
 
     logical              :: do_gwd         = .false.                  !< flag for running gravity wave drag
     logical              :: do_cnvgwd      = .false.                  !< flag for running conv gravity wave drag
@@ -3719,6 +3743,7 @@ module GFS_typedefs
 !VAY-ugwp  --- set some GW-related switches
 !
     Model%ldiag_ugwp       = ldiag_ugwp
+    Model%ugwp_seq_update  = ugwp_seq_update
     Model%do_ugwp          = do_ugwp
     Model%do_tofd          = do_tofd
 
@@ -6929,9 +6954,20 @@ module GFS_typedefs
       allocate (Diag%dtdt_tot  (IM,Model%levs) )
       allocate (Diag%uav_ugwp  (IM,Model%levs) )
       allocate (Diag%tav_ugwp  (IM,Model%levs) )
+      allocate (Diag%dws3dt_ogw (IM,Model%levs) )
+      allocate (Diag%dws3dt_obl (IM,Model%levs) )
+      allocate (Diag%dws3dt_oss (IM,Model%levs) )
+      allocate (Diag%dws3dt_ofd (IM,Model%levs) )
+      allocate (Diag%ldu3dt_ogw  (IM,Model%levs) )
+      allocate (Diag%ldu3dt_obl  (IM,Model%levs) )
+      allocate (Diag%ldu3dt_oss  (IM,Model%levs) )
+      allocate (Diag%ldu3dt_ofd  (IM,Model%levs) )
+      allocate (Diag%ldu3dt_ngw (IM,Model%levs) )
+      allocate (Diag%ldv3dt_ngw (IM,Model%levs) )
+      allocate (Diag%ldt3dt_ngw (IM,Model%levs) )
     endif
 
-    if (Model%do_ugwp_v1 .or. Model%gwd_opt==33 .or. Model%gwd_opt==22) then
+    if (Model%do_ugwp_v1 .or. Model%ldiag_ugwp) then
       allocate (Diag%dudt_ogw  (IM,Model%levs))
       allocate (Diag%dvdt_ogw  (IM,Model%levs))
       allocate (Diag%dudt_obl  (IM,Model%levs))
@@ -6948,6 +6984,14 @@ module GFS_typedefs
       allocate (Diag%dv_osscol (IM)           )
       allocate (Diag%du_ofdcol (IM)           )
       allocate (Diag%dv_ofdcol (IM)           )
+      allocate (Diag%du3_ogwcol (IM)          )
+      allocate (Diag%dv3_ogwcol (IM)          )
+      allocate (Diag%du3_oblcol (IM)          )
+      allocate (Diag%dv3_oblcol (IM)          )
+      allocate (Diag%du3_osscol (IM)          )
+      allocate (Diag%dv3_osscol (IM)          )
+      allocate (Diag%du3_ofdcol (IM)          )
+      allocate (Diag%dv3_ofdcol (IM)          )
     else
       allocate (Diag%dudt_ogw  (IM,Model%levs))
     endif
@@ -7225,7 +7269,7 @@ module GFS_typedefs
     Diag%dtdt_gw     = zero
     Diag%kdis_gw     = zero
 
-    if (Model%do_ugwp_v1 .or. Model%gwd_opt==33 .or. Model%gwd_opt==22) then
+    if (Model%do_ugwp_v1 .or. Model%ldiag_ugwp) then
       Diag%dudt_ogw    = zero
       Diag%dvdt_ogw    = zero
       Diag%dudt_obl    = zero
@@ -7242,6 +7286,14 @@ module GFS_typedefs
       Diag%dv_osscol   = zero
       Diag%du_ofdcol   = zero
       Diag%dv_ofdcol   = zero
+      Diag%du3_ogwcol  = zero
+      Diag%dv3_ogwcol  = zero
+      Diag%du3_oblcol  = zero
+      Diag%dv3_oblcol  = zero
+      Diag%du3_osscol  = zero
+      Diag%dv3_osscol  = zero
+      Diag%du3_ofdcol  = zero
+      Diag%dv3_ofdcol  = zero
     else
       Diag%dudt_ogw    = zero
     end if
@@ -7270,6 +7322,17 @@ module GFS_typedefs
       Diag%dtdt_tot    = zero
       Diag%uav_ugwp    = zero
       Diag%tav_ugwp    = zero
+      Diag%dws3dt_ogw  = zero
+      Diag%dws3dt_obl  = zero
+      Diag%dws3dt_oss  = zero
+      Diag%dws3dt_ofd  = zero
+      Diag%ldu3dt_ogw  = zero
+      Diag%ldu3dt_obl  = zero
+      Diag%ldu3dt_oss  = zero
+      Diag%ldu3dt_ofd  = zero
+      Diag%ldu3dt_ngw  = zero
+      Diag%ldv3dt_ngw  = zero
+      Diag%ldt3dt_ngw  = zero
 !COORDE
       Diag%du3dt_dyn   = zero
     endif

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1864,8 +1864,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: dt3dt_pbl(:,:) => null()  !< daily aver GFS_phys tend for Temp pbl
 !
     real (kind=kind_phys), pointer :: du3dt_ogw(:,:) => null()  !< daily aver GFS_phys tend for WE-U OGW
-    real (kind=kind_phys), pointer :: dv3dt_ogw(:,:) => null()  !< daily aver GFS_phys tend for SN-V OGW
-    real (kind=kind_phys), pointer :: dt3dt_ogw(:,:) => null()  !< daily aver GFS_phys tend for Temp OGW
 !
     real (kind=kind_phys), pointer :: ldu3dt_ogw(:,:) => null()  !< time aver GFS_phys tend for WE-U OGW
     real (kind=kind_phys), pointer :: ldu3dt_obl(:,:) => null()  !< time aver GFS_phys tend for WE-U OBL
@@ -1873,24 +1871,11 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: ldu3dt_ofd(:,:) => null()  !< time aver GFS_phys tend for WE-U OFD
 !
     real (kind=kind_phys), pointer :: du3dt_mtb(:,:) => null()  !< daily aver GFS_phys tend for WE-U MTB
-    real (kind=kind_phys), pointer :: dv3dt_mtb(:,:) => null()  !< daily aver GFS_phys tend for SN-V MTB
-    real (kind=kind_phys), pointer :: dt3dt_mtb(:,:) => null()  !< daily aver GFS_phys tend for Temp MTB
 !
     real (kind=kind_phys), pointer :: du3dt_tms(:,:) => null()  !< daily aver GFS_phys tend for WE-U TMS
-    real (kind=kind_phys), pointer :: dv3dt_tms(:,:) => null()  !< daily aver GFS_phys tend for SN-V TMS
-    real (kind=kind_phys), pointer :: dt3dt_tms(:,:) => null()  !< daily aver GFS_phys tend for Temp TMS
 !
     real (kind=kind_phys), pointer :: du3dt_ngw(:,:) => null()  !< daily aver GFS_phys tend for WE-U NGW
     real (kind=kind_phys), pointer :: dv3dt_ngw(:,:) => null()  !< daily aver GFS_phys tend for SN-V NGW
-    real (kind=kind_phys), pointer :: dt3dt_ngw(:,:) => null()  !< daily aver GFS_phys tend for Temp NGW
-!
-    real (kind=kind_phys), pointer :: du3dt_cgw(:,:) => null()  !< daily aver GFS_phys tend for WE-U NGW
-    real (kind=kind_phys), pointer :: dv3dt_cgw(:,:) => null()  !< daily aver GFS_phys tend for SN-V NGW
-    real (kind=kind_phys), pointer :: dt3dt_cgw(:,:) => null()  !< daily aver GFS_phys tend for Temp NGW
-!
-    real (kind=kind_phys), pointer :: du3dt_moist(:,:) => null()  !< daily aver GFS_phys tend for WE-U MOIST
-    real (kind=kind_phys), pointer :: dv3dt_moist(:,:) => null()  !< daily aver GFS_phys tend for SN-V MOIST
-    real (kind=kind_phys), pointer :: dt3dt_moist(:,:) => null()  !< daily aver GFS_phys tend for Temp MOIST
 !
     real (kind=kind_phys), pointer :: dws3dt_ogw(:,:) => null()  !< time aver GFS_phys tend for windspeed OGW
     real (kind=kind_phys), pointer :: dws3dt_obl(:,:) => null()  !< time aver GFS_phys tend for windspeed OBL
@@ -6945,20 +6930,10 @@ module GFS_typedefs
       allocate (Diag%dv3dt_pbl  (IM,Model%levs) )
       allocate (Diag%dt3dt_pbl  (IM,Model%levs) )
       allocate (Diag%du3dt_ogw  (IM,Model%levs) )
-      allocate (Diag%dv3dt_ogw  (IM,Model%levs) )
-      allocate (Diag%dt3dt_ogw  (IM,Model%levs) )
       allocate (Diag%du3dt_mtb  (IM,Model%levs) )
-      allocate (Diag%dv3dt_mtb  (IM,Model%levs) )
-      allocate (Diag%dt3dt_mtb  (IM,Model%levs) )
       allocate (Diag%du3dt_tms  (IM,Model%levs) )
-      allocate (Diag%dv3dt_tms  (IM,Model%levs) )
-      allocate (Diag%dt3dt_tms  (IM,Model%levs) )
       allocate (Diag%du3dt_ngw  (IM,Model%levs) )
       allocate (Diag%dv3dt_ngw  (IM,Model%levs) )
-      allocate (Diag%dt3dt_ngw  (IM,Model%levs) )
-      allocate (Diag%du3dt_cgw  (IM,Model%levs) )
-      allocate (Diag%dv3dt_cgw  (IM,Model%levs) )
-      allocate (Diag%dt3dt_moist (IM,Model%levs))
       allocate (Diag%dudt_tot  (IM,Model%levs) )
       allocate (Diag%dvdt_tot  (IM,Model%levs) )
       allocate (Diag%dtdt_tot  (IM,Model%levs) )
@@ -7313,20 +7288,10 @@ module GFS_typedefs
       Diag%dv3dt_pbl   = zero
       Diag%dt3dt_pbl   = zero
       Diag%du3dt_ogw   = zero
-      Diag%dv3dt_ogw   = zero
-      Diag%dt3dt_ogw   = zero
       Diag%du3dt_mtb   = zero
-      Diag%dv3dt_mtb   = zero
-      Diag%dt3dt_mtb   = zero
       Diag%du3dt_tms   = zero
-      Diag%dv3dt_tms   = zero
-      Diag%dt3dt_tms   = zero
       Diag%du3dt_ngw   = zero
       Diag%dv3dt_ngw   = zero
-      Diag%dt3dt_ngw   = zero
-      Diag%du3dt_moist = zero
-      Diag%dv3dt_moist = zero
-      Diag%dt3dt_moist = zero
       Diag%dudt_tot    = zero
       Diag%dvdt_tot    = zero
       Diag%dtdt_tot    = zero

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -3557,7 +3557,7 @@ module GFS_typedefs
                                do_ugwp_v0_nst_only,                                         &
                                do_gsl_drag_ls_bl, do_gsl_drag_ss, do_gsl_drag_tofd,         &
                                do_ugwp_v1, do_ugwp_v1_orog_only,  do_ugwp_v1_w_gsldrag,     &
-                               var_ric, coef_ric_l, coef_ric_s, hurr_pbl,                   &
+                               ugwp_seq_update, var_ric, coef_ric_l, coef_ric_s, hurr_pbl,  &
                                do_myjsfc, do_myjpbl,                                        &
                                hwrf_samfdeep, hwrf_samfshal,progsigma,                      &
                                h2o_phys, pdfcld, shcnvcw, redrag, hybedmf, satmedmf,        &

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -8458,7 +8458,7 @@
   kind = kind_phys
 [dudt_ogw]
   standard_name = tendency_of_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = x momentum tendency from meso scale ogw
+  long_name = x wind tendency from meso scale ogw
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -8466,7 +8466,7 @@
   active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dvdt_ogw]
   standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = y momentum tendency from meso scale ogw
+  long_name = y wind tendency from meso scale ogw
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -8489,16 +8489,16 @@
   kind = kind_phys
   active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dudt_obl]
-  standard_name = tendency_of_x_momentum_due_to_blocking_drag
-  long_name = x momentum tendency from blocking drag
+  standard_name = tendency_of_x_wind_due_to_blocking_drag
+  long_name = x wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dvdt_obl]
-  standard_name = tendency_of_y_momentum_due_to_blocking_drag
-  long_name = y momentum tendency from blocking drag
+  standard_name = tendency_of_y_wind_due_to_blocking_drag
+  long_name = y wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -8585,16 +8585,16 @@
   kind = kind_phys
   active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dudt_oss]
-  standard_name = tendency_of_x_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = x momentum tendency from small scale gwd
+  standard_name = tendency_of_x_wind_due_to_small_scale_gravity_wave_drag
+  long_name = x wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dvdt_oss]
-  standard_name = tendency_of_y_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = y momentum tendency from small scale gwd
+  standard_name = tendency_of_y_wind_due_to_small_scale_gravity_wave_drag
+  long_name = y wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -8617,16 +8617,16 @@
   kind = kind_phys
   active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dudt_ofd]
-  standard_name = tendency_of_x_momentum_due_to_form_drag
-  long_name = x momentum tendency from form drag
+  standard_name = tendency_of_x_wind_due_to_form_drag
+  long_name = x wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dvdt_ofd]
-  standard_name = tendency_of_y_momentum_due_to_form_drag
-  long_name = y momentum tendency from form drag
+  standard_name = tendency_of_y_wind_due_to_form_drag
+  long_name = y wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -6323,6 +6323,12 @@
   units = flag
   dimensions = ()
   type = logical
+[ugwp_seq_update]
+  standard_name = ugwp_sequential_update_flag
+  long_name = flag for ugwp sequential update
+  units = flag
+  dimensions = ()
+  type = logical
 [uni_cld]
   standard_name = flag_for_shoc_cloud_area_fraction_for_radiation
   long_name = flag for uni_cld
@@ -6354,8 +6360,8 @@
   dimensions = ()
   type = logical
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_large_scale_orographic_and_blocking_drag
-  long_name = flag to activate GSL drag suite - large-scale GWD and blocking
+  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical
@@ -8312,6 +8318,38 @@
   type = real
   kind = kind_phys
   active = (flag_for_unified_gravity_wave_physics_diagnostics)
+[ldu3dt_ogw]
+  standard_name = cumulative_change_in_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = cumulative change in x wind due to mesoscale orographic gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_unified_gravity_wave_physics_diagnostics)
+[ldu3dt_obl]
+  standard_name = cumulative_change_in_x_wind_due_to_blocking_drag
+  long_name = cumulative change in x wind due to blocking drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_unified_gravity_wave_physics_diagnostics)
+[ldu3dt_oss]
+  standard_name = cumulative_change_in_x_wind_due_to_small_scale_gravity_wave_drag
+  long_name = cumulative change in x wind due to small scale gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_unified_gravity_wave_physics_diagnostics)
+[ldu3dt_ofd]
+  standard_name = cumulative_change_in_x_wind_due_to_form_drag
+  long_name = cumulative change in x wind due to form drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_unified_gravity_wave_physics_diagnostics)
 [du3dt_tms]
   standard_name = time_integral_of_change_in_x_wind_due_to_turbulent_orographic_form_drag
   long_name = time integral of change in x wind due to TOFD
@@ -8328,6 +8366,62 @@
   type = real
   kind = kind_phys
   active = (flag_for_unified_gravity_wave_physics_diagnostics)
+[dws3dt_ogw]
+ standard_name = cumulative_change_in_wind_speed_due_to_mesoscale_orographic_gravity_wave_drag
+ long_name = cumulative change in wind speed due to mesoscale orographic gravity wave drag
+ units = m s-1
+ dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+ type = real
+ kind = kind_phys
+ active = (flag_for_unified_gravity_wave_physics_diagnostics)
+[dws3dt_obl]
+ standard_name = cumulative_change_in_wind_speed_due_to_blocking_drag
+ long_name = cumulative change in wind speed due to blocking drag
+ units = m s-1
+ dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+ type = real
+ kind = kind_phys
+ active = (flag_for_unified_gravity_wave_physics_diagnostics)
+[dws3dt_oss]
+ standard_name = cumulative_change_in_wind_speed_due_to_small_scale_orographic_gravity_wave_drag
+ long_name = cumulative change in wind speed due to small scale orographic gravity wave drag
+ units = m s-1
+ dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+ type = real
+ kind = kind_phys
+ active = (flag_for_unified_gravity_wave_physics_diagnostics)
+[dws3dt_ofd]
+ standard_name = cumulative_change_in_wind_speed_due_to_turbulent_orographic_form_drag
+ long_name = cumulative change in wind speed due to turbulent orographic form drag
+ units = m s-1
+ dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+ type = real
+ kind = kind_phys
+ active = (flag_for_unified_gravity_wave_physics_diagnostics)
+[ldu3dt_ngw]
+ standard_name = cumulative_change_in_x_wind_due_to_convective_gravity_wave_drag
+ long_name = cumulative change in x wind due to convective gravity wave drag
+ units = m s-1
+ dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+ type = real
+ kind = kind_phys
+ active = (flag_for_unified_gravity_wave_physics_diagnostics)
+[ldv3dt_ngw]
+ standard_name = cumulative_change_in_y_wind_due_to_convective_gravity_wave_drag
+ long_name = cumulative change in y wind due to convective gravity wave drag
+ units = m s-1
+ dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+ type = real
+ kind = kind_phys
+ active = (flag_for_unified_gravity_wave_physics_diagnostics)
+[ldt3dt_ngw]
+ standard_name = cumulative_change_in_temperature_due_to_convective_gravity_wave_drag
+ long_name = cumulative change in temperature due to convective gravity wave drag
+ units = K
+ dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+ type = real
+ kind = kind_phys
+ active = (flag_for_unified_gravity_wave_physics_diagnostics)
 [dudt_gw]
   standard_name = tendency_of_x_wind_due_to_gravity_wave_drag
   long_name = zonal wind tendency due to all GWs
@@ -8363,7 +8457,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dvdt_ogw]
   standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = y momentum tendency from meso scale ogw
@@ -8371,7 +8465,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [du_ogwcol]
   standard_name = vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = integrated x momentum flux from meso scale ogw
@@ -8379,7 +8473,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dv_ogwcol]
   standard_name = vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = integrated y momentum flux from meso scale ogw
@@ -8387,7 +8481,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dudt_obl]
   standard_name = tendency_of_x_momentum_due_to_blocking_drag
   long_name = x momentum tendency from blocking drag
@@ -8395,7 +8489,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dvdt_obl]
   standard_name = tendency_of_y_momentum_due_to_blocking_drag
   long_name = y momentum tendency from blocking drag
@@ -8403,7 +8497,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [du_oblcol]
   standard_name = vertically_integrated_x_momentum_flux_due_to_blocking_drag
   long_name = integrated x momentum flux from blocking drag
@@ -8411,7 +8505,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33 .or. control_for_drag_suite_gravity_wave_drag==22)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dv_oblcol]
   standard_name = vertically_integrated_y_momentum_flux_due_to_blocking_drag
   long_name = integrated y momentum flux from blocking drag
@@ -8419,7 +8513,71 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
+[du3_ogwcol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = cumulative integrated x momentum flux from mesoscale orographic gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
+[dv3_ogwcol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = cumulative integrated y momentum flux from mesoscale orographic gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
+[du3_oblcol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_blocking_drag
+  long_name = cumulative integrated x momentum flux from blocking drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
+[dv3_oblcol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_to_blocking_drag
+  long_name = cumulative integrated y momentum flux from blocking drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
+[du3_osscol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_small_scale_gravity_wave_drag
+  long_name = cumulative integrated x momentum flux from small scale gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
+[dv3_osscol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_small_scale_gravity_wave_drag
+  long_name = cumulative integrated y momentum flux from small scale gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
+[du3_ofdcol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_form_drag
+  long_name = cumulative integrated x momentum flux from form drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
+[dv3_ofdcol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_to_form_drag
+  long_name = cumulative integrated y momentum flux from form drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dudt_oss]
   standard_name = tendency_of_x_momentum_due_to_small_scale_gravity_wave_drag
   long_name = x momentum tendency from small scale gwd
@@ -8427,7 +8585,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dvdt_oss]
   standard_name = tendency_of_y_momentum_due_to_small_scale_gravity_wave_drag
   long_name = y momentum tendency from small scale gwd
@@ -8435,7 +8593,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [du_osscol]
   standard_name = vertically_integrated_x_momentum_flux_due_to_small_scale_gravity_wave_drag
   long_name = integrated x momentum flux from small scale gwd
@@ -8443,7 +8601,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dv_osscol]
   standard_name = vertically_integrated_y_momentum_flux_due_to_small_scale_gravity_wave_drag
   long_name = integrated y momentum flux from small scale gwd
@@ -8451,7 +8609,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dudt_ofd]
   standard_name = tendency_of_x_momentum_due_to_form_drag
   long_name = x momentum tendency from form drag
@@ -8459,7 +8617,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dvdt_ofd]
   standard_name = tendency_of_y_momentum_due_to_form_drag
   long_name = y momentum tendency from form drag
@@ -8467,7 +8625,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [du_ofdcol]
   standard_name = vertically_integrated_x_momentum_flux_due_to_form_drag
   long_name = integrated x momentum flux from form drag
@@ -8475,7 +8633,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dv_ofdcol]
   standard_name = vertically_integrated_y_momentum_flux_due_to_form_drag
   long_name = integrated y momentum flux from form drag
@@ -8483,7 +8641,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_ugwp_version_1 .or. control_for_drag_suite_gravity_wave_drag==33)
+  active = (flag_for_ugwp_version_1 .or. flag_for_unified_gravity_wave_physics_diagnostics)
 [dv3dt_ngw]
   standard_name = time_integral_of_change_in_y_wind_due_to_nonstationary_gravity_wave
   long_name = time integral of change in y wind due to NGW

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -6324,7 +6324,7 @@
   dimensions = ()
   type = logical
 [ugwp_seq_update]
-  standard_name = ugwp_sequential_update_flag
+  standard_name = do_ugwp_sequential_update
   long_name = flag for ugwp sequential update
   units = flag
   dimensions = ()
@@ -6360,19 +6360,19 @@
   dimensions = ()
   type = logical
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  standard_name = do_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
   long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical
 [do_gsl_drag_ss]
-  standard_name = flag_for_gsl_drag_suite_small_scale_orographic_drag
+  standard_name = do_gsl_drag_suite_small_scale_orographic_drag
   long_name = flag to activate GSL drag suite - small-scale GWD
   units = flag
   dimensions = ()
   type = logical
 [do_gsl_drag_tofd]
-  standard_name = flag_for_gsl_drag_suite_turbulent_orographic_form_drag
+  standard_name = do_gsl_drag_suite_turbulent_orographic_form_drag
   long_name = flag to activate GSL drag suite - turb orog form drag
   units = flag
   dimensions = ()

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -2656,7 +2656,7 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dudt_tot(:,:)
     enddo
 
-     idx = idx + 1
+    idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'dtdt_tot'
     ExtDiag(idx)%desc = ' dtdt_tot averaged Temp dycore-tendency'
@@ -2666,8 +2666,420 @@ module GFS_diagnostics
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dtdt_tot(:,:)
     enddo
-   ENDIF
 
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dudt_ogw'
+    ExtDiag(idx)%desc = 'x wind tendency from mesoscale OGWD'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dudt_ogw(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dvdt_ogw'
+    ExtDiag(idx)%desc = 'y wind tendency from mesoscale OGWD'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dvdt_ogw(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dudt_obl'
+    ExtDiag(idx)%desc = 'x wind tendency from blocking drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dudt_obl(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dvdt_obl'
+    ExtDiag(idx)%desc = 'y wind tendency from blocking drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dvdt_obl(:,:)
+    enddo
+
+    ! 2D variables
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'du_ogwcol'
+    ExtDiag(idx)%desc = 'integrated x momentum flux from meso scale ogw'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%du_ogwcol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'dv_ogwcol'
+    ExtDiag(idx)%desc = 'integrated y momentum flux from meso scale ogw'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%dv_ogwcol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'du_oblcol'
+    ExtDiag(idx)%desc = 'integrated x momentum flux from blocking drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%du_oblcol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'dv_oblcol'
+    ExtDiag(idx)%desc = 'integrated y momentum flux from blocking drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%dv_oblcol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dws3dt_ogw'
+    ExtDiag(idx)%desc = 'averaged wind speed tendency due to mesoscale gravity wave drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dws3dt_ogw(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dws3dt_obl'
+    ExtDiag(idx)%desc = 'averaged wind speed tendency due to blocking drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dws3dt_obl(:,:)
+    enddo
+
+    ! Variables for GSL drag suite
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dudt_oss'
+    ExtDiag(idx)%desc = 'x wind tendency from small scale GWD'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dudt_oss(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dvdt_oss'
+    ExtDiag(idx)%desc = 'y wind tendency from small scale GWD'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dvdt_oss(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dudt_ofd'
+    ExtDiag(idx)%desc = 'x wind tendency from form drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dudt_ofd(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dvdt_ofd'
+    ExtDiag(idx)%desc = 'y wind tendency from form drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dvdt_ofd(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dws3dt_oss'
+    ExtDiag(idx)%desc = 'averaged wind speed tendency due to small-scale gravity wave drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dws3dt_oss(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'dws3dt_ofd'
+    ExtDiag(idx)%desc = 'averaged wind speed tendency due to turbulent orographic form drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%dws3dt_ofd(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'ldu3dt_ogw'
+    ExtDiag(idx)%desc = 'averaged x wind tendency due to mesoscale orographic gravity wave drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%ldu3dt_ogw(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'ldu3dt_obl'
+    ExtDiag(idx)%desc = 'averaged x wind tendency due to blocking drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%ldu3dt_obl(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'ldu3dt_ofd'
+    ExtDiag(idx)%desc = 'averaged x wind tendency due to form drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%ldu3dt_ofd(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'ldu3dt_oss'
+    ExtDiag(idx)%desc = 'averaged x wind tendency due to small scale gravity wave drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%ldu3dt_oss(:,:)
+    enddo
+
+    ! 2D variables
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'du_osscol'
+    ExtDiag(idx)%desc = 'integrated x momentum flux from small scale gwd'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%du_osscol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'dv_osscol'
+    ExtDiag(idx)%desc = 'integrated y momentum flux from small scale gwd'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%dv_osscol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'du_ofdcol'
+    ExtDiag(idx)%desc = 'integrated x momentum flux from form drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%du_ofdcol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'dv_ofdcol'
+    ExtDiag(idx)%desc = 'integrated y momentum flux from form drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%dv_ofdcol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'du3_ogwcol'
+    ExtDiag(idx)%desc = 'time averaged surface x momentum flux from mesoscale orographic gravity wave drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%du3_ogwcol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'dv3_ogwcol'
+    ExtDiag(idx)%desc = 'time averaged surface y momentum flux from mesoscale orographic gravity wave drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%dv3_ogwcol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'du3_oblcol'
+    ExtDiag(idx)%desc = 'time averaged surface x momentum flux from blocking drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%du3_oblcol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'dv3_oblcol'
+    ExtDiag(idx)%desc = 'time averaged surface y momentum flux from blocking drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%dv3_oblcol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'du3_osscol'
+    ExtDiag(idx)%desc = 'time averaged surface x momentum flux from small scale gravity wave drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%du3_osscol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'dv3_osscol'
+    ExtDiag(idx)%desc = 'time averaged surface y momentum flux from small scale gravity wave drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%dv3_osscol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'du3_ofdcol'
+    ExtDiag(idx)%desc = 'time averaged surface x momentum flux from form drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%du3_ofdcol(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'dv3_ofdcol'
+    ExtDiag(idx)%desc = 'time averaged surface y momentum flux from form drag'
+    ExtDiag(idx)%unit = 'Pa'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%dv3_ofdcol(:)
+    enddo
+
+    ! UGWP non-stationary GWD outputs
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'ldu3dt_ngw'
+    ExtDiag(idx)%desc = 'time averaged u momentum tendency due to non-stationary gravity wave drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%ldu3dt_ngw(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'ldv3dt_ngw'
+    ExtDiag(idx)%desc = 'time averaged v momentum tendency due to non-stationary gravity wave drag'
+    ExtDiag(idx)%unit = 'm s-2'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%ldv3dt_ngw(:,:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'ldt3dt_ngw'
+    ExtDiag(idx)%desc = 'time averaged temperature tendency due to non-stationary gravity wave drag'
+    ExtDiag(idx)%unit = 'K s-1'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%ldt3dt_ngw(:,:)
+    enddo
+
+  ENDIF  ! if (Model%ldiag_ugwp)
 
 
 !    if(mpp_pe()==mpp_root_pe())print *,'in gfdl_diag_register,af shum_wts,idx=',idx


### PR DESCRIPTION
## Description

This pull request has three main components:
1)  To fix some issues with the orographic drag schemes of the "_drag_suite_" CCPP module which have caused model crashes to occur in GFSv17 p8 testing.  These issues are described in [ufs-community/ccpp-physics/Issue #20](https://github.com/ufs-community/ccpp-physics/issues/20).
2)  To add optional diagnostic outputs for each of the components of the drag suite for tuning purposes.  This is also described in [ufs-community/ccpp-physics/Issue #20](https://github.com/ufs-community/ccpp-physics/issues/20).  The optional diagnostic outputs can be selected at run time by the already-existing _ldiag_ugwp_ namelist flag.
3)  As part of the 1st component above, at the suggestion of Philip Pegion, we have added the capability to update the u and v winds in each model column based on the tendencies calculated by the mesoscale gravity wave drag and blocking schemes, and using these for the calculation of the tendencies by the small-scale gravity wave drag and turbulent orographic form drag schemes.  This sequential updating of the wind profile has been shown to improve the numerical stability.  The option to update the winds in this manner is controlled by a new logic flag _ugwp_seq_update_, which for now, is not a namelist option, but is hardwired by default to ._false_. in _GFS_typedefs.F90_.  The user can change this to ._true_. at compile time.

Is a change of answers expected from this PR?  Yes.



### Issue(s) addressed

- fixes [ufs-community/ccpp-physics/Issue #20](https://github.com/ufs-community/ccpp-physics/issues/20)



## Testing

How were these changes tested?  RT (new baseline, then tested against new baseline).  ORT.
What compilers / HPCs was it tested with?  Intel.  Hera.

Have the ufs-weather-model regression test been run? Yes.
On what platform?  Hera/Intel.
- Will the code updates change regression test baseline? Yes.  Changes to CCPP unified_ugwp drag suite. Please show the baseline directory below.
/scratch1/BMC/wrfruc/mtoy/git_local/ufs-weather-model/REGRESSION_TEST_INTEL.2022_11_08


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
https://github.com/mdtoyNOAA/ufs-weather-model/tree/develop_ugwp_improvements
https://github.com/mdtoyNOAA/ccpp-physics/tree/ufs/dev_ugwp_improvements

CCPP-physics pull request dependency: [ccpp-physics#20](https://github.com/ufs-community/ccpp-physics/pull/22)