### PR TITLE
Bug fix for the NoahMP scheme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = ufs/dev
-  url = https://github.com/HelinWei-NOAA/ccpp-physics
-  branch = baseline.hr1
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/HelinWei-NOAA/ccpp-physics
+  branch = baseline.hr1
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION

## Description
This PR aims to fix the ccpp-physics bugs that are reported in [#963](https://github.com/NCAR/ccpp-physics/issues/963) and [#964](https://github.com/NCAR/ccpp-physics/issues/964).  It will change the baselines for the RTs that use the NoahMP scheme.

### Issue(s) addressed
- fixes ccpp-physics #<[963](https://github.com/NCAR/ccpp-physics/issues/963)>
- fixes ccpp-physics #<[964](https://github.com/NCAR/ccpp-physics/issues/964)>

## Testing
The testing will be reported in the upstream ufs-weather-model PR.

## Dependencies
- waiting on ufs-community/ccpp-physics/pull/<[23](https://github.com/ufs-community/ccpp-physics/pull/23)>
