### PR TITLE
adding hr_ave_chem_v1 to atmos_cubed_sphere

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+#  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+#  branch = dev/emc
+  url = https://github.com/JianpingHuang-NOAA/GFDL_atmos_cubed_sphere
+  branch = hr_ave_chem_v1 
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-#  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-#  branch = dev/emc
-  url = https://github.com/JianpingHuang-NOAA/GFDL_atmos_cubed_sphere
-  branch = hr_ave_chem_v1 
+  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description

to update atmos_cubed_sphere with online-calculation and writing of chemical species 

## Testing

How were these changes tested?  
Test was done on WCOSS2

Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) 
Yes
 
Have the ufs-weather-model regression test been run? On what platform?  
Done on WCOSS2

- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.


- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs

https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/226

https://github.com/ufs-community/ufs-weather-model/pull/1513



