### PR TITLE
MYNNsfc uniform real kind

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/dustinswales/ccpp-physics
+  branch = mynnsfc_uniform_real_kind
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  url = https://github.com/NCAR/ccpp-framework
-  branch = main
+  url = https://github.com/climbfuji/ccpp-framework
+  branch = python311_global_flags
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/dustinswales/ccpp-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,12 +4,12 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  url = https://github.com/climbfuji/ccpp-framework
-  branch = python311_global_flags
+  url = https://github.com/NCAR/ccpp-framework
+  branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/dustinswales/ccpp-physics
-  branch = mynnsfc_uniform_real_kind
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This change modifies REAL-type variables and specific REAL-type constants so that they uniformly utilize the kind=kind_phys definition for REAL types found in the CCPP-physics machine.F file. This reduces casting and recasting of REALs between types of differing precision. Additional changes include changing occurances of ALOG to LOG to support more than single precision REALs as needed when kind=kind_phys is defined in that manner.
Opened on behalf of @timsliwinski-noaa 

## Testing
No changes to baselines for UFS regression tests with Intel on Cheyenne.
