### PR TITLE
Add optional 'time_unlimited' logical flag to model_configure

### DIFF
--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -37,7 +37,8 @@ module fv3gfs_cap_mod
                                     num_files, filename_base,                &
                                     wrttasks_per_group, n_group,             &
                                     lead_wrttask, last_wrttask,              &
-                                    nsout_io, iau_offset, lflname_fulltime
+                                    nsout_io, iau_offset, lflname_fulltime,  &
+                                    time_unlimited
 !
   use module_fcst_grid_comp,  only: fcstSS => SetServices
 
@@ -321,6 +322,8 @@ module fv3gfs_cap_mod
       nsout_io = nsout
 !
       if(mype==0) print *,'af nems config,nfhout,nsout=',nfhout,nfhmax_hf,nfhout_hf, nsout,noutput_fh
+
+      call ESMF_ConfigGetAttribute(config=CF, value=time_unlimited, label ='time_unlimited:', default=.false., rc=rc)
 
     endif ! quilting
 !

--- a/io/module_fv3_io_def.F90
+++ b/io/module_fv3_io_def.F90
@@ -17,6 +17,7 @@ module module_fv3_io_def
   integer           :: nbdlphys
   integer           :: nsout_io, iau_offset
   logical           :: lflname_fulltime
+  logical           :: time_unlimited
 
   character(len=esmf_maxstr),dimension(:),allocatable :: filename_base
   character(len=esmf_maxstr),dimension(:),allocatable :: output_file

--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -11,7 +11,8 @@ module module_write_netcdf
   use netcdf
   use module_fv3_io_def,only : ideflate, nbits, &
                                ichunk2d,jchunk2d,ichunk3d,jchunk3d,kchunk3d, &
-                               output_grid,dx,dy,lon1,lat1,lon2,lat2
+                               output_grid,dx,dy,lon1,lat1,lon2,lat2, &
+                               time_unlimited
   use mpi
 
   implicit none
@@ -896,12 +897,15 @@ module module_write_netcdf
                            typekind=typekind, itemCount=n, rc=rc); ESMF_ERR_RETURN(rc)
 
     if (trim(dim_name) == "time") then
-    ! using an unlimited dim requires collective mode (NF90_COLLECTIVE)
-    ! for parallel writes, which seems to slow things down on hera.
-    !ncerr = nf90_def_dim(ncid, trim(dim_name), NF90_UNLIMITED, dimid); NC_ERR_STOP(ncerr)
-    ncerr = nf90_def_dim(ncid, trim(dim_name), 1, dimid); NC_ERR_STOP(ncerr)
+      ! using an unlimited dim requires collective mode (NF90_COLLECTIVE)
+      ! for parallel writes, which seems to slow things down on hera.
+      if (time_unlimited) then
+        ncerr = nf90_def_dim(ncid, trim(dim_name), NF90_UNLIMITED, dimid); NC_ERR_STOP(ncerr)
+      else
+        ncerr = nf90_def_dim(ncid, trim(dim_name), 1, dimid); NC_ERR_STOP(ncerr)
+      end if
     else
-    ncerr = nf90_def_dim(ncid, trim(dim_name), n, dimid); NC_ERR_STOP(ncerr)
+      ncerr = nf90_def_dim(ncid, trim(dim_name), n, dimid); NC_ERR_STOP(ncerr)
     end if
 
     if (typekind==ESMF_TYPEKIND_R8) then


### PR DESCRIPTION
## Description

Add new model_configure parameter (logical flag) 'time_unlimited'. This flag is set to .false.by default. When the user sets it to .true. explicitly in the model_configure file the time dimension in history files will be a record dimension (ie. unlimited)

Is a change of answers expected from this PR?  No.

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes https://github.com/ufs-community/ufs-weather-model/issues/1521

## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first? No.
