### PR TITLE
Update submodule UPP and some HAFS moving-nesting related fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,5 @@
   branch = ufs/dev
 [submodule "upp"]
   path = upp
- #url = https://github.com/NOAA-EMC/UPP
- #branch = develop
-  url = https://github.com/hafs-community/UPP
-  branch = feature/update_upp
+  url = https://github.com/NOAA-EMC/UPP
+  branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,7 @@
   branch = ufs/dev
 [submodule "upp"]
   path = upp
-  url = https://github.com/NOAA-EMC/UPP
-  branch = develop
+ #url = https://github.com/NOAA-EMC/UPP
+ #branch = develop
+  url = https://github.com/hafs-community/UPP
+  branch = feature/update_upp

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
@@ -62,8 +62,8 @@
       <scheme>satmedmfvdifq</scheme>
       <scheme>GFS_PBL_generic_post</scheme>
       <scheme>GFS_GWD_generic_pre</scheme>
-      <scheme>cires_ugwp</scheme>
-      <scheme>cires_ugwp_post</scheme>
+      <scheme>unified_ugwp</scheme>
+      <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
@@ -60,8 +60,8 @@
       <scheme>satmedmfvdifq</scheme>
       <scheme>GFS_PBL_generic_post</scheme>
       <scheme>GFS_GWD_generic_pre</scheme>
-      <scheme>cires_ugwp</scheme>
-      <scheme>cires_ugwp_post</scheme>
+      <scheme>unified_ugwp</scheme>
+      <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
@@ -57,8 +57,8 @@
       <scheme>satmedmfvdifq</scheme>
       <scheme>GFS_PBL_generic_post</scheme>
       <scheme>GFS_GWD_generic_pre</scheme>
-      <scheme>cires_ugwp</scheme>
-      <scheme>cires_ugwp_post</scheme>
+      <scheme>unified_ugwp</scheme>
+      <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_noahmp.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_noahmp.xml
@@ -57,8 +57,8 @@
       <scheme>satmedmfvdifq</scheme>
       <scheme>GFS_PBL_generic_post</scheme>
       <scheme>GFS_GWD_generic_pre</scheme>
-      <scheme>cires_ugwp</scheme>
-      <scheme>cires_ugwp_post</scheme>
+      <scheme>unified_ugwp</scheme>
+      <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_noahmp_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_noahmp_nonsst.xml
@@ -55,8 +55,8 @@
       <scheme>satmedmfvdifq</scheme>
       <scheme>GFS_PBL_generic_post</scheme>
       <scheme>GFS_GWD_generic_pre</scheme>
-      <scheme>cires_ugwp</scheme>
-      <scheme>cires_ugwp_post</scheme>
+      <scheme>unified_ugwp</scheme>
+      <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
@@ -55,8 +55,8 @@
       <scheme>satmedmfvdifq</scheme>
       <scheme>GFS_PBL_generic_post</scheme>
       <scheme>GFS_GWD_generic_pre</scheme>
-      <scheme>cires_ugwp</scheme>
-      <scheme>cires_ugwp_post</scheme>
+      <scheme>unified_ugwp</scheme>
+      <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
@@ -57,8 +57,8 @@
       <scheme>satmedmfvdifq</scheme>
       <scheme>GFS_PBL_generic_post</scheme>
       <scheme>GFS_GWD_generic_pre</scheme>
-      <scheme>cires_ugwp</scheme>
-      <scheme>cires_ugwp_post</scheme>
+      <scheme>unified_ugwp</scheme>
+      <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
       <scheme>ozphys_2015</scheme>

--- a/moving_nest/fv_moving_nest.F90
+++ b/moving_nest/fv_moving_nest.F90
@@ -261,6 +261,13 @@ contains
     call fill_nest_halos_from_parent("q", Atm(n)%q, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
         Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, is_fine_pe, nest_domain, position, nz)
 
+    ! Interpolate terrain from coarse grid
+    if (Moving_nest(n)%mn_flag%terrain_smoother .eq. 4) then
+      print '("[INFO] WDR fv_moving_nest.F90 SMOOTH fill_nest_halos_from_parent terrain_smoother=",I0)', Moving_nest(n)%mn_flag%terrain_smoother
+      call fill_nest_halos_from_parent("phis", Atm(n)%phis, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, is_fine_pe, nest_domain, position)
+    endif
+
     !  Move the A-grid winds.  TODO consider recomputing them from D grid instead
     call fill_nest_halos_from_parent("ua", Atm(n)%ua, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
         Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, is_fine_pe, nest_domain, position, nz)
@@ -350,6 +357,8 @@ contains
     integer :: this_pe
     type(fv_moving_nest_prog_type), pointer :: mn_prog
 
+    integer :: child_grid_num = 2
+
     mn_prog => Moving_nest(2)%mn_prog  ! TODO allow nest number to vary
     this_pe = mpp_pe()
 
@@ -359,6 +368,11 @@ contains
     !call mn_var_fill_intern_nest_halos(Atm%omga, domain_fine, is_fine_pe)
     call mn_var_fill_intern_nest_halos(Atm%delp, domain_fine, is_fine_pe)
     call mn_var_fill_intern_nest_halos(mn_prog%delz, domain_fine, is_fine_pe)
+
+    if (Moving_nest(child_grid_num)%mn_flag%terrain_smoother .eq. 4) then
+      print '("[INFO] WDR fv_moving_nest.F90 SMOOTH fill_intern_nest_halos terrain_smoother=",I0)', Moving_nest(child_grid_num)%mn_flag%terrain_smoother
+      call mn_var_fill_intern_nest_halos(Atm%phis, domain_fine, is_fine_pe)
+    endif
 
     call mn_var_fill_intern_nest_halos(Atm%ua, domain_fine, is_fine_pe)
     call mn_var_fill_intern_nest_halos(Atm%va, domain_fine, is_fine_pe)
@@ -1033,6 +1047,12 @@ contains
 
     call mn_var_shift_data(mn_prog%delz, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
         delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position, nz)
+
+    if (Moving_nest(n)%mn_flag%terrain_smoother .eq. 4) then
+      print '("[INFO] WDR fv_moving_nest.F90 SMOOTH var_shift_data terrain_smoother=",I0)', Moving_nest(n)%mn_flag%terrain_smoother
+      call mn_var_shift_data(Atm(n)%phis, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
+    endif
 
     call mn_var_shift_data(Atm(n)%ua, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
         delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position, nz)

--- a/moving_nest/fv_moving_nest.F90
+++ b/moving_nest/fv_moving_nest.F90
@@ -263,7 +263,6 @@ contains
 
     ! Interpolate terrain from coarse grid
     if (Moving_nest(n)%mn_flag%terrain_smoother .eq. 4) then
-      print '("[INFO] WDR fv_moving_nest.F90 SMOOTH fill_nest_halos_from_parent terrain_smoother=",I0)', Moving_nest(n)%mn_flag%terrain_smoother
       call fill_nest_halos_from_parent("phis", Atm(n)%phis, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, is_fine_pe, nest_domain, position)
     endif
@@ -370,7 +369,6 @@ contains
     call mn_var_fill_intern_nest_halos(mn_prog%delz, domain_fine, is_fine_pe)
 
     if (Moving_nest(child_grid_num)%mn_flag%terrain_smoother .eq. 4) then
-      print '("[INFO] WDR fv_moving_nest.F90 SMOOTH fill_intern_nest_halos terrain_smoother=",I0)', Moving_nest(child_grid_num)%mn_flag%terrain_smoother
       call mn_var_fill_intern_nest_halos(Atm%phis, domain_fine, is_fine_pe)
     endif
 
@@ -1049,7 +1047,6 @@ contains
         delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position, nz)
 
     if (Moving_nest(n)%mn_flag%terrain_smoother .eq. 4) then
-      print '("[INFO] WDR fv_moving_nest.F90 SMOOTH var_shift_data terrain_smoother=",I0)', Moving_nest(n)%mn_flag%terrain_smoother
       call mn_var_shift_data(Atm(n)%phis, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
           delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
     endif

--- a/moving_nest/fv_moving_nest.F90
+++ b/moving_nest/fv_moving_nest.F90
@@ -2663,16 +2663,9 @@ contains
       !
 
       do j = bbox_fine%js, bbox_fine%je
-
-        jc = ind(i,j,2)        
-        
         do i = bbox_fine%is, bbox_fine%ie
-
           jc = ind(i,j,2)         ! reset this if the UPDATE code altered it
-
           ic = ind(i,j,1)
-
-
           if (ic+1 .gt. ubound(p_grid, 1)) print '("[ERROR] WDR CALCWT off end of p_grid i npe=",I0," ic+1=",I0," bound=",I0)', mpp_pe(), ic+1, ubound(p_grid,1)
           if (jc+1 .gt. ubound(p_grid, 2)) print '("[ERROR] WDR CALCWT off end of p_grid j npe=",I0," jc+1=",I0," bound=",I0)', mpp_pe(), jc+1, ubound(p_grid,2)
           

--- a/moving_nest/fv_moving_nest_main.F90
+++ b/moving_nest/fv_moving_nest_main.F90
@@ -986,6 +986,7 @@ contains
         ! 0 -- all high-resolution data, 1 - static nest smoothing algorithm, 5 - 5 point smoother, 9 - 9 point smoother
         ! Defaults to 1 - static nest smoothing algorithm; this seems to produce the most stable solutions
 
+        print '("[INFO] WDR fv_moving_nest_main.F90 SMOOTH terrain_smoother=",I0)', Moving_nest(n)%mn_flag%terrain_smoother
         select case(Moving_nest(n)%mn_flag%terrain_smoother)
         case (0)
           ! High-resolution terrain for entire nest
@@ -996,6 +997,8 @@ contains
         case (2)
           ! Static nest smoothing algorithm - interpolation of coarse terrain in halo zone and 5 point blending zone of coarse and fine data
           call set_blended_terrain(Atm(n), mn_static%parent_orog_grid, mn_static%orog_grid, x_refine, Atm(n)%bd%ng, 10, a_step)
+        case (4)  ! Use coarse terrain;  no-op here.
+          ;
         case (5)
           ! 5 pt smoother.  blend zone of 5 to match static nest
           call set_smooth_nest_terrain(Atm(n), mn_static%orog_grid, x_refine, 5, Atm(n)%bd%ng, 5)

--- a/moving_nest/fv_moving_nest_main.F90
+++ b/moving_nest/fv_moving_nest_main.F90
@@ -918,20 +918,28 @@ contains
         call mn_reset_phys_latlon(Atm, n, tile_geo, fp_super_tile_geo, Atm_block, IPD_control, IPD_data)
 
         if (use_timers) call mpp_clock_end (id_movnest5_2)
-        if (use_timers) call mpp_clock_begin (id_movnest5_3)
+      endif
 
         !!============================================================================
         !! Step 5.2 -- Fill the wt* variables for each stagger
         !!============================================================================
 
+      call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_h)
+      call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_u)
+      call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_v)
+      call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_b)
+
+      if (is_fine_pe) then
+        if (use_timers) call mpp_clock_begin (id_movnest5_3)
+
         call mn_meta_recalc( delta_i_c, delta_j_c, x_refine, y_refine, tile_geo, parent_geo, fp_super_tile_geo, &
-            is_fine_pe, global_nest_domain, position, p_grid, n_grid, wt_h, istart_coarse, jstart_coarse)
+            is_fine_pe, global_nest_domain, position, p_grid, n_grid, wt_h, istart_coarse, jstart_coarse, Atm(child_grid_num)%neststruct%ind_h)
 
         call mn_meta_recalc( delta_i_c, delta_j_c, x_refine, y_refine, tile_geo_u, parent_geo, fp_super_tile_geo, &
-            is_fine_pe, global_nest_domain, position_u, p_grid_u, n_grid_u, wt_u, istart_coarse, jstart_coarse)
+            is_fine_pe, global_nest_domain, position_u, p_grid_u, n_grid_u, wt_u, istart_coarse, jstart_coarse, Atm(child_grid_num)%neststruct%ind_u)
 
         call mn_meta_recalc( delta_i_c, delta_j_c, x_refine, y_refine, tile_geo_v, parent_geo, fp_super_tile_geo, &
-            is_fine_pe, global_nest_domain, position_v, p_grid_v, n_grid_v, wt_v, istart_coarse, jstart_coarse)
+            is_fine_pe, global_nest_domain, position_v, p_grid_v, n_grid_v, wt_v, istart_coarse, jstart_coarse, Atm(child_grid_num)%neststruct%ind_v)
 
         if (use_timers) call mpp_clock_end (id_movnest5_3)
       endif
@@ -942,10 +950,10 @@ contains
       !! Step 5.3 -- Adjust the indices by the values of delta_i_c, delta_j_c
       !!============================================================================
 
-      call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_h)
-      call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_u)
-      call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_v)
-      call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_b)
+      !call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_h)
+      !call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_u)
+      !call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_v)
+      !call mn_shift_index(delta_i_c, delta_j_c, Atm(child_grid_num)%neststruct%ind_b)
 
       if (debug_sync) call mpp_sync(full_pelist)   ! Used to make debugging easier.  Can be removed.
 

--- a/moving_nest/fv_moving_nest_main.F90
+++ b/moving_nest/fv_moving_nest_main.F90
@@ -682,6 +682,12 @@ contains
 
         allocate(wt_v(Atm(child_grid_num)%bd%isd:Atm(child_grid_num)%bd%ied+1, Atm(child_grid_num)%bd%jsd:Atm(child_grid_num)%bd%jed, 4))
         wt_v = real_snan
+
+	! Fill in the local weights with the ones from Atm just to be safe
+        call fill_weight_grid(wt_h, Atm(n)%neststruct%wt_h)
+        call fill_weight_grid(wt_u, Atm(n)%neststruct%wt_u)
+        call fill_weight_grid(wt_v, Atm(n)%neststruct%wt_v)
+
       else
         allocate(wt_h(1,1,4))
         wt_h = 0.0

--- a/moving_nest/fv_moving_nest_main.F90
+++ b/moving_nest/fv_moving_nest_main.F90
@@ -986,7 +986,6 @@ contains
         ! 0 -- all high-resolution data, 1 - static nest smoothing algorithm, 5 - 5 point smoother, 9 - 9 point smoother
         ! Defaults to 1 - static nest smoothing algorithm; this seems to produce the most stable solutions
 
-        print '("[INFO] WDR fv_moving_nest_main.F90 SMOOTH terrain_smoother=",I0)', Moving_nest(n)%mn_flag%terrain_smoother
         select case(Moving_nest(n)%mn_flag%terrain_smoother)
         case (0)
           ! High-resolution terrain for entire nest

--- a/moving_nest/fv_moving_nest_types.F90
+++ b/moving_nest/fv_moving_nest_types.F90
@@ -46,7 +46,7 @@ module fv_moving_nest_types_mod
     ! Moving Nest Namelist Variables
     logical               :: is_moving_nest = .false.
     character(len=120)    :: surface_dir = "INPUT/moving_nest"
-    integer               :: terrain_smoother = 1
+    integer               :: terrain_smoother = 4
     integer               :: vortex_tracker = 0
     integer               :: ntrack = 1
     integer               :: corral_x = 5
@@ -221,7 +221,7 @@ module fv_moving_nest_types_mod
   ! Moving Nest Namelist Variables
   logical, dimension(MAX_NNEST) :: is_moving_nest = .False.
   character(len=120)            :: surface_dir = "INPUT/moving_nest"
-  integer, dimension(MAX_NNEST) :: terrain_smoother = 1  ! 0 -- all high-resolution data, 1 - static nest smoothing algorithm with blending zone of 5 points, 2 - blending zone of 10 points, 5 - 5 point smoother, 9 - 9 point smoother
+  integer, dimension(MAX_NNEST) :: terrain_smoother = 4  ! 0 -- all high-resolution data, 1 - static nest smoothing algorithm with blending zone of 5 points, 2 - blending zone of 10 points, 5 - 5 point smoother, 9 - 9 point smoother
   integer, dimension(MAX_NNEST) :: vortex_tracker = 0 ! 0 - not a moving nest, tracker not needed
   ! 1 - prescribed nest moving
   ! 2 - following child domain center
@@ -269,6 +269,7 @@ contains
         Moving_nest(n)%mn_flag%is_moving_nest         = is_moving_nest(n)
         Moving_nest(n)%mn_flag%surface_dir            = trim(surface_dir)
         Moving_nest(n)%mn_flag%terrain_smoother       = terrain_smoother(n)
+        print '("[INFO] WDR SMOOTH npe=",I0," terrain_smoother=",I0)', mpp_pe(), Moving_nest(n)%mn_flag%terrain_smoother
         Moving_nest(n)%mn_flag%vortex_tracker         = vortex_tracker(n)
         Moving_nest(n)%mn_flag%ntrack                 = ntrack(n)
         Moving_nest(n)%mn_flag%move_cd_x              = move_cd_x(n)

--- a/moving_nest/fv_moving_nest_types.F90
+++ b/moving_nest/fv_moving_nest_types.F90
@@ -269,7 +269,6 @@ contains
         Moving_nest(n)%mn_flag%is_moving_nest         = is_moving_nest(n)
         Moving_nest(n)%mn_flag%surface_dir            = trim(surface_dir)
         Moving_nest(n)%mn_flag%terrain_smoother       = terrain_smoother(n)
-        print '("[INFO] WDR SMOOTH npe=",I0," terrain_smoother=",I0)', mpp_pe(), Moving_nest(n)%mn_flag%terrain_smoother
         Moving_nest(n)%mn_flag%vortex_tracker         = vortex_tracker(n)
         Moving_nest(n)%mn_flag%ntrack                 = ntrack(n)
         Moving_nest(n)%mn_flag%move_cd_x              = move_cd_x(n)

--- a/moving_nest/fv_moving_nest_utils.F90
+++ b/moving_nest/fv_moving_nest_utils.F90
@@ -930,7 +930,7 @@ contains
     character(*), intent(in)              :: nc_filename
     integer, intent(in)                   :: nxp, nyp, refine
     integer, allocatable, intent(in)      :: pelist(:)
-    type(grid_geometry), intent(out)      :: fp_tile_geo
+    type(grid_geometry), intent(inout)    :: fp_tile_geo
     integer, intent(out)                  :: fp_istart_fine, fp_iend_fine, fp_jstart_fine, fp_jend_fine
 
     !========================================================================================


### PR DESCRIPTION
## Description

- Update submodule UPP to its latest develop branch, which is needed by HAFSv1.
- Add the terrain_smoother namelist option of 4, with which the moving nest leading edge will use the topography interpolated from its parent coarse grid. Enabled and implemented by @wramstrom to fix the artificial gravity wave issues and model failures caused by the moving nest edge crossing steep topography.
- Bug fix in calculation of moving-nest halo weights identified by @BijuThomas-NOAA in DDEBUG=ON builds (from @wramstrom).

### Issue(s) addressed
- fixes ufs-community/ufs-weather-model/issues/1543
- fixes NOAA-EMC/fv3atm/issues/615

## Testing
Regression tests conducted at the ufs-weather-model level.

## Dependencies
- related to ufs-community/ufs-weather-model/pull/1544
