### PR TITLE
Allow HAFS app to be compiled with 64bit FMS

### DIFF
--- a/moving_nest/fv_moving_nest.F90
+++ b/moving_nest/fv_moving_nest.F90
@@ -72,7 +72,11 @@ module fv_moving_nest_mod
 
   use boundary_mod,           only: update_coarse_grid, update_coarse_grid_mpp
   use bounding_box_mod,       only: bbox, bbox_get_C2F_index, fill_bbox
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,        only: cp_air, omega, rdgas, grav, rvgas, kappa, pstd_mks, hlv
+#else
   use constants_mod,          only: cp_air, omega, rdgas, grav, rvgas, kappa, pstd_mks, hlv
+#endif
   use field_manager_mod,      only: MODEL_ATMOS
   use fv_arrays_mod,          only: fv_atmos_type, fv_nest_type, fv_grid_type, R_GRID
   use fv_arrays_mod,          only: allocate_fv_nest_bc_type, deallocate_fv_nest_bc_type

--- a/moving_nest/fv_moving_nest_main.F90
+++ b/moving_nest/fv_moving_nest_main.F90
@@ -33,7 +33,11 @@ module fv_moving_nest_main_mod
   ! FMS modules:
   !-----------------
   use block_control_mod,      only: block_control_type
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,        only: cp_air, rdgas, grav, rvgas, kappa, pstd_mks
+#else
   use constants_mod,          only: cp_air, rdgas, grav, rvgas, kappa, pstd_mks
+#endif
   use time_manager_mod,       only: time_type, get_time, get_date, set_time, operator(+), &
       operator(-), operator(/), time_type_to_real
   use fms_mod,                only: file_exist, open_namelist_file,    &

--- a/moving_nest/fv_moving_nest_physics.F90
+++ b/moving_nest/fv_moving_nest_physics.F90
@@ -68,7 +68,11 @@ module fv_moving_nest_physics_mod
   use GFS_init,               only: GFS_grid_populate
 
   use boundary_mod,           only: update_coarse_grid, update_coarse_grid_mpp
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,        only: cp_air, rdgas, grav, rvgas, kappa, pstd_mks, hlv
+#else
   use constants_mod,          only: cp_air, rdgas, grav, rvgas, kappa, pstd_mks, hlv
+#endif
   use field_manager_mod,      only: MODEL_ATMOS
   use fv_arrays_mod,          only: fv_atmos_type, fv_nest_type, fv_grid_type, R_GRID
   use fv_moving_nest_types_mod,   only: fv_moving_nest_prog_type, fv_moving_nest_physics_type, mn_surface_grids, fv_moving_nest_type

--- a/moving_nest/fv_moving_nest_utils.F90
+++ b/moving_nest/fv_moving_nest_utils.F90
@@ -67,7 +67,11 @@ module fv_moving_nest_utils_mod
   use IPD_typedefs,      only: kind_phys => IPD_kind_phys
 #endif
 
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,   only: grav
+#else
   use constants_mod,     only: grav
+#endif
 
   use boundary_mod,      only: update_coarse_grid, update_coarse_grid_mpp
   use bounding_box_mod,  only: bbox, bbox_get_C2F_index, fill_bbox

--- a/moving_nest/fv_tracker.F90
+++ b/moving_nest/fv_tracker.F90
@@ -26,7 +26,11 @@ module fv_tracker_mod
 
 #include <fms_platform.h>
 
+#ifdef OVERLOAD_R4
+  use constantsR4_mod,     only: pi=>pi_8, rad_to_deg, deg_to_rad, RVGAS, RDGAS
+#else
   use constants_mod,       only: pi=>pi_8, rad_to_deg, deg_to_rad, RVGAS, RDGAS
+#endif
   use fms_mod,             only: mpp_clock_id, CLOCK_SUBCOMPONENT, clock_flag_default, &
                                  mpp_clock_begin, mpp_clock_end
   use time_manager_mod,    only: time_type, get_time, set_time, operator(+), &


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Conditionally 'use' either r4 or r8 version of FMS constants module depending on which version of FMS is used.

What bug does it fix, or what feature does it add?  
https://github.com/ufs-community/ufs-weather-model/issues/1545

Is a change of answers expected from this PR?  
No.


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes https://github.com/ufs-community/ufs-weather-model/issues/1545



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch
