### PR TITLE
Changed UGWP diagnostic variable declaration intents from 'out' to 'inout'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/mdtoyNOAA/ccpp-physics
-  branch = ufs/dev_drag_suite_intent_mods
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/mdtoyNOAA/ccpp-physics
+  branch = ufs/dev_drag_suite_intent_mods
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This pull request fixes [Issue #37](https://github.com/ufs-community/ccpp-physics/issues/37) of the ufs-community/ccpp-physics repository.  The UGWP diagnostic variables (i.e., dusfc_ms, dvsfc_ms, tdaux2d_ms, datauy2d_ms, etc.) are declared with "intent(out)" and initialized in module unified_ugwp.F90, then they are passed to subroutine "drag_suite_run" (in drag_suite.F90).  In this subroutine, the UGWP diagnostic variables should have been declared with "intent(inout)" instead of "intent(out)".  This PR fixes this.
This PR does not change any results.


### Issue(s) addressed

- Fixes [Issue #37](https://github.com/ufs-community/ccpp-physics/issues/37)


## Testing

How were these changes tested?  Regression testing and ORT testing.
What compilers / HPCs was it tested with?  Intel/Hera
Are the changes covered by regression tests? Yes. (But there are no baseline changes.)  
Have the ufs-weather-model regression test been run? On what platform?  Yes.  Hera/Intel.
- Will the code updates change regression test baseline? No,
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

None.

