### PR TITLE
MYNN-EDMF Updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/joeolson42/ccpp-physics
+  branch = mynn_01March
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1082,7 +1082,7 @@ module GFS_typedefs
     logical              :: do_mynnedmf
     logical              :: do_mynnsfclay
     ! DH* TODO - move this to MYNN namelist section
-    logical              :: bl_mynn_tkebudget  !< flag for activating TKE budget
+    integer              :: tke_budget         !< flag for activating TKE budget
     logical              :: bl_mynn_tkeadvect  !< activate computation of TKE advection (not yet in use for FV3)
     integer              :: bl_mynn_cloudpdf   !< flag to determine which cloud PDF to use
     integer              :: bl_mynn_mixlength  !< flag for different version of mixing length formulation
@@ -3252,7 +3252,7 @@ module GFS_typedefs
     logical              :: do_mynnedmf       = .false.               !< flag for MYNN-EDMF
     logical              :: do_mynnsfclay     = .false.               !< flag for MYNN Surface Layer Scheme
     ! DH* TODO - move to MYNN namelist section
-    logical              :: bl_mynn_tkebudget = .false.
+    integer              :: tke_budget        = 0
     logical              :: bl_mynn_tkeadvect = .false.
     integer              :: bl_mynn_cloudpdf  = 2
     integer              :: bl_mynn_mixlength = 1
@@ -3549,7 +3549,7 @@ module GFS_typedefs
                                bl_mynn_cloudpdf, bl_mynn_edmf, bl_mynn_edmf_mom,            &
                                bl_mynn_edmf_tke, bl_mynn_mixlength, bl_mynn_cloudmix,       &
                                bl_mynn_mixqt, bl_mynn_output, icloud_bl, bl_mynn_tkeadvect, &
-                               bl_mynn_closure, bl_mynn_tkebudget,                          &
+                               bl_mynn_closure, tke_budget,                                 &
                                isftcflx, iz0tlnd, sfclay_compute_flux, sfclay_compute_diag, &
                                ! *DH
                                gwd_opt, do_ugwp_v0, do_ugwp_v0_orog_only,                   &
@@ -4320,7 +4320,7 @@ module GFS_typedefs
     Model%bl_mynn_output    = bl_mynn_output
     Model%bl_mynn_tkeadvect = bl_mynn_tkeadvect
     Model%bl_mynn_closure   = bl_mynn_closure
-    Model%bl_mynn_tkebudget = bl_mynn_tkebudget
+    Model%tke_budget        = tke_budget
     Model%icloud_bl         = icloud_bl
     Model%isftcflx          = isftcflx
     Model%iz0tlnd           = iz0tlnd
@@ -7052,7 +7052,7 @@ module GFS_typedefs
         allocate (Diag%det_thl   (IM,Model%levs))
         allocate (Diag%det_sqv   (IM,Model%levs))
       endif
-      if (Model%bl_mynn_tkebudget) then
+      if (Model%tke_budget .gt. 0) then
         allocate (Diag%dqke      (IM,Model%levs))
         allocate (Diag%qwt       (IM,Model%levs))
         allocate (Diag%qshear    (IM,Model%levs))
@@ -7076,7 +7076,7 @@ module GFS_typedefs
         Diag%det_thl       = clear_val
         Diag%det_sqv       = clear_val
       endif
-      if (Model%bl_mynn_tkebudget) then
+      if (Model%tke_budget .gt. 0) then
         Diag%dqke          = clear_val
         Diag%qwt           = clear_val
         Diag%qshear        = clear_val

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -6198,12 +6198,12 @@
   units = flag
   dimensions = ()
   type = logical
-[bl_mynn_tkebudget]
+[tke_budget]
   standard_name = control_for_tke_budget_output
   long_name = flag for activating TKE budget
   units = flag
   dimensions = ()
-  type = logical
+  type = integer
 [bl_mynn_tkeadvect]
   standard_name = flag_for_tke_advection
   long_name = flag for activating TKE advection

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="FV3_GFS_v17_p8_mynn" version="1">
+  <!-- <init></init> -->
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>GFS_radiation_surface</scheme>
+      <scheme>rad_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw_pre</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>sgscloud_radpost</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_surface_composites_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_surface_composites_inter</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+    </subcycle>
+    <!-- Surface iteration loop -->
+    <subcycle loop="2">
+      <scheme>sfc_diff</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_nst_pre</scheme>
+      <scheme>sfc_nst</scheme>
+      <scheme>sfc_nst_post</scheme>
+      <scheme>noahmpdrv</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
+    </subcycle>
+    <!-- End of surface iteration loop -->
+    <subcycle loop="1">
+      <scheme>GFS_surface_composites_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <!--scheme>GFS_PBL_generic_pre</scheme-->
+      <!--scheme>satmedmfvdifq</scheme-->
+      <!--scheme>GFS_PBL_generic_post</scheme-->
+      <scheme>mynnedmf_wrapper</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>unified_ugwp</scheme>
+      <scheme>unified_ugwp_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>ozphys_2015</scheme>
+      <scheme>h2ophys</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>samfdeepcnv</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <!--scheme>GFS_SCNV_generic_pre</scheme-->
+      <!--scheme>samfshalcnv</scheme-->
+      <!--scheme>GFS_SCNV_generic_post</scheme-->
+      <scheme>GFS_suite_interstitial_4</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>mp_thompson_pre</scheme>
+      </subcycle>
+      <subcycle loop="1">
+        <scheme>mp_thompson</scheme>
+      </subcycle>
+        <subcycle loop="1">
+        <scheme>mp_thompson_post</scheme>
+        <scheme>GFS_MP_generic_post</scheme>
+        <scheme>maximum_hourly_diagnostics</scheme>
+      </subcycle>
+  </group>
+  <group name="stochastics">
+    <subcycle loop="1">
+      <scheme>GFS_stochastics</scheme>
+      <scheme>phys_tend</scheme>
+    </subcycle>
+  </group>
+  <!-- <finalize></finalize> -->
+</suite>


### PR DESCRIPTION
## Description

This commit includes the following:

1. Changes the bl_mynn_tkebudget array to a more generic tke_budget array for use by other TKE-based schemes and changes it from logical to integer. The latter change was forced by universality requirements, where WRF could not handle a logical variable in it's array-package declarations.
2. Add a new SDF for running the MYNN-EDMF with GFSp8.

This PR is connected with a ccpp-physics PR (#43) to the ufs/dev branch

## Testing

These changes have been well tested in SCM. RRFS and some global case studies, almost entirely with the intel compiler on Hera and Jet.
Are the changes covered by regression tests? The TKE budget changes are not yet covered by a regression test, since they are only for use in research and require more 3D output fields. Other (physics) changes are covered by regression tests.
Have the ufs-weather-model regression test been run? Running them on Hera now.
- Will the code updates change regression test baseline? Yes, the changes in ccpp-physics include physics changes for all configurations that use the MYNN-EDMF.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on ufs-community/ccpp-physics/pull/43
