### PR TITLE
add three parameters to input.nml for NSSL MP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/Jili-Dong/community-ccpp-physics
+  branch = rrfs_dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,13 +6,11 @@
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework
   branch = main
-[submodule "ccpp/physics"]
-  path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = ufs/dev
-  url = https://github.com/Jili-Dong/community-ccpp-physics
-  branch = rrfs_dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP
   branch = develop
+[submodule "ccpp/physics"]
+  path = ccpp/physics
+  url = https://github.com/Jili-Dong/community-ccpp-physics.git
+  branch = rrfs_dev

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -884,6 +884,9 @@ module GFS_typedefs
     real(kind=kind_phys) :: nssl_cccn      !<  CCN concentration (m-3)
     real(kind=kind_phys) :: nssl_alphah    !<  graupel shape parameter
     real(kind=kind_phys) :: nssl_alphahl   !<  hail shape parameter
+    real(kind=kind_phys) :: nssl_alphar  ! shape parameter for rain (imurain=1 only)                         
+    real(kind=kind_phys) :: nssl_ehw0_in ! constant or max assumed graupel-droplet collection efficiency   
+    real(kind=kind_phys) :: nssl_ehlw0_in! constant or max assumed hail-droplet collection efficiency   
     logical              :: nssl_hail_on   !<  NSSL flag to activate the hail category
     logical              :: nssl_ccn_on    !<  NSSL flag to activate the CCN category
     logical              :: nssl_invertccn !<  NSSL flag to treat CCN as activated (true) or unactivated (false)
@@ -3100,6 +3103,9 @@ module GFS_typedefs
     real(kind=kind_phys) :: nssl_cccn       = 0.6e9             !<  CCN concentration (m-3)
     real(kind=kind_phys) :: nssl_alphah     = 0.0               !<  graupel shape parameter
     real(kind=kind_phys) :: nssl_alphahl    = 1.0               !<  hail shape parameter
+    real(kind=kind_phys) :: nssl_alphar     = 0.0               ! shape parameter for rain (imurain=1 only)  
+    real(kind=kind_phys) :: nssl_ehw0_in    = 0.9               ! constant or max assumed graupel-droplet collection efficiency  
+    real(kind=kind_phys) :: nssl_ehlw0_in   = 0.9               ! constant or max assumed hail-droplet collection efficiency  
     logical              :: nssl_hail_on    = .false.           !<  NSSL flag to activate the hail category
     logical              :: nssl_ccn_on     = .true.            !<  NSSL flag to activate the CCN category
     logical              :: nssl_invertccn  = .true.            !<  NSSL flag to treat CCN as activated (true) or unactivated (false)
@@ -3525,6 +3531,7 @@ module GFS_typedefs
                                ext_diag_thompson, dt_inner, lgfdlmprad,                     &
                                sedi_semi, decfl,                                            &
                                nssl_cccn, nssl_alphah, nssl_alphahl,                        &
+                               nssl_alphar, nssl_ehw0_in, nssl_ehlw0_in,                    &
                                nssl_invertccn, nssl_hail_on, nssl_ccn_on,                   &
                           !--- max hourly
                                avg_max_length,                                              &
@@ -4059,6 +4066,9 @@ module GFS_typedefs
     Model%nssl_cccn        = nssl_cccn
     Model%nssl_alphah      = nssl_alphah
     Model%nssl_alphahl     = nssl_alphahl
+    Model%nssl_alphar      = nssl_alphar
+    Model%nssl_ehw0_in     = nssl_ehw0_in
+    Model%nssl_ehlw0_in    = nssl_ehlw0_in
     Model%nssl_hail_on     = nssl_hail_on
     Model%nssl_ccn_on      = nssl_ccn_on
     Model%nssl_invertccn   = nssl_invertccn
@@ -5895,6 +5905,9 @@ module GFS_typedefs
         print *, ' nssl_cccn - CCCN background CCN conc. : ', Model%nssl_cccn
         print *, ' nssl_alphah - graupel shape parameter : ', Model%nssl_alphah
         print *, ' nssl_alphahl - hail shape parameter   : ', Model%nssl_alphahl
+        print *, ' nssl_alphar - rain shape parameter : ', Model%nssl_alphar
+        print *, ' nssl_ehw0_in - graupel-droplet collection effiency : ', Model%nssl_ehw0_in 
+        print *, ' nssl_ehlw0_in - hail-droplet collection effiency : ', Model%nssl_ehlw0_in                              
         print *, ' nssl_hail_on - hail activation flag   : ', Model%nssl_hail_on
         print *, ' lradar - radar refl. flag             : ', Model%lradar
         print *, ' lrefres                : ', Model%lrefres

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -3850,6 +3850,27 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[nssl_alphar]
+  standard_name = nssl_alpha_rain
+  long_name = rain PSD shape parameter in NSSL micro
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[nssl_ehw0_in]
+  standard_name = nssl_hw_collec_eff
+  long_name = graupel droplet collection efficiency in NSSL micro
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[nssl_ehlw0_in]
+  standard_name = nssl_hlw_collec_eff
+  long_name = graupel droplet collection efficiency in NSSL micro
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
 [nssl_ccn_on]
   standard_name = nssl_ccn_on
   long_name = CCN activation flag in NSSL micro

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -3935,54 +3935,54 @@
   kind = kind_phys
 [nssl_alphah]
   standard_name = nssl_alpha_graupel
-  long_name = graupel PSD shape parameter in NSSL micro
+  long_name = graupel particle size distribution(PSD) shape parameter in NSSL microphysics scheme
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [nssl_alphahl]
   standard_name = nssl_alpha_hail
-  long_name = hail PSD shape parameter in NSSL micro
+  long_name = hail particle size distribution(PSD) shape parameter in NSSL microphysics scheme
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [nssl_alphar]
   standard_name = nssl_alpha_rain
-  long_name = rain PSD shape parameter in NSSL micro
+  long_name = rain particle size distribution(PSD) shape parameter in NSSL microphysics scheme
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [nssl_ehw0_in]
   standard_name = nssl_graupel_collection_efficiency
-  long_name = graupel droplet collection efficiency in NSSL micro
+  long_name = graupel droplet collection efficiency in NSSL microphysics scheme
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [nssl_ehlw0_in]
   standard_name = nssl_hail_collection_efficiency
-  long_name = hail droplet collection efficiency in NSSL micro
+  long_name = hail droplet collection efficiency in NSSL microphysics scheme
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [nssl_ccn_on]
   standard_name = nssl_ccn_on
-  long_name = CCN activation flag in NSSL micro
+  long_name = CCN activation flag in NSSL microphysics scheme
   units = flag
   dimensions = ()
   type = logical
 [nssl_hail_on]
   standard_name = nssl_hail_on
-  long_name = hail activation flag in NSSL micro
+  long_name = hail activation flag in NSSL microphysics scheme
   units = flag
   dimensions = ()
   type = logical
 [nssl_invertccn]
   standard_name = nssl_invertccn
-  long_name = flag to invert CCN in NSSL micro
+  long_name = flag to invert CCN in NSSL microphysics scheme
   units = flag
   dimensions = ()
   type = logical

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -3955,15 +3955,15 @@
   type = real
   kind = kind_phys
 [nssl_ehw0_in]
-  standard_name = nssl_hw_collec_eff
+  standard_name = nssl_graupel_collection_efficiency
   long_name = graupel droplet collection efficiency in NSSL micro
   units = none
   dimensions = ()
   type = real
   kind = kind_phys
 [nssl_ehlw0_in]
-  standard_name = nssl_hlw_collec_eff
-  long_name = graupel droplet collection efficiency in NSSL micro
+  standard_name = nssl_hail_collection_efficiency
+  long_name = hail droplet collection efficiency in NSSL micro
   units = none
   dimensions = ()
   type = real


### PR DESCRIPTION
To support RRFS multiphysics ensemble, three parameters in NSSL MP are being added to input.nml, including rain shape parameter (nssl_alphar), graupel-droplet collection efficiency (nssl_ehw0_in) and hail-droplet collection efficiency (nssl_ehlw0_in)

This PR is not expected to change RT results.

related to ccpp/physics PR
https://github.com/ufs-community/ccpp-physics/pull/45

 and issue
https://github.com/NOAA-EMC/fv3atm/issues/631




