### PR TITLE
fix diag time at GEFS restart and clean up output_1st_tstep_rst

### DIFF
--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -30,8 +30,7 @@ module fv3gfs_cap_mod
   use module_fv3_config,      only: quilting, quilting_restart, output_fh,   &
                                     nfhout, nfhout_hf, nsout, dt_atmos,      &
                                     calendar, cpl_grid_id,                   &
-                                    cplprint_flag,output_1st_tstep_rst,      &
-                                    first_kdt
+                                    cplprint_flag, first_kdt
 
   use module_fv3_io_def,      only: num_pes_fcst,write_groups,               &
                                     num_files, filename_base,                &
@@ -284,10 +283,6 @@ module fv3gfs_cap_mod
 
     if (.not.quilting) quilting_restart = .false.
 
-    call ESMF_ConfigGetAttribute(config=CF,value=output_1st_tstep_rst, &
-                                 default=.false., label ='output_1st_tstep_rst:',rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
     call ESMF_ConfigGetAttribute(config=CF,value=iau_offset,default=0,label ='iau_offset:',rc=rc)
     if (iau_offset < 0) iau_offset=0
 
@@ -350,11 +345,6 @@ module fv3gfs_cap_mod
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
     first_kdt = 1
-    if( output_1st_tstep_rst) then
-      rsthour   = currTime - StartTime
-      first_kdt = nint(rsthour/timeStep) + 1
-    endif
-
 !
 !#######################################################################
 ! set up fcst grid component

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -2295,7 +2295,7 @@
 !** write out log file
 !
     if (mype == lead_write_task) then
-      open(newunit=nolog,file='logf'//trim(cfhour),form='FORMATTED')
+      open(newunit=nolog,file='atm.logf'//trim(cfhour),form='FORMATTED')
         write(nolog,100)nfhour,idate(1:6)
 100     format(' completed fv3gfs fhour=',f10.3,2x,6(i4,2x))
       close(nolog)

--- a/module_fv3_config.F90
+++ b/module_fv3_config.F90
@@ -19,7 +19,7 @@
 !
   integer                  :: cpl_grid_id
   logical                  :: cplprint_flag
-  logical                  :: quilting, quilting_restart, output_1st_tstep_rst
+  logical                  :: quilting, quilting_restart
 !
   real,dimension(:),allocatable                   :: output_fh
   character(esmf_maxstr),dimension(:),allocatable :: filename_base


### PR DESCRIPTION
## Description

This PR is to fix issue [#1420](https://github.com/ufs-community/ufs-weather-model/issues/1420), where the GEFS reforecast needs to start the model in the middle of fhzero (fhzero=6, but model starts at fh=3), the model bucket time needs to be set to the beginning of the model start time. Also since model now is using the flexible output_fh to control history file output time, the option for the special case to output the history files after the first restart time is removed.   


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes [#1420](https://github.com/ufs-community/ufs-weather-model/issues/1420)


## Testing

How were these changes tested?  Hera
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

