### PR TITLE
range_check_3d optimization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  url = https://github.com/dkokron/GFDL_atmos_cubed_sphere
+  branch = hafs-rangeCheck3d
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/dkokron/GFDL_atmos_cubed_sphere
-  branch = hafs-rangeCheck3d
+  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description
Performance profiling of a HAFS case on NOAA systems revealed significant of time was spent in subroutine range_check_3d().  This commit effectively reverts a commit from Oct 2021 (see below).  This commit also changes the code to use the minval() and maxval() fortran intrinsics.

commit 2c8363e057dde026e65ddcec1b62c18d5e260017
Author: Xiaqiong Zhou <Xiaqiong.Zhou@noaa.gov>
Date:   Thu Oct 21 17:51:10 2021 +0000
    Revise back the range definition form. The compiling issue on DELL can be fixed by using -O0 instead of -O2 to compile fv_diagnostics.F90

I requested more details from Xiaqiong Zhou and got the following responses.

> It is a very strange error when compiling fv_diagostics.F90 on DELL (OK on HERA, Orion et al).
> vsrange = (/ -200., 200. /) was not accepted but it is OK to use
> vsrange(1) = -200. ; vsrange(2) = 200.
> In order to keep the original form as vsrange = (/ -200., 200. /), -O0 instead of -O2 to compile fv_diagnostics.F90 in dynamics.
> 
> DELL was retired. It should be an Intel compiler but I do not remember the version.

I don't see any compile time issues using ifort-19.1.3.304 at -O2 on the WCOSS2 systems.

**How Has This Been Tested?**
The modifications have been tested on WCOSS2 systems Acorn and Dogwood using a HAFS case as well as on Cactus and Dogwood by running the UFS (develop branch cloned on 17 April) regression suite.

Scenarios:
1. Unmodified code and compiler flags (Baseline)
2. Delete the line in FV3/atmos_cubed_sphere/CMakeLists.txt that adds "-O0" to the compile flags.  Thus, this file gets compiled with the global defaults
3. Replace the nested loop calculation in range_check_3d() (not in range_check_2d) with calls to the minval() and maxval() intrinsic functions.
4. Same as scenario three with the addition of minval and maxval intrinsics in range_check_2d.

HAFS case regional simulation with one nest
The case was run on 26 nodes of the Acorn system for a 126 hour simulation.
```
Parent grid:
  layout = 24,20
  npx = 1321
  npy = 1201
  ntiles = 1
  npz = 81

Nest grid:
  layout = 20,12
  npx = 601
  npy = 601
  ntiles = 1
  npz = 81

The 26 nodes are allocated as follows.
ATM_petlist_bounds: 000 735
OCN_petlist_bounds: 736 855
MED_petlist_bounds: 736 855
```

---
Performance metric:
Add up the phase1 and phase2 timings printed in the output listing
grep PASS stdout | awk '{t+=$10;print t}' | tail -1
The units are seconds.
|   Scenario  |   Trial1    |    Trial2   |
| -------------- | ------------ | ----------- |
| 1 | 7881  |   7866.69 |
| 2 | 7206.2   |    7200.81 |
| 3 | 7179.37 | Not run |
| 4 | 7180.67   |  7163.4 |

Validation:
Using scenario four, the UFS regression suite revealed numerous diagnostic variables changed numerically.  A review of all files declared as "NOT OK" by the pass/fail comparison revealed that all of those variables are calculated using routines found in fv_diagnostics.F90 (see attached file variables.txt)
[variables.txt](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/files/11297839/variables.txt)

Some of these variables show up in files that are part of the UFS regression suite pass/fail comparisons so a new baseline will be needed. 

Comparison between stdout from scenario1 and scenario4 revealed certain variables related to tropical cyclone (TC) tracking changed at the 7th significant digit.  A code review revealed that those variables are also calculated using routines from fv_diagnostics.F90

E.g. from time step 6299
 u700 g2 max =    14.35157      min =   -9.42382**7**        |	 u700 g2 max =    14.35157      min =   -9.42382**8**    
 u850 g2 max =    7.198**199**      min =   -18.35876        |	 u850 g2 max =    7.198**200**      min =   -18.35876    
 v700 g2 max =    8.67357**2**      min =   -15.10008        |	 v700 g2 max =    8.67357**1**      min =   -15.10008

Comparing output from the TC tracker printed to stdout revealed no differences between scenario1 and scenario4.

E.g. the last output from a 126 hour simulation.
==> Baseline_5Day_736p/tracker.txt <==
 tracker fixlon= 350.647 fixlat=  30.150 ifix=   302 jfix=   302 pmin=  100795.047 vmax=  16.500 rmw= 119.294

==> RANGECHECKnD-GlobalminvalmaxvalOnly_736p/tracker.txt <==
 tracker fixlon= 350.647 fixlat=  30.150 ifix=   302 jfix=   302 pmin=  100795.047 vmax=  16.500 rmw= 119.294

### Issue(s) addressed
This PR does not fix any open issues


## Testing

How were these changes tested?  HAFS case and UFS regression suite
What compilers / HPCs was it tested with?  ifort-19.1.3.304
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  No tests need to be added
Have the ufs-weather-model regression test been run? On what platform?  Yes. Dogwood and Cactus.
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch Done. tests/RegressionTests_wcoss2.intel.log
The baseline directory for these test was dogwood:/lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230418/INTEL

## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first? No
If so add the "waiting for other repos" label and list the upstream PRs
