### PR TITLE
Use inline post with cubed sphere history output

### DIFF
--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -209,7 +209,7 @@ module fv3atm_cap_mod
     integer                                :: wrttasks_per_group_from_parent, wrtLocalPet, num_threads
     character(len=64)                      :: rh_filename
     logical                                :: use_saved_routehandles, rh_file_exist
-    logical                                :: fieldbundle_is_restart = .false.
+    logical                                :: fieldbundle_uses_redist = .false.
 
     integer                                :: sloc
     type(ESMF_StaggerLoc)                  :: staggerloc
@@ -698,11 +698,12 @@ module fv3atm_cap_mod
             if(mype == 0) print *,'af get wrtfb=',"output_"//trim(fcstItemNameList(j)),' rc=',rc
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-            fieldbundle_is_restart = .false.
+            fieldbundle_uses_redist = .false.
+            ! if (fcstItemNameList(j)(1:8) == "restart_" .or. fcstItemNameList(j)(1:18) == "cubed_sphere_grid_") then
             if (fcstItemNameList(j)(1:8) == "restart_") then
               ! restart output forecast bundles, no need to set regridmethod
               ! Redist will be used instead of Regrid
-              fieldbundle_is_restart = .true.
+              fieldbundle_uses_redist = .true.
             else
               ! history output forecast bundles
               ! determine regridmethod
@@ -739,7 +740,7 @@ module fv3atm_cap_mod
                 if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
               else
                 ! this is a Store() for the first wrtComp -> must do the Store()
-                if (fieldbundle_is_restart) then
+                if (fieldbundle_uses_redist) then
                   call ESMF_TraceRegionEnter("ESMF_FieldBundleRedistStore()", rc=rc)
                   call ESMF_FieldBundleRedistStore(fcstFB(j), wrtFB(j,1), &
                                                    routehandle=routehandle(j,1), &

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -163,6 +163,8 @@
       type(ESMF_DELayout)                     :: delayout
       type(ESMF_Grid)                         :: fcstGrid
       type(ESMF_Grid), allocatable            :: wrtGrid(:)
+      type(ESMF_Grid)                         :: wrtGrid_cubed_sphere
+      logical                                 :: create_wrtGrid_cubed_sphere = .true.
       type(ESMF_Grid)                         :: actualWrtGrid
       type(ESMF_Array)                        :: array
       type(ESMF_Field)                        :: field_work, field
@@ -208,6 +210,9 @@
 
       type(ESMF_DistGrid)                     :: acceptorDG, newAcceptorDG
       integer                                 :: grid_id
+
+      logical                    :: top_parent_history_file_is_on_cubed_sphere_grid
+      character(len=esmf_maxstr) :: output_grid_name
 !
 !-----------------------------------------------------------------------
 !***********************************************************************
@@ -480,10 +485,35 @@
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
         endif
 
+    call ESMF_ConfigGetAttribute(config=CF, value=top_parent_history_file_is_on_cubed_sphere_grid, default=.false., &
+                                 label='top_parent_history_file_is_on_cubed_sphere_grid:', rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+#if 1
+        if (n == 1 .and. top_parent_is_global .and. top_parent_history_file_is_on_cubed_sphere_grid) then
+          do tl=1,6
+            decomptile(1,tl) = 1
+            decomptile(2,tl) = jidx
+            decompflagPTile(:,tl) = (/ESMF_DECOMP_SYMMEDGEMAX,ESMF_DECOMP_SYMMEDGEMAX/)
+          enddo
+          call ESMF_AttributeGet(imp_state_write, convention="NetCDF", purpose="FV3", &
+                                 name="gridfile", value=gridfile, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+          wrtGrid_cubed_sphere = ESMF_GridCreateMosaic(filename="INPUT/"//trim(gridfile),                                 &
+                                                       regDecompPTile=decomptile,tileFilePath="INPUT/",                   &
+                                                       decompflagPTile=decompflagPTile,                                   &
+                                                       staggerlocList=(/ESMF_STAGGERLOC_CENTER, ESMF_STAGGERLOC_CORNER/), &
+                                                       name='wrt_grid', rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+          create_wrtGrid_cubed_sphere = .false.
+        endif
+#endif
+
         if ( trim(output_grid(n)) == 'cubed_sphere_grid' ) then
           !*** Create cubed sphere grid from file
-          if (top_parent_is_global .and. n==1) then
-            gridfile = 'grid_spec.nc'   ! global top-level parent
+          if (top_parent_is_global .and. n == 1) then
             do tl=1,6
               decomptile(1,tl) = 1
               decomptile(2,tl) = jidx
@@ -493,7 +523,6 @@
                                    name="gridfile", value=gridfile, rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-            call ESMF_LogWrite("wrtComp: gridfile:"//trim(gridfile),ESMF_LOGMSG_INFO,rc=rc)
             wrtGrid(n) = ESMF_GridCreateMosaic(filename="INPUT/"//trim(gridfile),                              &
                                             regDecompPTile=decomptile,tileFilePath="INPUT/",                   &
                                             decompflagPTile=decompflagPTile,                                   &
@@ -528,8 +557,6 @@
                                       rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-            if (lprnt) print *,'in nested/regional cubed_sphere grid, regDecomp=',regDecomp,' PetMap=',petMap(1),petMap(ntasks), &
-              'gridfile=',trim(gridfile)
             deallocate(petMap)
           endif
         else  ! non 'cubed_sphere_grid'
@@ -869,13 +896,13 @@
             call ESMF_StateAdd(imp_state_write, (/mirrorFB/), rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-! copy the fcstFB Attributes to the 'mirror_' FieldBundle
+            ! copy the fcstFB Attributes to the 'mirror_' FieldBundle
             call ESMF_AttributeCopy(fcstFB, mirrorFB, attcopy=ESMF_ATTCOPY_REFERENCE, rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
           endif
 
-! deal with all of the Fields inside this fcstFB
+          ! deal with all of the Fields inside this fcstFB
           call ESMF_FieldBundleGet(fcstFB, fieldCount=fieldCount, grid=fcstGrid, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
@@ -886,12 +913,31 @@
                                      itemorderflag=ESMF_ITEMORDER_ADDORDER, rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-            actualWrtGrid = wrtGrid(grid_id)
+            if (fcstItemNameList(i)(1:18) == 'cubed_sphere_grid_') then
 
-            ! If this is a 'restart' bundle the actual grid that the output field ('field_work' below) is created on
-            ! must be the same grid as forecast grid, not the output grid for this grid_id (wrtGrid(grid_id)).
-            ! For 'cubed_sphere_grid' these are the same, but for all other output grids (like Lambert) they are not.
-            if (fcstItemNameList(i)(1:8) == 'restart_') then
+              if (create_wrtGrid_cubed_sphere) then
+                ! create a grid from fcstGrid on forecast grid comp, by rebalancing distgrid to the local PETs
+                ! access the acceptor DistGrid
+                call ESMF_GridGet(fcstGrid, distgrid=acceptorDG, rc=rc)
+                if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+                ! rebalance the acceptor DistGrid across the local PETs
+                newAcceptorDG = ESMF_DistGridCreate(acceptorDG, balanceflag=.true., rc=rc)
+                if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+                wrtGrid_cubed_sphere = ESMF_GridCreate(fcstGrid, newAcceptorDG, copyAttributes=.true., rc=rc)
+                if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+                create_wrtGrid_cubed_sphere = .false.
+              end if
+
+              actualWrtGrid = wrtGrid_cubed_sphere
+              call ESMF_AttributeSet(fieldbundle, convention="NetCDF", purpose="FV3-nooutput", name="output_grid", value="cubed_sphere_grid", rc=rc)
+              if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+            else if (fcstItemNameList(i)(1:8) == 'restart_') then
+              ! If this is a 'restart' bundle the actual grid that the output field ('field_work' below) is created on
+              ! must be the same grid as forecast grid, not the output grid for this grid_id (wrtGrid(grid_id)).
+              ! For 'cubed_sphere_grid' these are the same, but for all other output grids (like Lambert) they are not.
+
               ! create a grid from fcstGrid on forecast grid comp, by rebalancing distgrid to the local PETs
               ! access the acceptor DistGrid
               call ESMF_GridGet(fcstGrid, distgrid=acceptorDG, rc=rc)
@@ -901,7 +947,11 @@
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
               actualWrtGrid = ESMF_GridCreate(fcstGrid, newAcceptorDG, rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-            end if ! end of setting actualWrtGrid for restart bundle
+            else
+              actualWrtGrid = wrtGrid(grid_id)
+              call ESMF_AttributeSet(fieldbundle, convention="NetCDF", purpose="FV3-nooutput", name="output_grid", value=output_grid(grid_id), rc=rc)
+              if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+            end if
 
             do j=1, fieldCount
 
@@ -925,7 +975,7 @@
 !                        'gridToFieldMap=',gridToFieldMap,'ungriddedLBound=',ungriddedLBound,         &
 !                        'ungriddedUBound=',ungriddedUBound,'rc=',rc
 
-! create the output field on output grid
+              ! create the output field on output grid
               field_work = ESMF_FieldCreate(actualWrtGrid, typekind, name=fieldName, & ! use actualWrtGrid instead of wrtGrid(grid_id)
                                             staggerloc=staggerloc,             &
                                             gridToFieldMap=gridToFieldMap,     &
@@ -936,7 +986,7 @@
               call ESMF_AttributeCopy(fcstField(j), field_work, attcopy=ESMF_ATTCOPY_REFERENCE, rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-! get output file name
+              ! get output file name
               call ESMF_AttributeGet(fcstField(j), convention="NetCDF", purpose="FV3", &
                                      name="output_file", value=outfile_name, rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
@@ -947,13 +997,13 @@
               endif
               call ESMF_LogWrite("af fcstfield, get output_file",ESMF_LOGMSG_INFO,rc=RC)
 
-!             if (lprnt) print *,' i=',i,' j=',j,' outfilename=',trim(outfilename(j,i))
+              ! if (lprnt) print *,' i=',i,' j=',j,' outfilename=',trim(outfilename(j,i))
 
-! add the output field to the 'output_' FieldBundle
+              ! add the output field to the 'output_' FieldBundle
               call ESMF_FieldBundleAdd(fieldbundle, (/field_work/), rc=rc)
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-! deal with grids for which 'is_moving' is .true.
+              ! deal with grids for which 'is_moving' is .true.
               if (is_moving(grid_id)) then
                 ! create an empty field that will serve as acceptor for GridTransfer of fcstGrid
                 field_work = ESMF_FieldEmptyCreate(name=fieldName, rc=rc)
@@ -981,11 +1031,10 @@
 
               endif
 
-! local garbage collection
+              ! local garbage collection
               deallocate(gridToFieldMap, ungriddedLBound, ungriddedUBound)
             enddo
-!
-            ! call ESMF_AttributeCopy(fcstGrid, wrtGrid(grid_id), &
+
             call ESMF_AttributeCopy(fcstGrid, actualWrtGrid   , &
                                     attcopy=ESMF_ATTCOPY_REFERENCE, rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
@@ -1000,15 +1049,13 @@
           return
         endif
 
-!end FBCount
-      enddo
-!
-!loop over all items in the imp_state_write and count output FieldBundles
+      enddo !FBCount
+
+      !loop over all items in the imp_state_write and count output FieldBundles
       call get_outfile(FBCount, outfilename, FBlist_outfilename, noutfile)
       wrt_int_state%FBCount = noutfile
 
-!
-!create output field bundles
+      !create output field bundles
       allocate(wrt_int_state%wrtFB(wrt_int_state%FBCount))
       ! if (lprnt) write(0,*)'wrt_initialize_p1: allocated ',wrt_int_state%FBCount, ' wrt_int_state%wrtFB'
 
@@ -1016,7 +1063,7 @@
 
         wrt_int_state%wrtFB(i) = ESMF_FieldBundleCreate(name=trim(FBlist_outfilename(i)), rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-        ! if (lprnt) write(0,*)'wrt_initialize_p1: created wrtFB ',i, ' with name ', trim(wrt_int_state%wrtFB_names(i))
+        ! if (lprnt) write(0,*)'wrt_initialize_p1: created wrtFB ',i, ' with name ', trim(FBlist_outfilename(i))
 
         ! if (lprnt) write(0,*)'wrt_initialize_p1: loop over ', FBCount, ' forecast bundles'
         do n=1, FBCount
@@ -1029,9 +1076,9 @@
           ! if (lprnt) write(0,*)'wrt_initialize_p1: is ', trim(fcstItemNameList(n)), ' == ', trim(FBlist_outfilename(i))
 
           if (trim_regridmethod_suffix(fcstItemNameList(n)) == trim_regridmethod_suffix(FBlist_outfilename(i))) then
-!
-! copy the fcstfield bundle Attributes to the output field bundle
-            ! if (lprnt) write(0,*)'wrt_initialize_p1: copy atts/fields from ', "output_"//trim(fcstItemNameList(n)), ' to ', trim(wrt_int_state%wrtFB_names(i))
+
+            ! copy the fcstfield bundle Attributes to the output field bundle
+            ! if (lprnt) write(0,*)'wrt_initialize_p1: copy atts/fields from ', "output_"//trim(fcstItemNameList(n)), ' to ', trim(FBlist_outfilename(i))
             call ESMF_AttributeCopy(fcstFB,  wrt_int_state%wrtFB(i), &
                                     attcopy=ESMF_ATTCOPY_REFERENCE, rc=rc)
 
@@ -1059,10 +1106,6 @@
 
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-!             if (lprnt) print *,'in wrt,add field,i=',i,'n=',n,' j=',j, &
-!                        'fieldname=',trim(fieldnamelist(j)), ' outfile_name=',trim(outfile_name), &
-!                       ' field bundle name, FBlist_outfilename(i)=',trim(FBlist_outfilename(i))
-
               if( trim(outfile_name) == trim(FBlist_outfilename(i))) then
                 call ESMF_FieldBundleAdd(wrt_int_state%wrtFB(i), (/fcstField(j)/), rc=rc)
 
@@ -1074,21 +1117,26 @@
 
           endif ! index(trim(fcstItemNameList(n)),trim(FBlist_outfilename(i)))
 
-        enddo ! end FBCount
+        enddo ! FBCount
 
-! add output grid related attributes
+        ! add output grid related attributes, only for history files(bundles), skip restart
+        if (FBlist_outfilename(i)(1:8) /= 'restart_') then
+
+            call ESMF_AttributeGet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3-nooutput", &
+                                   name="output_grid", value=output_grid_name, rc=rc)
+            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
             call ESMF_AttributeAdd(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                    attrList=(/"source","grid  "/), rc=rc)
             call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                    name="source", value="FV3GFS", rc=rc)
 
-            if (trim(output_grid(grid_id)) == 'cubed_sphere_grid') then
+            if (trim(output_grid_name) == 'cubed_sphere_grid') then
 
               call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                      name="grid", value="cubed_sphere", rc=rc)
 
-            else if (trim(output_grid(grid_id)) == 'gaussian_grid') then
+            else if (trim(output_grid_name) == 'gaussian_grid') then
 
               call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                      name="grid", value="gaussian", rc=rc)
@@ -1099,9 +1147,9 @@
               call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                      name="jm", value=jmo(grid_id), rc=rc)
 
-            else if (trim(output_grid(grid_id)) == 'regional_latlon'        &
-                .or. trim(output_grid(grid_id)) == 'regional_latlon_moving' &
-                .or. trim(output_grid(grid_id)) == 'global_latlon') then
+            else if (trim(output_grid_name) == 'regional_latlon'        &
+                .or. trim(output_grid_name) == 'regional_latlon_moving' &
+                .or. trim(output_grid_name) == 'global_latlon') then
 
               ! for 'regional_latlon_moving' lon1/2 and lat1/2 will be overwritten in run phase
               call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
@@ -1112,7 +1160,7 @@
                                      name="dlon", value=dlon(grid_id), rc=rc)
               call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                      name="dlat", value=dlat(grid_id), rc=rc)
-              if (trim(output_grid(grid_id)) /= 'regional_latlon_moving') then
+              if (trim(output_grid_name) /= 'regional_latlon_moving') then
                 call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                        name="lon1", value=lon1(grid_id), rc=rc)
                 call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
@@ -1122,8 +1170,8 @@
                 call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                        name="lat2", value=lat2(grid_id), rc=rc)
               endif
-            else if (trim(output_grid(grid_id)) == 'rotated_latlon' &
-                .or. trim(output_grid(grid_id)) == 'rotated_latlon_moving') then
+            else if (trim(output_grid_name) == 'rotated_latlon' &
+                .or. trim(output_grid_name) == 'rotated_latlon_moving') then
 
               call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                      name="grid", value="rotated_latlon", rc=rc)
@@ -1145,7 +1193,7 @@
                                      name="dlon", value=dlon(grid_id), rc=rc)
               call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                      name="dlat", value=dlat(grid_id), rc=rc)
-              if (trim(output_grid(grid_id)) /= 'rotated_latlon_moving') then
+              if (trim(output_grid_name) /= 'rotated_latlon_moving') then
                 call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                        name="lon1", value=lon1(grid_id), rc=rc)
                 call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
@@ -1155,7 +1203,7 @@
                 call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                      name="lat2", value=lat2(grid_id), rc=rc)
               endif
-            else if (trim(output_grid(grid_id)) == 'lambert_conformal') then
+            else if (trim(output_grid_name) == 'lambert_conformal') then
 
               call ESMF_AttributeSet(wrt_int_state%wrtFB(i), convention="NetCDF", purpose="FV3", &
                                      name="grid", value="lambert_conformal", rc=rc)
@@ -1192,6 +1240,7 @@
                                      name="dy", value=dy(grid_id), rc=rc)
 
             end if
+        end if
 
       enddo ! end wrt_int_state%FBCount
 !
@@ -1235,13 +1284,18 @@
         endif
       enddo
 
-
     do n = 1, ngrids
-! add the transfer attributes from importState to grid
+    ! add the transfer attributes from importState to grid
     call ESMF_AttributeAdd(wrtGrid(n), convention="NetCDF", purpose="FV3", &
                            attrList=attNameList(1:j-1), rc=rc)
-
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+    ! add the transfer attributes from importState to special cubed_sphere grid
+    if (n == 1 .and. top_parent_is_global .and. top_parent_history_file_is_on_cubed_sphere_grid) then
+      call ESMF_AttributeAdd(wrtGrid_cubed_sphere, convention="NetCDF", purpose="FV3", &
+                             attrList=attNameList(1:j-1), rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+    endif
 
 ! loop over the added attributes, access the value (only scalar allowed),
 ! and set them on the grid
@@ -1266,8 +1320,13 @@
         endif
         call ESMF_AttributeSet(wrtGrid(n), convention="NetCDF", purpose="FV3", &
                                name=trim(attNameList(i)), value=valueS, rc=rc)
-
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+        if (n == 1 .and. top_parent_is_global .and. top_parent_history_file_is_on_cubed_sphere_grid) then
+          call ESMF_AttributeSet(wrtGrid_cubed_sphere, convention="NetCDF", purpose="FV3", &
+                                 name=trim(attNameList(i)), value=valueS, rc=rc)
+          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+        endif
 
       else if (typekindList(i) == ESMF_TYPEKIND_I4) then
         call ESMF_AttributeGet(imp_state_write,                    &
@@ -1804,6 +1863,7 @@
                              fieldbundle=mirror_bundle, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
+          ! if (fcstItemNameList(i)(1:8) == "restart_" .or. fcstItemNameList(i)(1:18) == 'cubed_sphere_grid_') then
           if (fcstItemNameList(i)(1:8) == "restart_") then
             ! restart output forecast bundles, use Redist instead of Regrid
 
@@ -2004,6 +2064,7 @@
                   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__,file=__FILE__)) return
 
                   if (wrtFBName(1:8) == 'restart_') cycle
+                  if (wrtFBName(1:18) == 'cubed_sphere_grid_') cycle
 
                   call mask_fields(wrt_int_state%wrtFB(nbdl),rc)
                   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
@@ -3290,7 +3351,7 @@
                        trim(tileFileName), ESMF_LOGMSG_INFO, rc=rc)
 
     if (status == ESMF_FILESTATUS_OLD) then
-      ! This writes the vectical coordinates and the time dimension into the
+      ! This writes the vertical coordinates and the time dimension into the
       ! file. Doing this before the large data sets are written, assuming that
       ! the first time coming into ioCompRun() with this tileFileName, only
       ! the grid info is written. Second time in, with ESMF_FILESTATUS_OLD,
@@ -3314,7 +3375,7 @@
         ncerr = nf90_open(tileFileName, NF90_WRITE, ncid=ncid)
 
         if (ESMF_LogFoundNetCDFError(ncerr, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
-        ! loop over all the fields in the bundle and handle their vectical dims
+        ! loop over all the fields in the bundle and handle their vertical dims
 
         thereAreVerticals = .false.
         do i=1, fieldCount
@@ -3447,7 +3508,6 @@
               attName = attNameList(i)
               call ESMF_AttributeGet(grid, convention="NetCDF", purpose="FV3", &
                                      name=trim(attNameList(i)), typekind=typekind, rc=rc)
-!                print *,'in esmf call, att name=',trim(attNameList(i))
 
               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
@@ -3455,7 +3515,7 @@
                 call ESMF_AttributeGet(grid,                               &
                                        convention="NetCDF", purpose="FV3", &
                                        name=trim(attNameList(i)), value=valueS, rc=rc)
-!                print *,'in esmf call, att string value=',trim(valueS)
+
                 if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
                 ncerr = nf90_put_att(ncid, varid, &
@@ -3468,7 +3528,7 @@
                 call ESMF_AttributeGet(grid,                               &
                                        convention="NetCDF", purpose="FV3", &
                                        name=trim(attNameList(i)), value=valueI4, rc=rc)
-!                print *,'in esmf call, att I4 value=',valueR8
+
                 if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
                 ncerr = nf90_put_att(ncid, varid, &
                                      trim(attName(6:len(attName))), values=valueI4)
@@ -3479,7 +3539,6 @@
                 call ESMF_AttributeGet(grid,                               &
                                        convention="NetCDF", purpose="FV3", &
                                        name=trim(attNameList(i)), value=valueR4, rc=rc)
-!                print *,'in esmf call, att r4 value=',valueR8
 
                 if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
@@ -3492,7 +3551,6 @@
                 call ESMF_AttributeGet(grid,                               &
                                        convention="NetCDF", purpose="FV3", &
                                        name=trim(attNameList(i)), value=valueR8, rc=rc)
-!                print *,'in esmf call, att r8 value=',valueR8
 
                 if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
                 ncerr = nf90_put_att(ncid, varid, &

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -211,7 +211,7 @@
       type(ESMF_DistGrid)                     :: acceptorDG, newAcceptorDG
       integer                                 :: grid_id
 
-      logical                    :: top_parent_history_file_is_on_cubed_sphere_grid
+      logical                    :: history_file_on_native_grid
       character(len=esmf_maxstr) :: output_grid_name
 !
 !-----------------------------------------------------------------------
@@ -485,12 +485,12 @@
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
         endif
 
-    call ESMF_ConfigGetAttribute(config=CF, value=top_parent_history_file_is_on_cubed_sphere_grid, default=.false., &
-                                 label='top_parent_history_file_is_on_cubed_sphere_grid:', rc=rc)
+    call ESMF_ConfigGetAttribute(config=CF, value=history_file_on_native_grid, default=.false., &
+                                 label='history_file_on_native_grid:', rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
 #if 1
-        if (n == 1 .and. top_parent_is_global .and. top_parent_history_file_is_on_cubed_sphere_grid) then
+        if (n == 1 .and. top_parent_is_global .and. history_file_on_native_grid) then
           do tl=1,6
             decomptile(1,tl) = 1
             decomptile(2,tl) = jidx
@@ -1291,7 +1291,7 @@
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
     ! add the transfer attributes from importState to special cubed_sphere grid
-    if (n == 1 .and. top_parent_is_global .and. top_parent_history_file_is_on_cubed_sphere_grid) then
+    if (n == 1 .and. top_parent_is_global .and. history_file_on_native_grid) then
       call ESMF_AttributeAdd(wrtGrid_cubed_sphere, convention="NetCDF", purpose="FV3", &
                              attrList=attNameList(1:j-1), rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
@@ -1322,7 +1322,7 @@
                                name=trim(attNameList(i)), value=valueS, rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-        if (n == 1 .and. top_parent_is_global .and. top_parent_history_file_is_on_cubed_sphere_grid) then
+        if (n == 1 .and. top_parent_is_global .and. history_file_on_native_grid) then
           call ESMF_AttributeSet(wrtGrid_cubed_sphere, convention="NetCDF", purpose="FV3", &
                                  name=trim(attNameList(i)), value=valueS, rc=rc)
           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return

--- a/io/post_fv3.F90
+++ b/io/post_fv3.F90
@@ -258,6 +258,7 @@ module post_fv3
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__,file=__FILE__)) return
 
         if (wrtFBName(1:8) == 'restart_') cycle
+        if (wrtFBName(1:18) == 'cubed_sphere_grid_') cycle
 
 ! set grid spec:
 !      if(mype==0) print*,'in post_getattr_lam,output_grid=',trim(output_grid(grid_id)),'nfb=',nfb
@@ -896,7 +897,7 @@ module post_fv3
        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__,file=__FILE__)) return
 
        if (wrtFBName(1:8) == 'restart_') cycle
-
+       if (wrtFBName(1:18) == 'cubed_sphere_grid_') cycle
 
        call ESMF_AttributeGet(wrt_int_state%wrtFB(ibdl), convention="NetCDF", purpose="FV3", &
                               name="grid_id", value=bundle_grid_id, rc=rc)
@@ -987,6 +988,7 @@ module post_fv3
           line=__LINE__, file=__FILE__)) return  ! bail out
 
        if (wrtFBName(1:8) == 'restart_') cycle
+       if (wrtFBName(1:18) == 'cubed_sphere_grid_') cycle
 
        call ESMF_AttributeGet(wrt_int_state%wrtFB(ibdl), convention="NetCDF", purpose="FV3", &
                               name="grid_id", value=bundle_grid_id, rc=rc)

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -317,9 +317,11 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     integer,intent(out)                    :: rc
 
     type(ESMF_Grid)                        :: grid
-    integer                                :: itemCount
-    character(len=ESMF_MAXSTR)             :: itemNameList(1), fb_name
-    type(ESMF_FieldBundle)                 :: fb, fcstFB
+    integer                                :: itemCount, i
+    character(len=ESMF_MAXSTR), allocatable :: itemNameList(:)
+    character(len=ESMF_MAXSTR)              :: fb_name
+    type(ESMF_FieldBundle), allocatable     :: fbList(:)
+    type(ESMF_FieldBundle)                  :: fcstFB
 
     call ESMF_GridCompGet(nest, grid=grid, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
@@ -327,42 +329,43 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     call ESMF_StateGet(importState, itemCount=itemCount, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-    if (itemCount /= 1) then
-      ! error condition, expect exactly one dynamics field bundle
-      call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-        msg="Expecting exactly one dynamics field bundle.", line=__LINE__, file=__FILE__)
-    endif
+    allocate(itemNameList(itemCount), fbList(itemCount))
 
     call ESMF_StateGet(importState, itemNameList=itemNameList, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-    call ESMF_StateGet(importState, itemName=itemNameList(1), fieldbundle=fcstFB, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+    do i=1, itemCount
+      call ESMF_StateGet(importState, itemName=itemNameList(i), fieldbundle=fcstFB, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-    fb = ESMF_FieldBundleCreate(name=itemNameList(1), rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+      fbList(i) = ESMF_FieldBundleCreate(name=itemNameList(i), rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-    call ESMF_AttributeCopy(fcstFB, fb, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+      call ESMF_AttributeCopy(fcstFB, fbList(i), rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-    call ESMF_StateAdd(exportState,(/fb/), rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+      call ESMF_StateAdd(exportState, (/fbList(i)/), rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+    enddo
 
-    call ESMF_FieldBundleGet(fb, name=fb_name, rc=rc)
+    ! get the name of the first field bundle and based on that determine if it's a history or restart bundles
+    call ESMF_FieldBundleGet(fbList(1), name=fb_name, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
     if (fb_name(1:19) == 'restart_fv_core.res') then
-      call fv_core_restart_bundle_setup(fb, grid, rc=rc)
+      call fv_core_restart_bundle_setup(fbList(1), grid, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
     else if (fb_name(1:22) == 'restart_fv_srf_wnd.res') then
-      call fv_srf_wnd_restart_bundle_setup(fb, grid, rc=rc)
+      call fv_srf_wnd_restart_bundle_setup(fbList(1), grid, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
     else if (fb_name(1:21) == 'restart_fv_tracer.res') then
-      call fv_tracer_restart_bundle_setup(fb, grid, rc=rc)
+      call fv_tracer_restart_bundle_setup(fbList(1), grid, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
     else
-      call fv_dyn_bundle_setup(Atmos%axes, fb, grid, quilting=.true., rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+      do i=1, itemCount
+        call fv_dyn_bundle_setup(Atmos%axes, fbList(i), grid, quilting=.true., rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+      end do
     endif
 
   end subroutine init_dyn_fb
@@ -541,10 +544,6 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     character(256)                         :: gridfile
 
     character(8) :: bundle_grid
-    type(ESMF_FieldBundle),dimension(:), allocatable    :: fieldbundle             ! dynamics hystory bundles
-    type(ESMF_FieldBundle),dimension(:,:), allocatable  :: fieldbundle_dyn_restart ! dynamics restart bundles
-    type(ESMF_FieldBundle),dimension(:,:), allocatable  :: fieldbundlephys         ! physics hystory bundles
-    type(ESMF_FieldBundle),dimension(:,:), allocatable  :: fieldbundle_phy_restart ! physics restart bundles
 
     real(kind=8) :: mpi_wtime, timeis
 
@@ -564,6 +563,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     integer               :: layout(2), nx, ny
     integer, pointer      :: pelist(:) => null()
     logical               :: top_parent_is_global
+    logical               :: top_parent_history_file_is_on_cubed_sphere_grid
 
     integer                       :: num_restart_interval, restart_starttime
     real,dimension(:),allocatable :: restart_interval
@@ -985,12 +985,10 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 ! Create FieldBundle for Fields that need to be regridded bilinear
       if( quilting ) then
 
-        allocate(fieldbundle(ngrids))
-        nbdlphys = 2
-        allocate(fieldbundlephys(nbdlphys,ngrids))
+        call ESMF_ConfigGetAttribute(config=CF, value=top_parent_history_file_is_on_cubed_sphere_grid, default=.false., label='top_parent_history_file_is_on_cubed_sphere_grid:', rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-        allocate(fieldbundle_dyn_restart(ngrids,3)) ! fv_core.res fv_srf_wnd.res fv_tracer.res
-        allocate(fieldbundle_phy_restart(ngrids,2)) ! phy_data sfc_data
+        nbdlphys = 2
 
         do n=1,ngrids
         bundle_grid=''
@@ -1005,69 +1003,41 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 
          name_FB = trim(filename_base(i)) // trim(bundle_grid)
 !
-         if( i==1 ) then
-! for dyn
+         if (i == 1) then ! for dyn
            name_FB1 = trim(name_FB)//'_bilinear'
-           fieldbundle(n) = ESMF_FieldBundleCreate(name=trim(name_FB1),rc=rc)
+           call create_bundle_and_add_it_to_state(trim(name_FB1), tempState, rc=rc)
            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-           call ESMF_AttributeAdd(fieldbundle(n), convention="NetCDF", purpose="FV3", &
-                                  attrList=(/"grid_id"/), rc=rc)
-           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-           call ESMF_AttributeSet(fieldbundle(n), convention="NetCDF", purpose="FV3", &
-                                  name="grid_id", value=n, rc=rc)
-           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-           call ESMF_AttributeAdd(fieldbundle(n), convention="NetCDF", purpose="FV3-nooutput", &
-                                  attrList=(/"frestart"/), rc=rc)
-           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-           call ESMF_AttributeSet(fieldbundle(n), convention="NetCDF", purpose="FV3-nooutput", &
-                                  name="frestart", valueList=frestart, rc=rc)
-            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-           call ESMF_StateAdd(tempState, (/fieldbundle(n)/), rc=rc)
-           if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+           if (n == 1 .AND. top_parent_is_global .AND. top_parent_history_file_is_on_cubed_sphere_grid) then
+             call create_bundle_and_add_it_to_state('cubed_sphere_grid_'//trim(name_FB1), tempState, rc=rc)
+             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+           end if
 
            call ESMF_GridCompInitialize(fcstGridComp(n), importState=tempState,&
-             exportState=exportState, phase=1, userrc=urc, rc=rc)
+                                        exportState=exportState, phase=1, userrc=urc, rc=rc)
            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
            if (ESMF_LogFoundError(rcToCheck=urc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
 
-         else if( i==2 ) then
-! for phys
+         else if (i == 2) then ! for phys
+
            do j=1, nbdlphys
-             if( j==1 ) then
+             if (j == 1) then
                name_FB1 = trim(name_FB)//'_nearest_stod'
              else
                name_FB1 = trim(name_FB)//'_bilinear'
              endif
-             fieldbundlephys(j,n) = ESMF_FieldBundleCreate(name=trim(name_FB1),rc=rc)
+             call create_bundle_and_add_it_to_state(trim(name_FB1), tempState, rc=rc)
              if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-             call ESMF_AttributeAdd(fieldbundlephys(j,n), convention="NetCDF", purpose="FV3", &
-                                    attrList=(/"grid_id"/), rc=rc)
-             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+             if (n == 1 .AND. top_parent_is_global .AND. top_parent_history_file_is_on_cubed_sphere_grid) then
+               call create_bundle_and_add_it_to_state('cubed_sphere_grid_'//trim(name_FB1), tempState, rc=rc)
+               if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+             endif
 
-             call ESMF_AttributeSet(fieldbundlephys(j,n), convention="NetCDF", purpose="FV3", &
-                                    name="grid_id", value=n, rc=rc)
-             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-             call ESMF_AttributeAdd(fieldbundlephys(j,n), convention="NetCDF", purpose="FV3-nooutput", &
-                                    attrList=(/"frestart"/), rc=rc)
-             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-             call ESMF_AttributeSet(fieldbundlephys(j,n), convention="NetCDF", purpose="FV3-nooutput", &
-                                    name="frestart", valueList=frestart, rc=rc)
-             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-             call ESMF_StateAdd(tempState, (/fieldbundlephys(j,n)/), rc=rc)
-             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
            enddo
 
            call ESMF_GridCompInitialize(fcstGridComp(n), importState=tempState,&
-             exportState=exportState, phase=2, userrc=urc, rc=rc)
+                                        exportState=exportState, phase=2, userrc=urc, rc=rc)
            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
            if (ESMF_LogFoundError(rcToCheck=urc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
 
@@ -1106,26 +1076,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
               name_FB = trim(name_FB)//nest_suffix
             endif
 
-            fieldbundle_dyn_restart(n,i) = ESMF_FieldBundleCreate(name=trim(name_FB),rc=rc)
-            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-            call ESMF_AttributeAdd(fieldbundle_dyn_restart(n,i), convention="NetCDF", purpose="FV3", &
-                                   attrList=(/"grid_id"/), rc=rc)
-            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-            call ESMF_AttributeSet(fieldbundle_dyn_restart(n,i), convention="NetCDF", purpose="FV3", &
-                                   name="grid_id", value=n, rc=rc)
-            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-            call ESMF_AttributeAdd(fieldbundle_dyn_restart(n,i), convention="NetCDF", purpose="FV3-nooutput", &
-                                   attrList=(/"frestart"/), rc=rc)
-            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-            call ESMF_AttributeSet(fieldbundle_dyn_restart(n,i), convention="NetCDF", purpose="FV3-nooutput", &
-                                   name="frestart", valueList=frestart, rc=rc)
-            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-            call ESMF_StateAdd(tempState, (/fieldbundle_dyn_restart(n,i)/), rc=rc)
+            call create_bundle_and_add_it_to_state(trim(name_FB), tempState, rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
             call ESMF_GridCompInitialize(fcstGridComp(n), importState=tempState, &
@@ -1157,26 +1108,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
               name_FB = trim(name_FB)//nest_suffix
             endif
 
-            fieldbundle_phy_restart(n,i) = ESMF_FieldBundleCreate(name=trim(name_FB),rc=rc)
-            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-            call ESMF_AttributeAdd(fieldbundle_phy_restart(n,i), convention="NetCDF", purpose="FV3", &
-                                   attrList=(/"grid_id"/), rc=rc)
-            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-            call ESMF_AttributeSet(fieldbundle_phy_restart(n,i), convention="NetCDF", purpose="FV3", &
-                                   name="grid_id", value=n, rc=rc)
-            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-            call ESMF_AttributeAdd(fieldbundle_phy_restart(n,i), convention="NetCDF", purpose="FV3-nooutput", &
-                                   attrList=(/"frestart"/), rc=rc)
-            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-            call ESMF_AttributeSet(fieldbundle_phy_restart(n,i), convention="NetCDF", purpose="FV3-nooutput", &
-                                   name="frestart", valueList=frestart, rc=rc)
-            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-
-            call ESMF_StateAdd(tempState, (/fieldbundle_phy_restart(n,i)/), rc=rc)
+            call create_bundle_and_add_it_to_state(trim(name_FB), tempState, rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
             call ESMF_GridCompInitialize(fcstGridComp(n), importState=tempState, &
@@ -1192,11 +1124,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 
         enddo ! ngrids
 
-        ! total number of field bundles created is ngrids * (1(atm) + 2(phy) + 3(dyn_rest) +2(phy_rest)
-        if (mype == 0) write(*,*)'fcst_initialize: total number of field bundles: ', ngrids*(1+2+0+2)
-
-!end qulting
-      endif
+      endif ! quilting
 
       call get_atmos_model_ungridded_dim(nlev=numLevels,         &
                                          nsoillev=numSoilLayers, &
@@ -1206,6 +1134,36 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 !
 !-----------------------------------------------------------------------
 !
+   contains
+
+     subroutine create_bundle_and_add_it_to_state(name_fb, state, rc)
+
+       character(len=*), intent(in)    :: name_fb
+       type(ESMF_State), intent(inout) :: state
+       integer, intent(out)            :: rc
+
+       type(ESMF_FieldBundle) :: fieldbundle
+
+       fieldbundle = ESMF_FieldBundleCreate(name=trim(name_fb), rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+       call ESMF_AttributeAdd(fieldbundle, convention="NetCDF", purpose="FV3", attrList=(/"grid_id"/), rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+       call ESMF_AttributeSet(fieldbundle, convention="NetCDF", purpose="FV3", name="grid_id", value=n, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+       call ESMF_AttributeAdd(fieldbundle, convention="NetCDF", purpose="FV3-nooutput", attrList=(/"frestart"/), rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+       call ESMF_AttributeSet(fieldbundle, convention="NetCDF", purpose="FV3-nooutput", name="frestart", valueList=frestart, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+       call ESMF_StateAdd(state, (/fieldbundle/), rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+     end subroutine create_bundle_and_add_it_to_state
+
    end subroutine fcst_initialize
 !
 !-----------------------------------------------------------------------

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -563,7 +563,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     integer               :: layout(2), nx, ny
     integer, pointer      :: pelist(:) => null()
     logical               :: top_parent_is_global
-    logical               :: top_parent_history_file_is_on_cubed_sphere_grid
+    logical               :: history_file_on_native_grid
 
     integer                       :: num_restart_interval, restart_starttime
     real,dimension(:),allocatable :: restart_interval
@@ -985,7 +985,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 ! Create FieldBundle for Fields that need to be regridded bilinear
       if( quilting ) then
 
-        call ESMF_ConfigGetAttribute(config=CF, value=top_parent_history_file_is_on_cubed_sphere_grid, default=.false., label='top_parent_history_file_is_on_cubed_sphere_grid:', rc=rc)
+        call ESMF_ConfigGetAttribute(config=CF, value=history_file_on_native_grid, default=.false., label='history_file_on_native_grid:', rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
         nbdlphys = 2
@@ -1008,7 +1008,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
            call create_bundle_and_add_it_to_state(trim(name_FB1), tempState, rc=rc)
            if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-           if (n == 1 .AND. top_parent_is_global .AND. top_parent_history_file_is_on_cubed_sphere_grid) then
+           if (n == 1 .AND. top_parent_is_global .AND. history_file_on_native_grid) then
              call create_bundle_and_add_it_to_state('cubed_sphere_grid_'//trim(name_FB1), tempState, rc=rc)
              if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
            end if
@@ -1029,7 +1029,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
              call create_bundle_and_add_it_to_state(trim(name_FB1), tempState, rc=rc)
              if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-             if (n == 1 .AND. top_parent_is_global .AND. top_parent_history_file_is_on_cubed_sphere_grid) then
+             if (n == 1 .AND. top_parent_is_global .AND. history_file_on_native_grid) then
                call create_bundle_and_add_it_to_state('cubed_sphere_grid_'//trim(name_FB1), tempState, rc=rc)
                if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
              endif


### PR DESCRIPTION
## Description

Add new model_configure parameter (history_file_on_native_grid) to allow history outputs on native (cubed sphere) grid to be created when inline post is enabled.

Fixes: https://github.com/ufs-community/ufs-weather-model/issues/1803

Is a change of answers expected from this PR?  No



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes https://github.com/ufs-community/ufs-weather-model/issues/1803


## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

N/A
