### PR TITLE
add SPP support to G-F deep convection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = ufs/dev
-  url = https://github.com/JiliDong-NOAA/ccpp-physics 
-  branch = feature/gf-spp 
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/JiliDong-NOAA/ccpp-physics 
+  branch = feature/gf-spp 
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -612,6 +612,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: spp_wts_mp    (:,:) => null()  ! spp-mp-perts
     real (kind=kind_phys), pointer :: spp_wts_gwd   (:,:) => null()  ! spp-gwd-perts
     real (kind=kind_phys), pointer :: spp_wts_rad   (:,:) => null()  ! spp-rad-perts
+    real (kind=kind_phys), pointer :: spp_wts_cu_deep (:,:) => null()  ! spp-cu-deep-perts                        
 
     !--- aerosol surface emissions for Thompson microphysics
     real (kind=kind_phys), pointer :: nwfa2d  (:)     => null()  !< instantaneous water-friendly sfc aerosol source
@@ -1368,8 +1369,9 @@ module GFS_typedefs
     integer              :: spp_mp
     integer              :: spp_rad
     integer              :: spp_gwd
+    integer              :: spp_cu_deep
     integer              :: n_var_spp
-    character(len=3)    , pointer :: spp_var_list(:) 
+    character(len=10)    , pointer :: spp_var_list(:) 
     real(kind=kind_phys), pointer :: spp_prt_list(:)
     real(kind=kind_phys), pointer :: spp_stddev_cutoff(:)
 
@@ -3119,6 +3121,8 @@ module GFS_typedefs
       Coupling%spp_wts_gwd = clear_val
       allocate (Coupling%spp_wts_rad   (IM,Model%levs))
       Coupling%spp_wts_rad = clear_val
+      allocate (Coupling%spp_wts_cu_deep   (IM,Model%levs))
+      Coupling%spp_wts_cu_deep = clear_val
     endif
 
     !--- needed for Thompson's aerosol option
@@ -3813,6 +3817,7 @@ module GFS_typedefs
     integer :: spp_mp       =  0
     integer :: spp_rad      =  0
     integer :: spp_gwd      =  0
+    integer :: spp_cu_deep  =  0
     logical :: do_spp       = .false.
 
     integer              :: ichoice         = 0 !< flag for closure of C3/GF deep convection

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -2938,6 +2938,14 @@
   type = real
   kind = kind_phys
   active = (do_stochastically_perturbed_parameterizations)
+[spp_wts_cu_deep]
+  standard_name = spp_weights_for_cu_deep_scheme
+  long_name = spp weights for cu deep scheme
+  units = 1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (do_stochastically_perturbed_parameterizations)
 [sfc_wts]
   standard_name = surface_stochastic_weights_from_coupled_process
   long_name = weights for stochastic surface physics perturbation
@@ -5853,7 +5861,7 @@
   units = none
   dimensions =  (number_of_perturbed_spp_schemes)
   type = character
-  kind = len=3
+  kind = len=10
   active = (do_stochastically_perturbed_parameterizations)
 [spp_pbl]
   standard_name = control_for_pbl_spp_perturbations
@@ -5882,6 +5890,12 @@
 [spp_gwd]
   standard_name = control_for_gravity_wave_drag_spp_perturbations
   long_name = control for gravity wave drag spp perturbations
+  units = count
+  dimensions = ()
+  type = integer
+[spp_cu_deep]
+  standard_name = control_for_deep_convection_spp_perturbations
+  long_name = control for deep convection spp perturbations
   units = count
   dimensions = ()
   type = integer

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -2510,6 +2510,19 @@ module GFS_diagnostics
       enddo
     endif
 
+    if (Model%do_spp) then
+      idx = idx + 1
+      ExtDiag(idx)%axes = 3
+      ExtDiag(idx)%name = 'spp_wts_cu_deep'
+      ExtDiag(idx)%desc = 'spp cu deep perturbation wts'
+      ExtDiag(idx)%unit = 'm/s'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var3 => Coupling(nb)%spp_wts_cu_deep(:,:)
+      enddo
+    endif
+
     if (Model%lndp_type /= 0) then
       idx = idx + 1
       ExtDiag(idx)%axes = 3

--- a/stochastic_physics/stochastic_physics_wrapper.F90
+++ b/stochastic_physics/stochastic_physics_wrapper.F90
@@ -137,6 +137,8 @@ module stochastic_physics_wrapper_mod
              GFS_Control%spp_rad = 1
            case('gwd')
              GFS_Control%spp_gwd = 1
+           case('cu_deep')
+             GFS_Control%spp_cu_deep = 1
            end select
          end do
       end if
@@ -248,6 +250,10 @@ module stochastic_physics_wrapper_mod
                case('rad')
                  do nb=1,Atm_block%nblks
                      GFS_Data(nb)%Coupling%spp_wts_rad(:,:) = spp_wts(nb,1:GFS_Control%blksz(nb),:,n)
+                 end do
+               case('cu_deep')
+                 do nb=1,Atm_block%nblks
+                     GFS_Data(nb)%Coupling%spp_wts_cu_deep(:,:) = spp_wts(nb,1:GFS_Control%blksz(nb),:,n)
                  end do
                end select
             end do


### PR DESCRIPTION
## Description

This PR is co-authored with Georg Grell and @haiqinli, including:

1. add stochastic parameterization perturbations support to Grell-Freitas deep convection parameterization by passing stochastic patterns to mass transport, vertical mass flux profile and closures
2. fix reproducibility issue in G-F deep convection at high resolutions (ichoice option switched to 0)

Related PRs for ufs-weather-model will be submitted shortly.


### Issue(s) addressed

https://github.com/NOAA-EMC/fv3atm/issues/687


## Testing

Tests were performed on Hera by adding a new entry to SPP. This PR is not expected to change any baseline.

## Dependencies

https://github.com/ufs-community/ccpp-physics/pull/98