### PR TITLE
bug fixed for mraerosol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/AnningCheng-NOAA/ccpp-physics
-  branch = mrfd
+  url = https://github.com/NCAR/ccpp-physics
+  branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/AnningCheng-NOAA/ccpp-physics
+  branch = mrfd
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Provide a detailed description of what this PR does.  
What bug does it fix, or what feature does it add?  
A bug fixed for MERRA2 coupled Thompson microphysics. The cloud water number concentration was not passed back when calling the microphysics, resulting model crash for some hurricane cases.
Is a change of answers expected from this PR?  
Yes. Baseline changed whenever mraerosol=T: merra2_thompson and atmaero_control_p8_rad_micro


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<1914>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
RTs in hera
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Yes
Have the ufs-weather-model regression test been run? On what platform?  
Yes. at Hera: /scratch1/NCEPDEV/global/Anning.Cheng/ufs-weather-model/tests
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- yes. /scratch1/NCEPDEV/global/Anning.Cheng/ufs-weather-model/tests
- Please commit the regression test log files in your ufs-weather-model branch
- commited


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
