### PR TITLE
Fix the broken error detection in GFS_phys_time_vary.fv3.F90 and pointer issues in c3 scheme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
+  branch = bugfix/errmsgflg-race-condition
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

There were several bugs in the error detection in GFS_phys_time_vary.fv3.F90. Errors might go undetected, or may be reported incorrectly.

### Issue(s) addressed

- fixes https://github.com/ufs-community/ccpp-physics/issues/108
- fixes https://github.com/ufs-community/ccpp-physics/issues/107
- fixes https://github.com/ufs-community/ccpp-physics/issues/105
- fixes https://github.com/ufs-community/ccpp-physics/issues/104
- fixes https://github.com/ufs-community/ccpp-physics/issues/101

## Testing

#### How were these changes tested?  

Hera regression tests.

#### What compilers / HPCs was it tested with?  

Intel and gnu on Hera.

#### Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  

Failures are sporadic. However, there are enough regression tests that the failures will be detected, as long as jobs are  not automatically resubmitted.

#### Have the ufs-weather-model regression test been run? On what platform?  

Yes. Hera.

#### Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.

No.

#### Please commit the regression test log files in your ufs-weather-model branch

Done.


## Dependencies

- waiting on https://github.com/ufs-community/ccpp-physics/pull/106