### PR TITLE
Remove nine 3D arrays from CLM Lake model

### DIFF
--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -431,13 +431,7 @@ module GFS_typedefs
 
     ! CLM Lake model internal variables:
     real (kind=kind_phys), pointer :: lake_albedo(:)     => null()  !
-    real (kind=kind_phys), pointer :: lake_z3d(:,:)     => null()  !
-    real (kind=kind_phys), pointer :: lake_dz3d(:,:)    => null()  !
-    real (kind=kind_phys), pointer :: lake_soil_watsat3d(:,:) => null()  !
-    real (kind=kind_phys), pointer :: lake_csol3d(:,:)   => null()  !
-    real (kind=kind_phys), pointer :: lake_soil_tkmg3d(:,:)   => null()  !
-    real (kind=kind_phys), pointer :: lake_soil_tkdry3d(:,:)  => null()  !
-    real (kind=kind_phys), pointer :: lake_soil_tksatu3d(:,:) => null()  !
+    real (kind=kind_phys), pointer :: input_lakedepth(:) => null()  !
     real (kind=kind_phys), pointer :: lake_h2osno2d(:)   => null()  !
     real (kind=kind_phys), pointer :: lake_sndpth2d(:)   => null()  !
     real (kind=kind_phys), pointer :: lake_snl2d(:)      => null()  !
@@ -454,8 +448,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: lake_icefrac3d(:,:)=> null()
     real (kind=kind_phys), pointer :: lake_rho0(:)=> null()
     real (kind=kind_phys), pointer :: lake_ht(:)=> null()
-    real (kind=kind_phys), pointer :: lake_clay3d(:,:) => null()
-    real (kind=kind_phys), pointer :: lake_sand3d(:,:) => null()
     integer, pointer :: lake_is_salty(:) => null()
     integer, pointer :: lake_cannot_freeze(:) => null()
     real (kind=kind_phys), pointer :: clm_lake_initialized(:) => null() !< lakeini was called
@@ -2715,13 +2707,7 @@ module GFS_typedefs
        allocate(Sfcprop%lake_t2m(IM))
        allocate(Sfcprop%lake_q2m(IM))
        allocate(Sfcprop%lake_albedo(IM))
-       allocate(Sfcprop%lake_z3d(IM,Model%nlevlake_clm_lake))
-       allocate(Sfcprop%lake_dz3d(IM,Model%nlevlake_clm_lake))
-       allocate(Sfcprop%lake_soil_watsat3d(IM,Model%nlevlake_clm_lake))
-       allocate(Sfcprop%lake_csol3d(IM,Model%nlevlake_clm_lake))
-       allocate(Sfcprop%lake_soil_tkmg3d(IM,Model%nlevlake_clm_lake))
-       allocate(Sfcprop%lake_soil_tkdry3d(IM,Model%nlevlake_clm_lake))
-       allocate(Sfcprop%lake_soil_tksatu3d(IM,Model%nlevlake_clm_lake))
+       allocate(Sfcprop%input_lakedepth(IM))
        allocate(Sfcprop%lake_h2osno2d(IM))
        allocate(Sfcprop%lake_sndpth2d(IM))
        allocate(Sfcprop%lake_snl2d(IM))
@@ -2738,8 +2724,6 @@ module GFS_typedefs
        allocate(Sfcprop%lake_icefrac3d(IM,Model%nlevlake_clm_lake))
        allocate(Sfcprop%lake_rho0(IM))
        allocate(Sfcprop%lake_ht(IM))
-       allocate(Sfcprop%lake_clay3d(IM,Model%nlevsoil_clm_lake))
-       allocate(Sfcprop%lake_sand3d(IM,Model%nlevsoil_clm_lake))
        allocate(Sfcprop%lake_is_salty(IM))
        allocate(Sfcprop%lake_cannot_freeze(IM))
        allocate(Sfcprop%clm_lake_initialized(IM))
@@ -2747,13 +2731,7 @@ module GFS_typedefs
        Sfcprop%lake_t2m = clear_val
        Sfcprop%lake_q2m = clear_val
        Sfcprop%lake_albedo = clear_val
-       Sfcprop%lake_z3d = clear_val
-       Sfcprop%lake_dz3d = clear_val
-       Sfcprop%lake_soil_watsat3d = clear_val
-       Sfcprop%lake_csol3d = clear_val
-       Sfcprop%lake_soil_tkmg3d = clear_val
-       Sfcprop%lake_soil_tkdry3d = clear_val
-       Sfcprop%lake_soil_tksatu3d = clear_val
+       Sfcprop%input_lakedepth = clear_val
        Sfcprop%lake_h2osno2d = clear_val
        Sfcprop%lake_sndpth2d = clear_val
        Sfcprop%lake_snl2d = clear_val
@@ -2770,8 +2748,6 @@ module GFS_typedefs
        Sfcprop%lake_icefrac3d = clear_val
        Sfcprop%lake_rho0 = -111
        Sfcprop%lake_ht = -111
-       Sfcprop%lake_clay3d = clear_val
-       Sfcprop%lake_sand3d = clear_val
        Sfcprop%lake_is_salty = zero
        Sfcprop%lake_cannot_freeze = zero
        Sfcprop%clm_lake_initialized = zero

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -2034,59 +2034,11 @@
   type = real
   kind = kind_phys
   active = (control_for_lake_model_selection == 2 .and. control_for_lake_model_execution_method > 0)
-[lake_z3d]
-  standard_name = depth_of_lake_interface_layers
-  long_name = depth of lake interface layers
-  units = fraction
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  active = (control_for_lake_model_selection == 2 .and. control_for_lake_model_execution_method > 0)
-[lake_dz3d]
-  standard_name = thickness_of_lake_layers
-  long_name = thickness of lake layers
-  units = fraction
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  active = (control_for_lake_model_selection == 2 .and. control_for_lake_model_execution_method > 0)
-[lake_soil_watsat3d]
-  standard_name = saturated_volumetric_soil_water_in_lake_model
-  long_name = saturated volumetric soil water in lake model
+[input_lakedepth]
+  standard_name = lake_depth_before_correction
+  long_name = lake depth_before_correction
   units = m
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  active = (control_for_lake_model_selection == 2 .and. control_for_lake_model_execution_method > 0)
-[lake_csol3d]
-  standard_name = soil_heat_capacity_in_lake_model
-  long_name = soil heat capacity in lake model
-  units = m
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  active = (control_for_lake_model_selection == 2 .and. control_for_lake_model_execution_method > 0)
-[lake_soil_tkmg3d]
-  standard_name = soil_mineral_thermal_conductivity_in_lake_model
-  long_name = soil mineral thermal conductivity in lake model
-  units = m
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  active = (control_for_lake_model_selection == 2 .and. control_for_lake_model_execution_method > 0)
-[lake_soil_tkdry3d]
-  standard_name = dry_soil_thermal_conductivity_in_lake_model
-  long_name = dry soil thermal conductivity in lake model
-  units = m
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  active = (control_for_lake_model_selection == 2 .and. control_for_lake_model_execution_method > 0)
-[lake_soil_tksatu3d]
-  standard_name = saturated_soil_thermal_conductivity_in_lake_model
-  long_name = saturated soil thermal conductivity in lake model
-  units = m
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   active = (control_for_lake_model_selection == 2 .and. control_for_lake_model_execution_method > 0)
@@ -2217,20 +2169,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (control_for_lake_model_selection == 2 .and. control_for_lake_model_execution_method > 0)
-[lake_clay3d]
-  standard_name = clm_lake_percent_clay
-  long_name = percent clay in clm lake model
-  units = percent
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_clm_lake_model)
-  type = integer
-  active = (control_for_lake_model_selection == 2 .and. control_for_lake_model_execution_method > 0)
-[lake_sand3d]
-  standard_name = clm_lake_percent_sand
-  long_name = percent sand in clm lake model
-  units = percent
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_clm_lake_model)
-  type = integer
   active = (control_for_lake_model_selection == 2 .and. control_for_lake_model_execution_method > 0)
 [lake_is_salty]
   standard_name = clm_lake_is_salty

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -5087,42 +5087,6 @@ module GFS_diagnostics
     integer :: nk, idx0, iblk
     
     do iblk=1,nblks
-      call link_all_levels(Sfcprop(iblk)%lake_z3d, 'lake_z3d', 'lake_depth_on_interface_levels', 'm')
-    enddo
-    
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop(iblk)%lake_clay3d, 'lake_clay3d', 'percent clay on soil levels in clm lake model', '%')
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop(iblk)%lake_sand3d, 'lake_sand3d', 'percent sand on soil levels in clm lake model', '%')
-    enddo
-    
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop(iblk)%lake_dz3d, 'lake_dz3d', 'lake level thickness', 'm')
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop(iblk)%lake_soil_watsat3d, 'lake_soil_watsat3d', 'saturated volumetric soil water', 'm3 m-3')
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop(iblk)%lake_csol3d, 'lake_csol3d', 'soil heat capacity', 'J m-3 K-1')
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop(iblk)%lake_soil_tkmg3d, 'lake_soil_tkmg3d', 'soil thermal conductivity, minerals', 'W m-1 K-1')
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop(iblk)%lake_soil_tkdry3d, 'lake_soil_tkdry3d', 'soil thermal conductivity, dry soil', 'W m-1 K-1')
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop(iblk)%lake_soil_tksatu3d, 'lake_soil_tksatu3d', 'soil thermal conductivity, saturated soil', 'W m-1 K-1')
-    enddo
-
-    do iblk=1,nblks
       call link_all_levels(Sfcprop(iblk)%lake_snow_z3d, 'lake_snow_z3d', 'lake snow level depth', 'm')
     enddo
 

--- a/io/fv3atm_clm_lake_io.F90
+++ b/io/fv3atm_clm_lake_io.F90
@@ -39,21 +39,19 @@ module fv3atm_clm_lake_io
     real(kind_phys), pointer, private, dimension(:,:) :: &
          T_snow=>null(), T_ice=>null(), &
          lake_snl2d=>null(), lake_h2osno2d=>null(), lake_tsfc=>null(), clm_lakedepth=>null(), &
-         lake_savedtke12d=>null(), lake_sndpth2d=>null(), clm_lake_initialized=>null()
+         lake_savedtke12d=>null(), lake_sndpth2d=>null(), clm_lake_initialized=>null(), &
+         input_lakedepth=>null()
 
     ! All 3D variables needed for a restart
     real(kind_phys), pointer, private, dimension(:,:,:) :: &
-         lake_z3d=>null(), lake_dz3d=>null(), lake_soil_watsat3d=>null(), &
-         lake_csol3d=>null(), lake_soil_tkmg3d=>null(), lake_soil_tkdry3d=>null(), &
-         lake_soil_tksatu3d=>null(), lake_snow_z3d=>null(), lake_snow_dz3d=>null(), &
+         lake_snow_z3d=>null(), lake_snow_dz3d=>null(), &
          lake_snow_zi3d=>null(), lake_h2osoi_vol3d=>null(), lake_h2osoi_liq3d=>null(), &
          lake_h2osoi_ice3d=>null(), lake_t_soisno3d=>null(), lake_t_lake3d=>null(), &
-         lake_icefrac3d=>null(),  lake_clay3d=>null(), lake_sand3d=>null()
+         lake_icefrac3d=>null()
 
     ! Axis indices in 1-based array, containing non-1-based indices
     real(kind_phys), pointer, private, dimension(:) :: &
-         levlake_clm_lake, levsoil_clm_lake, levsnowsoil_clm_lake, &
-         levsnowsoil1_clm_lake
+         levlake_clm_lake, levsnowsoil_clm_lake, levsnowsoil1_clm_lake
   contains
 
     ! register_axes calls registers_axis on Sfc_restart for all required axes
@@ -117,14 +115,8 @@ CONTAINS
     allocate(clm_lake%lake_sndpth2d(nx,ny))
     allocate(clm_lake%clm_lakedepth(nx,ny))
     allocate(clm_lake%clm_lake_initialized(nx,ny))
+    allocate(clm_lake%input_lakedepth(nx,ny))
 
-    allocate(clm_lake%lake_z3d(nx,ny,Model%nlevlake_clm_lake))
-    allocate(clm_lake%lake_dz3d(nx,ny,Model%nlevlake_clm_lake))
-    allocate(clm_lake%lake_soil_watsat3d(nx,ny,Model%nlevlake_clm_lake))
-    allocate(clm_lake%lake_csol3d(nx,ny,Model%nlevlake_clm_lake))
-    allocate(clm_lake%lake_soil_tkmg3d(nx,ny,Model%nlevlake_clm_lake))
-    allocate(clm_lake%lake_soil_tkdry3d(nx,ny,Model%nlevlake_clm_lake))
-    allocate(clm_lake%lake_soil_tksatu3d(nx,ny,Model%nlevlake_clm_lake))
     allocate(clm_lake%lake_snow_z3d(nx,ny,Model%nlevsnowsoil1_clm_lake))
     allocate(clm_lake%lake_snow_dz3d(nx,ny,Model%nlevsnowsoil1_clm_lake))
     allocate(clm_lake%lake_snow_zi3d(nx,ny,Model%nlevsnowsoil_clm_lake))
@@ -134,19 +126,13 @@ CONTAINS
     allocate(clm_lake%lake_t_soisno3d(nx,ny,Model%nlevsnowsoil1_clm_lake))
     allocate(clm_lake%lake_t_lake3d(nx,ny,Model%nlevlake_clm_lake))
     allocate(clm_lake%lake_icefrac3d(nx,ny,Model%nlevlake_clm_lake))
-    allocate(clm_lake%lake_clay3d(nx,ny,Model%nlevsoil_clm_lake))
-    allocate(clm_lake%lake_sand3d(nx,ny,Model%nlevsoil_clm_lake))
 
     allocate(clm_lake%levlake_clm_lake(Model%nlevlake_clm_lake))
-    allocate(clm_lake%levsoil_clm_lake(Model%nlevsoil_clm_lake))
     allocate(clm_lake%levsnowsoil_clm_lake(Model%nlevsnowsoil_clm_lake))
     allocate(clm_lake%levsnowsoil1_clm_lake(Model%nlevsnowsoil1_clm_lake))
 
     do i=1,Model%nlevlake_clm_lake
       clm_lake%levlake_clm_lake(i) = i
-    enddo
-    do i=1,Model%nlevsoil_clm_lake
-      clm_lake%levsoil_clm_lake(i) = i
     enddo
     do i=-Model%nlevsnow_clm_lake,Model%nlevsoil_clm_lake
       clm_lake%levsnowsoil_clm_lake(i+Model%nlevsnow_clm_lake+1) = i
@@ -165,7 +151,6 @@ CONTAINS
     type(FmsNetcdfDomainFile_t) :: Sfc_restart
 
     call register_axis(Sfc_restart, 'levlake_clm_lake', dimension_length=Model%nlevlake_clm_lake)
-    call register_axis(Sfc_restart, 'levsoil_clm_lake', dimension_length=Model%nlevsoil_clm_lake)
     call register_axis(Sfc_restart, 'levsnowsoil_clm_lake', dimension_length=Model%nlevsnowsoil_clm_lake)
     call register_axis(Sfc_restart, 'levsnowsoil1_clm_lake', dimension_length=Model%nlevsnowsoil1_clm_lake)
   end subroutine clm_lake_register_axes
@@ -182,9 +167,6 @@ CONTAINS
     call register_field(Sfc_restart, 'levlake_clm_lake', axis_type, (/'levlake_clm_lake'/))
     call register_variable_attribute(Sfc_restart, 'levlake_clm_lake', 'cartesian_axis' ,'Z', str_len=1)
 
-    call register_field(Sfc_restart, 'levsoil_clm_lake', axis_type, (/'levsoil_clm_lake'/))
-    call register_variable_attribute(Sfc_restart, 'levsoil_clm_lake', 'cartesian_axis' ,'Z', str_len=1)
-
     call register_field(Sfc_restart, 'levsnowsoil_clm_lake', axis_type, (/'levsnowsoil_clm_lake'/))
     call register_variable_attribute(Sfc_restart, 'levsnowsoil_clm_lake', 'cartesian_axis' ,'Z', str_len=1)
 
@@ -192,7 +174,6 @@ CONTAINS
     call register_variable_attribute(Sfc_restart, 'levsnowsoil1_clm_lake', 'cartesian_axis' ,'Z', str_len=1)
 
     call write_data(Sfc_restart, 'levlake_clm_lake', clm_lake%levlake_clm_lake)
-    call write_data(Sfc_restart, 'levsoil_clm_lake', clm_lake%levsoil_clm_lake)
     call write_data(Sfc_restart, 'levsnowsoil_clm_lake', clm_lake%levsnowsoil_clm_lake)
     call write_data(Sfc_restart, 'levsnowsoil1_clm_lake', clm_lake%levsnowsoil1_clm_lake)
   end subroutine clm_lake_write_axes
@@ -229,14 +210,8 @@ CONTAINS
         clm_lake%lake_sndpth2d(i,j) = zero
         clm_lake%clm_lakedepth(i,j) = zero
         clm_lake%clm_lake_initialized(i,j) = zero
+        clm_lake%input_lakedepth(i,j) = zero
 
-        clm_lake%lake_z3d(i,j,:) = zero
-        clm_lake%lake_dz3d(i,j,:) = zero
-        clm_lake%lake_soil_watsat3d(i,j,:) = zero
-        clm_lake%lake_csol3d(i,j,:) = zero
-        clm_lake%lake_soil_tkmg3d(i,j,:) = zero
-        clm_lake%lake_soil_tkdry3d(i,j,:) = zero
-        clm_lake%lake_soil_tksatu3d(i,j,:) = zero
         clm_lake%lake_snow_z3d(i,j,:) = zero
         clm_lake%lake_snow_dz3d(i,j,:) = zero
         clm_lake%lake_snow_zi3d(i,j,:) = zero
@@ -246,8 +221,6 @@ CONTAINS
         clm_lake%lake_t_soisno3d(i,j,:) = zero
         clm_lake%lake_t_lake3d(i,j,:) = zero
         clm_lake%lake_icefrac3d(i,j,:) = zero
-        clm_lake%lake_clay3d(i,j,:) = zero
-        clm_lake%lake_sand3d(i,j,:) = zero
       enddo
     enddo
   end subroutine clm_lake_fill_data
@@ -284,14 +257,8 @@ CONTAINS
         clm_lake%lake_sndpth2d(i,j) = Sfcprop(nb)%lake_sndpth2d(ix)
         clm_lake%clm_lakedepth(i,j) = Sfcprop(nb)%clm_lakedepth(ix)
         clm_lake%clm_lake_initialized(i,j) = Sfcprop(nb)%clm_lake_initialized(ix)
+        clm_lake%input_lakedepth(i,j) = Sfcprop(nb)%input_lakedepth(ix)
 
-        clm_lake%lake_z3d(i,j,:) = Sfcprop(nb)%lake_z3d(ix,:)
-        clm_lake%lake_dz3d(i,j,:) = Sfcprop(nb)%lake_dz3d(ix,:)
-        clm_lake%lake_soil_watsat3d(i,j,:) = Sfcprop(nb)%lake_soil_watsat3d(ix,:)
-        clm_lake%lake_csol3d(i,j,:) = Sfcprop(nb)%lake_csol3d(ix,:)
-        clm_lake%lake_soil_tkmg3d(i,j,:) = Sfcprop(nb)%lake_soil_tkmg3d(ix,:)
-        clm_lake%lake_soil_tkdry3d(i,j,:) = Sfcprop(nb)%lake_soil_tkdry3d(ix,:)
-        clm_lake%lake_soil_tksatu3d(i,j,:) = Sfcprop(nb)%lake_soil_tksatu3d(ix,:)
         clm_lake%lake_snow_z3d(i,j,:) = Sfcprop(nb)%lake_snow_z3d(ix,:)
         clm_lake%lake_snow_dz3d(i,j,:) = Sfcprop(nb)%lake_snow_dz3d(ix,:)
         clm_lake%lake_snow_zi3d(i,j,:) = Sfcprop(nb)%lake_snow_zi3d(ix,:)
@@ -301,8 +268,6 @@ CONTAINS
         clm_lake%lake_t_soisno3d(i,j,:) = Sfcprop(nb)%lake_t_soisno3d(ix,:)
         clm_lake%lake_t_lake3d(i,j,:) = Sfcprop(nb)%lake_t_lake3d(ix,:)
         clm_lake%lake_icefrac3d(i,j,:) = Sfcprop(nb)%lake_icefrac3d(ix,:)
-        clm_lake%lake_clay3d(i,j,:) = Sfcprop(nb)%lake_clay3d(ix,:)
-        clm_lake%lake_sand3d(i,j,:) = Sfcprop(nb)%lake_sand3d(ix,:)
       enddo
     enddo
   end subroutine clm_lake_copy_from_grid
@@ -338,14 +303,8 @@ CONTAINS
         Sfcprop(nb)%lake_sndpth2d(ix) = clm_lake%lake_sndpth2d(i,j)
         Sfcprop(nb)%clm_lakedepth(ix) = clm_lake%clm_lakedepth(i,j)
         Sfcprop(nb)%clm_lake_initialized(ix) = clm_lake%clm_lake_initialized(i,j)
+        Sfcprop(nb)%input_lakedepth(ix) = clm_lake%input_lakedepth(i,j)
 
-        Sfcprop(nb)%lake_z3d(ix,:) = clm_lake%lake_z3d(i,j,:)
-        Sfcprop(nb)%lake_dz3d(ix,:) = clm_lake%lake_dz3d(i,j,:)
-        Sfcprop(nb)%lake_soil_watsat3d(ix,:) = clm_lake%lake_soil_watsat3d(i,j,:)
-        Sfcprop(nb)%lake_csol3d(ix,:) = clm_lake%lake_csol3d(i,j,:)
-        Sfcprop(nb)%lake_soil_tkmg3d(ix,:) = clm_lake%lake_soil_tkmg3d(i,j,:)
-        Sfcprop(nb)%lake_soil_tkdry3d(ix,:) = clm_lake%lake_soil_tkdry3d(i,j,:)
-        Sfcprop(nb)%lake_soil_tksatu3d(ix,:) = clm_lake%lake_soil_tksatu3d(i,j,:)
         Sfcprop(nb)%lake_snow_z3d(ix,:) = clm_lake%lake_snow_z3d(i,j,:)
         Sfcprop(nb)%lake_snow_dz3d(ix,:) = clm_lake%lake_snow_dz3d(i,j,:)
         Sfcprop(nb)%lake_snow_zi3d(ix,:) = clm_lake%lake_snow_zi3d(i,j,:)
@@ -355,8 +314,6 @@ CONTAINS
         Sfcprop(nb)%lake_t_soisno3d(ix,:) = clm_lake%lake_t_soisno3d(i,j,:)
         Sfcprop(nb)%lake_t_lake3d(ix,:) = clm_lake%lake_t_lake3d(i,j,:)
         Sfcprop(nb)%lake_icefrac3d(ix,:) = clm_lake%lake_icefrac3d(i,j,:)
-        Sfcprop(nb)%lake_clay3d(ix,:) = clm_lake%lake_clay3d(i,j,:)
-        Sfcprop(nb)%lake_sand3d(ix,:) = clm_lake%lake_sand3d(i,j,:)
       enddo
     enddo
   end subroutine clm_lake_copy_to_grid
@@ -397,29 +354,10 @@ CONTAINS
          dimensions=(/'xaxis_1', 'yaxis_1', 'Time   '/), chunksizes=chunksizes2d, is_optional=.true.)
     call register_restart_field(Sfc_restart, 'clm_lake_initialized', clm_lake%clm_lake_initialized, &
          dimensions=(/'xaxis_1', 'yaxis_1', 'Time   '/), chunksizes=chunksizes2d, is_optional=.true.)
+    call register_restart_field(Sfc_restart, 'input_lakedepth', clm_lake%input_lakedepth, &
+         dimensions=(/'xaxis_1', 'yaxis_1', 'Time   '/), chunksizes=chunksizes2d, is_optional=.true.)
 
     ! Register 3D fields
-    call register_restart_field(Sfc_restart, 'lake_z3d', clm_lake%lake_z3d, &
-         dimensions=(/'xaxis_1              ', 'yaxis_1              ', &
-         'levlake_clm_lake     ', 'Time                 '/), chunksizes=chunksizes3d, is_optional=.true.)
-    call register_restart_field(Sfc_restart, 'lake_dz3d', clm_lake%lake_dz3d, &
-         dimensions=(/'xaxis_1              ', 'yaxis_1              ', &
-         'levlake_clm_lake     ', 'Time                 '/), chunksizes=chunksizes3d, is_optional=.true.)
-    call register_restart_field(Sfc_restart,'lake_soil_watsat3d', clm_lake%lake_soil_watsat3d, &
-         dimensions=(/'xaxis_1              ', 'yaxis_1              ', &
-         'levlake_clm_lake     ', 'Time                 '/), chunksizes=chunksizes3d, is_optional=.true.)
-    call register_restart_field(Sfc_restart,'lake_csol3d', clm_lake%lake_csol3d, &
-         dimensions=(/'xaxis_1              ', 'yaxis_1              ', &
-         'levlake_clm_lake     ', 'Time                 '/), chunksizes=chunksizes3d, is_optional=.true.)
-    call register_restart_field(Sfc_restart,'lake_soil_tkmg3d', clm_lake%lake_soil_tkmg3d, &
-         dimensions=(/'xaxis_1              ', 'yaxis_1              ', &
-         'levlake_clm_lake     ', 'Time                 '/), chunksizes=chunksizes3d, is_optional=.true.)
-    call register_restart_field(Sfc_restart,'lake_soil_tkdry3d', clm_lake%lake_soil_tkdry3d, &
-         dimensions=(/'xaxis_1              ', 'yaxis_1              ', &
-         'levlake_clm_lake     ', 'Time                 '/), chunksizes=chunksizes3d, is_optional=.true.)
-    call register_restart_field(Sfc_restart,'lake_soil_tksatu3d', clm_lake%lake_soil_tksatu3d, &
-         dimensions=(/'xaxis_1              ', 'yaxis_1              ', &
-         'levlake_clm_lake     ', 'Time                 '/), chunksizes=chunksizes3d, is_optional=.true.)
     call register_restart_field(Sfc_restart,'lake_snow_z3d', clm_lake%lake_snow_z3d, &
          dimensions=(/'xaxis_1              ', 'yaxis_1              ', &
          'levsnowsoil1_clm_lake', 'Time                 '/), chunksizes=chunksizes3d, is_optional=.true.)
@@ -447,12 +385,6 @@ CONTAINS
     call register_restart_field(Sfc_restart,'lake_icefrac3d', clm_lake%lake_icefrac3d, &
          dimensions=(/'xaxis_1              ', 'yaxis_1              ', &
          'levlake_clm_lake     ', 'Time                 '/), chunksizes=chunksizes3d, is_optional=.true.)
-    call register_restart_field(Sfc_restart,'lake_clay3d', clm_lake%lake_clay3d, &
-         dimensions=(/'xaxis_1              ', 'yaxis_1              ', &
-         'levsoil_clm_lake     ', 'Time                 '/), chunksizes=chunksizes3d, is_optional=.true.)
-    call register_restart_field(Sfc_restart,'lake_sand3d', clm_lake%lake_sand3d, &
-         dimensions=(/'xaxis_1              ', 'yaxis_1              ', &
-         'levsoil_clm_lake     ', 'Time                 '/), chunksizes=chunksizes3d, is_optional=.true.)
   end subroutine clm_lake_register_fields
 
   !>@ This is clm_lake%bundle_fields, and it is only used in the
@@ -484,22 +416,9 @@ CONTAINS
     call create_2d_field_and_add_to_bundle(clm_lake%lake_sndpth2d, "lake_sndpth2d", trim(outputfile), grid, bundle)
     call create_2d_field_and_add_to_bundle(clm_lake%clm_lakedepth, "clm_lakedepth", trim(outputfile), grid, bundle)
     call create_2d_field_and_add_to_bundle(clm_lake%clm_lake_initialized, "clm_lake_initialized", trim(outputfile), grid, bundle)
+    call create_2d_field_and_add_to_bundle(clm_lake%input_lakedepth, "input_lakedepth", trim(outputfile), grid, bundle)
 
     ! Register 3D fields
-    call create_3d_field_and_add_to_bundle(clm_lake%lake_z3d, 'lake_z3d', 'levlake_clm_lake', &
-         clm_lake%levlake_clm_lake, trim(outputfile), grid, bundle)
-    call create_3d_field_and_add_to_bundle(clm_lake%lake_dz3d, 'lake_dz3d', 'levlake_clm_lake', &
-         clm_lake%levlake_clm_lake, trim(outputfile), grid, bundle)
-    call create_3d_field_and_add_to_bundle(clm_lake%lake_soil_watsat3d, 'lake_soil_watsat3d', 'levlake_clm_lake', &
-         clm_lake%levlake_clm_lake, trim(outputfile), grid, bundle)
-    call create_3d_field_and_add_to_bundle(clm_lake%lake_csol3d, 'lake_csol3d', 'levlake_clm_lake', &
-         clm_lake%levlake_clm_lake, trim(outputfile), grid, bundle)
-    call create_3d_field_and_add_to_bundle(clm_lake%lake_soil_tkmg3d, 'lake_soil_tkmg3d', 'levlake_clm_lake', &
-         clm_lake%levlake_clm_lake, trim(outputfile), grid, bundle)
-    call create_3d_field_and_add_to_bundle(clm_lake%lake_soil_tkdry3d, 'lake_soil_tkdry3d', 'levlake_clm_lake', &
-         clm_lake%levlake_clm_lake, trim(outputfile), grid, bundle)
-    call create_3d_field_and_add_to_bundle(clm_lake%lake_soil_tksatu3d, 'lake_soil_tksatu3d', 'levlake_clm_lake', &
-         clm_lake%levlake_clm_lake, trim(outputfile), grid, bundle)
     call create_3d_field_and_add_to_bundle(clm_lake%lake_snow_z3d, 'lake_snow_z3d', 'levsnowsoil1_clm_lake', &
          clm_lake%levsnowsoil1_clm_lake, trim(outputfile), grid, bundle)
     call create_3d_field_and_add_to_bundle(clm_lake%lake_snow_dz3d, 'lake_snow_dz3d', 'levsnowsoil1_clm_lake', &
@@ -518,10 +437,6 @@ CONTAINS
          clm_lake%levlake_clm_lake, trim(outputfile), grid, bundle)
     call create_3d_field_and_add_to_bundle(clm_lake%lake_icefrac3d, 'lake_icefrac3d', 'levlake_clm_lake', &
          clm_lake%levlake_clm_lake, trim(outputfile), grid, bundle)
-    call create_3d_field_and_add_to_bundle(clm_lake%lake_clay3d, 'lake_clay3d', 'levsoil_clm_lake', &
-         clm_lake%levsoil_clm_lake, trim(outputfile), grid, bundle)
-    call create_3d_field_and_add_to_bundle(clm_lake%lake_sand3d, 'lake_sand3d', 'levsoil_clm_lake', &
-         clm_lake%levsoil_clm_lake, trim(outputfile), grid, bundle)
 
   end subroutine Clm_lake_bundle_fields
 
@@ -560,14 +475,8 @@ CONTAINS
     IF_ASSOC_DEALLOC_NULL(lake_sndpth2d)
     IF_ASSOC_DEALLOC_NULL(clm_lakedepth)
     IF_ASSOC_DEALLOC_NULL(clm_lake_initialized)
+    IF_ASSOC_DEALLOC_NULL(input_lakedepth)
 
-    IF_ASSOC_DEALLOC_NULL(lake_z3d)
-    IF_ASSOC_DEALLOC_NULL(lake_dz3d)
-    IF_ASSOC_DEALLOC_NULL(lake_soil_watsat3d)
-    IF_ASSOC_DEALLOC_NULL(lake_csol3d)
-    IF_ASSOC_DEALLOC_NULL(lake_soil_tkmg3d)
-    IF_ASSOC_DEALLOC_NULL(lake_soil_tkdry3d)
-    IF_ASSOC_DEALLOC_NULL(lake_soil_tksatu3d)
     IF_ASSOC_DEALLOC_NULL(lake_snow_z3d)
     IF_ASSOC_DEALLOC_NULL(lake_snow_dz3d)
     IF_ASSOC_DEALLOC_NULL(lake_snow_zi3d)
@@ -577,8 +486,6 @@ CONTAINS
     IF_ASSOC_DEALLOC_NULL(lake_t_soisno3d)
     IF_ASSOC_DEALLOC_NULL(lake_t_lake3d)
     IF_ASSOC_DEALLOC_NULL(lake_icefrac3d)
-    IF_ASSOC_DEALLOC_NULL(lake_clay3d)
-    IF_ASSOC_DEALLOC_NULL(lake_sand3d)
 
 #undef IF_ASSOC_DEALLOC_NULL
   end subroutine clm_lake_deallocate_data


### PR DESCRIPTION
## Description

There are nine 3D arrays in CLM Lake that are constant. Seven of them are 2D arrays copied to all vertical levels. All are cheap to calculate.

This PR removes all nine arrays. When the numbers are needed, they're recalculated.

To do this, I had to add a 2D array: the lakedepth before correction.

### Issue(s) addressed

- fixes https://github.com/ufs-community/ccpp-physics/issues/112

## Testing

#### How were these changes tested?  

A 3km RRFS case was run, removing one array at a time until all nine were gone.

#### What compilers / HPCs was it tested with?  

Hera intel & gnu.

#### Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  

Existing tests are sufficient.

#### Have the ufs-weather-model regression test been run? On what platform?  

Hera

#### Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.

Yes.

1. Any configuration running clm lake that verifies restart files will change because of removing nine variables and adding two.
2. Removing kind_phys arrays means some calculations are promoted to kind_lake (double precision). This causes 32-bit physics cases with lake data running clm lake to change results.
3. When run with optimization, some clm lake cases with lake data will change results due to a different order of operations.

#### Please commit the regression test log files in your ufs-weather-model branch

Done.

## Dependencies

- waiting on https://github.com/ufs-community/ccpp-physics/pull/113
