### PR TITLE
Add zstandard compression

### DIFF
--- a/io/module_fv3_io_def.F90
+++ b/io/module_fv3_io_def.F90
@@ -29,7 +29,7 @@ module module_fv3_io_def
   real,dimension(:),allocatable     :: cen_lon, cen_lat
   real,dimension(:),allocatable     :: lon1, lat1, lon2, lat2, dlon, dlat
   real,dimension(:),allocatable     :: stdlat1, stdlat2, dx, dy
-  integer,dimension(:),allocatable  :: ideflate, nbits
+  integer,dimension(:),allocatable  :: ideflate, nbits, zstandard_level
   integer,dimension(:),allocatable  :: ichunk2d, jchunk2d, ichunk3d, jchunk3d, kchunk3d
 
 end module module_fv3_io_def

--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -83,8 +83,10 @@ module module_write_netcdf
     integer :: oldMode
     integer :: im_dimid, jm_dimid, tile_dimid, pfull_dimid, phalf_dimid, time_dimid, ch_dimid
     integer :: im_varid, jm_varid, tile_varid, lon_varid, lat_varid, timeiso_varid
-    integer, dimension(:), allocatable :: dimids_2d, dimids_3d
+    integer, dimension(:), allocatable :: dimids_2d, dimids_3d, dimids, chunksizes
     integer, dimension(:), allocatable :: varids
+    integer :: xtype
+    integer :: ishuffle
     logical shuffle
 
     logical :: is_cubed_sphere
@@ -315,136 +317,59 @@ module module_write_netcdf
          call ESMF_FieldGet(fcstField(i), name=fldName, rank=rank, typekind=typekind, rc=rc); ESMF_ERR_RETURN(rc)
 
          par_access = NF90_INDEPENDENT
-         ! define variables
+
          if (rank == 2) then
-           if (typekind == ESMF_TYPEKIND_R4) then
-             if (ideflate(grid_id) > 0) then
-               shuffle=.true.
-               if (ichunk2d(grid_id) < 0 .or. jchunk2d(grid_id) < 0) then
-                  ! let netcdf lib choose chunksize
-                  ! shuffle filter on for 2d fields (lossless compression)
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_2d, varids(i), &
-                                       shuffle=shuffle,deflate_level=ideflate(grid_id)); NC_ERR_STOP(ncerr)
-               else
-                  if (is_cubed_sphere) then
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_2d, varids(i), &
-                                       shuffle=shuffle,deflate_level=ideflate(grid_id), &
-                                       chunksizes=[im,jm,tileCount,1]); NC_ERR_STOP(ncerr)
-                  else
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_2d, varids(i), &
-                                       shuffle=shuffle,deflate_level=ideflate(grid_id), &
-                                       chunksizes=[ichunk2d(grid_id),jchunk2d(grid_id),          1]); NC_ERR_STOP(ncerr)
-                  end if
-               end if
-               ! compression filters require collective access.
-               par_access = NF90_COLLECTIVE
-             else if (zstandard_level(grid_id) > 0) then
-               shuffle=.true.
-               if (ichunk2d(grid_id) < 0 .or. jchunk2d(grid_id) < 0) then
-                  ! let netcdf lib choose chunksize
-                  ! shuffle filter on for 2d fields (lossless compression)
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_2d, varids(i), &
-                                       shuffle=shuffle,zstandard_level=zstandard_level(grid_id)); NC_ERR_STOP(ncerr)
-               else
-                  if (is_cubed_sphere) then
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_2d, varids(i), &
-                                       shuffle=shuffle,zstandard_level=zstandard_level(grid_id),&
-                                       chunksizes=[im,jm,tileCount,1]); NC_ERR_STOP(ncerr)
-                  else
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_2d, varids(i), &
-                                       shuffle=shuffle,zstandard_level=zstandard_level(grid_id),&
-                                       chunksizes=[ichunk2d(grid_id),jchunk2d(grid_id),          1]); NC_ERR_STOP(ncerr)
-                  end if
-               end if
-               ! compression filters require collective access.
-               par_access = NF90_COLLECTIVE
-             else ! no compression
-               ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                    dimids_2d, varids(i)); NC_ERR_STOP(ncerr)
-             end if
-           else if (typekind == ESMF_TYPEKIND_R8) then
-             ncerr = nf90_def_var(ncid, trim(fldName), NF90_DOUBLE, &
-                                  dimids_2d, varids(i)); NC_ERR_STOP(ncerr)
-           else
-             if (mype==0) write(0,*)'Unsupported typekind ', typekind
-             call ESMF_Finalize(endflag=ESMF_END_ABORT)
-           end if
+           dimids = dimids_2d
          else if (rank == 3) then
-           if (typekind == ESMF_TYPEKIND_R4) then
-             if (ideflate(grid_id) > 0) then
-               ! shuffle filter off for 3d fields using lossy compression
-               if (nbits(grid_id) > 0) then
-                   shuffle=.false.
-               else
-                   shuffle=.true.
-               end if
-               if (ichunk3d(grid_id) < 0 .or. jchunk3d(grid_id) < 0 .or. kchunk3d(grid_id) < 0) then
-                  ! let netcdf lib choose chunksize
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_3d, varids(i), &
-                                       shuffle=shuffle, deflate_level=ideflate(grid_id)); NC_ERR_STOP(ncerr)
-               else
-                  if (is_cubed_sphere) then
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_3d, varids(i), &
-                                       shuffle=shuffle, deflate_level=ideflate(grid_id), &
-                                       chunksizes=[im,jm,lm,tileCount,1]); NC_ERR_STOP(ncerr)
-                  else
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_3d, varids(i), &
-                                       shuffle=shuffle, deflate_level=ideflate(grid_id), &
-                                       chunksizes=[ichunk3d(grid_id),jchunk3d(grid_id),kchunk3d(grid_id),          1]); NC_ERR_STOP(ncerr)
-                  end if
-               end if
-               ! compression filters require collective access.
-               par_access = NF90_COLLECTIVE
-             else if (zstandard_level(grid_id) > 0) then
-               ! shuffle filter off for 3d fields using lossy compression
-               if (nbits(grid_id) > 0) then
-                   shuffle=.false.
-               else
-                   shuffle=.true.
-               end if
-               if (ichunk3d(grid_id) < 0 .or. jchunk3d(grid_id) < 0 .or. kchunk3d(grid_id) < 0) then
-                  ! let netcdf lib choose chunksize
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_3d, varids(i), &
-                                       shuffle=shuffle, zstandard_level=zstandard_level(grid_id)); NC_ERR_STOP(ncerr)
-               else
-                  if (is_cubed_sphere) then
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_3d, varids(i), &
-                                       shuffle=shuffle, zstandard_level=zstandard_level(grid_id),&
-                                       chunksizes=[im,jm,tileCount,1]); NC_ERR_STOP(ncerr)
-                  else
-                  ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                       dimids_3d, varids(i), &
-                                       shuffle=shuffle, zstandard_level=zstandard_level(grid_id),&
-                                       chunksizes=[ichunk3d(grid_id),jchunk3d(grid_id),kchunk3d(grid_id),          1]); NC_ERR_STOP(ncerr)
-                  end if
-               end if
-               ! compression filters require collective access.
-               par_access = NF90_COLLECTIVE
-             else ! no compression
-               ncerr = nf90_def_var(ncid, trim(fldName), NF90_FLOAT, &
-                                    dimids_3d, varids(i)); NC_ERR_STOP(ncerr)
-             end if
-           else if (typekind == ESMF_TYPEKIND_R8) then
-             ncerr = nf90_def_var(ncid, trim(fldName), NF90_DOUBLE, &
-                                  dimids_3d, varids(i)); NC_ERR_STOP(ncerr)
-           else
-             if (mype==0) write(0,*)'Unsupported typekind ', typekind
-             call ESMF_Finalize(endflag=ESMF_END_ABORT)
-           end if
+           dimids = dimids_3d
          else
            if (mype==0) write(0,*)'Unsupported rank ', rank
            call ESMF_Finalize(endflag=ESMF_END_ABORT)
+         end if
+
+         if (typekind == ESMF_TYPEKIND_R4) then
+           xtype = NF90_FLOAT
+         else if (typekind == ESMF_TYPEKIND_R8) then
+           xtype = NF90_DOUBLE
+         else
+           if (mype==0) write(0,*)'Unsupported typekind ', typekind
+           call ESMF_Finalize(endflag=ESMF_END_ABORT)
+         end if
+
+         ! define variable
+         ncerr = nf90_def_var(ncid, trim(fldName), xtype, dimids, varids(i)) ; NC_ERR_STOP(ncerr)
+
+         ! compression, shuffling  and chunking
+         if (ideflate(grid_id) > 0 .or. zstandard_level(grid_id) > 0) then
+            par_access = NF90_COLLECTIVE
+            if (rank == 2 .and. ichunk2d(grid_id) > 0 .and. jchunk2d(grid_id) > 0) then
+               if (is_cubed_sphere) then
+                  chunksizes = [im, jm, tileCount, 1]
+               else
+                  chunksizes = [ichunk2d(grid_id), jchunk2d(grid_id),            1]
+               end if
+               ncerr = nf90_def_var_chunking(ncid, varids(i), NF90_CHUNKED, chunksizes) ; NC_ERR_STOP(ncerr)
+            else if (rank == 3 .and. ichunk3d(grid_id) > 0 .and. jchunk3d(grid_id) > 0 .and. kchunk3d(grid_id) > 0) then
+               if (is_cubed_sphere) then
+                  chunksizes = [im, jm, lm, tileCount, 1]
+               else
+                  chunksizes = [ichunk3d(grid_id), jchunk3d(grid_id), kchunk3d(grid_id),            1]
+               end if
+               ncerr = nf90_def_var_chunking(ncid, varids(i), NF90_CHUNKED, chunksizes) ; NC_ERR_STOP(ncerr)
+            end if
+
+            ishuffle = NF90_SHUFFLE
+            ! shuffle filter off for 3d fields using lossy compression
+            if (rank == 3 .and. nbits(grid_id) > 0) then
+                ishuffle = NF90_NOSHUFFLE
+            end if
+            if (ideflate(grid_id) > 0) then
+              ncerr = nf90_def_var_deflate(ncid, varids(i), ishuffle, 1, ideflate(grid_id)) ; NC_ERR_STOP(ncerr)
+            else if (zstandard_level(grid_id) > 0) then
+              ncerr = nf90_def_var_deflate(ncid, varids(i), ishuffle, 0, 0) ; NC_ERR_STOP(ncerr)
+              ncerr = nf90_def_var_zstandard(ncid, varids(i), zstandard_level(grid_id)) ; NC_ERR_STOP(ncerr)
+            end if
+
          end if
 
          if (par) then

--- a/io/module_write_restart_netcdf.F90
+++ b/io/module_write_restart_netcdf.F90
@@ -10,6 +10,7 @@ module module_write_restart_netcdf
   use mpi
   use esmf
   use fms
+  use mpp_mod, only : mpp_chksum   ! needed for fms 2023.02
   use netcdf
   use module_fv3_io_def,only : zstandard_level
 

--- a/io/module_write_restart_netcdf.F90
+++ b/io/module_write_restart_netcdf.F90
@@ -7,10 +7,11 @@
 
 module module_write_restart_netcdf
 
+  use mpi
   use esmf
   use fms
   use netcdf
-  use mpi
+  use module_fv3_io_def,only : zstandard_level
 
   implicit none
   private
@@ -361,6 +362,16 @@ module module_write_restart_netcdf
          end if
          if (par) then
              ncerr = nf90_var_par_access(ncid, varids(i), par_access); NC_ERR_STOP(ncerr)
+         end if
+
+         if (zstandard_level(1) > 0) then
+            ncerr = nf90_def_var_zstandard(ncid, varids(i), zstandard_level(1))
+            if (ncerr /= nf90_noerr) then
+               if (ncerr == nf90_enofilter) then
+                  if (mype==0) write(0,*) 'Zstandard filter not found.'
+               end if
+               NC_ERR_STOP(ncerr)
+            end if
          end if
 
        end do   ! i=1,fieldCount

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -478,6 +478,13 @@
         if (ideflate(n) < 0) ideflate(n)=0
 
         call ESMF_ConfigGetAttribute(config=CF,value=nbits(n),default=0,label ='nbits:',rc=rc)
+
+        if (ideflate(n) > 0 .and. zstandard_level(n) > 0) then
+           write(0,*)"wrt_initialize_p1: zlib and zstd compression cannot be both enabled at the same time"
+           call ESMF_LogWrite("wrt_initialize_p1: zlib and zstd compression cannot be both enabled at the same time",ESMF_LOGMSG_ERROR,rc=RC)
+           call ESMF_Finalize(endflag=ESMF_END_ABORT)
+        end if
+
         if (lprnt) then
             print *,'ideflate=',ideflate(n),' nbits=',nbits(n)
             print *,'zstandard_level=',zstandard_level(n)

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -29,6 +29,7 @@
       use mpi
       use esmf
       use fms
+      use mpp_mod, only : mpp_init   ! needed for fms 2023.02
 
       use write_internal_state
       use module_fv3_io_def,   only : num_pes_fcst,                             &

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -40,7 +40,7 @@
                                       cen_lon, cen_lat,                         &
                                       lon1, lat1, lon2, lat2, dlon, dlat,       &
                                       stdlat1, stdlat2, dx, dy, iau_offset,     &
-                                      ideflate, lflname_fulltime
+                                      ideflate, zstandard_level, lflname_fulltime
       use module_write_netcdf, only : write_netcdf
       use module_write_restart_netcdf
       use physcons,            only : pi => con_pi
@@ -361,6 +361,7 @@
       allocate(kchunk3d(ngrids))
       allocate(ideflate(ngrids))
       allocate(nbits(ngrids))
+      allocate(zstandard_level(ngrids))
 
       allocate(wrt_int_state%out_grid_info(ngrids))
 
@@ -466,6 +467,12 @@
         call ESMF_ConfigGetAttribute(config=CF,value=jchunk3d(n),default=0,label ='jchunk3d:',rc=rc)
         call ESMF_ConfigGetAttribute(config=CF,value=kchunk3d(n),default=0,label ='kchunk3d:',rc=rc)
 
+        ! zstandard compression flag
+        call ESMF_ConfigGetAttribute(config=CF,value=zstandard_level(n),default=0,label ='zstandard_level:',rc=rc)
+        if (zstandard_level(n) < 0) zstandard_level(n)=0
+
+        call ESMF_ConfigGetAttribute(config=CF,value=nbits(n),default=0,label ='nbits:',rc=rc)
+
         ! zlib compression flag
         call ESMF_ConfigGetAttribute(config=CF,value=ideflate(n),default=0,label ='ideflate:',rc=rc)
         if (ideflate(n) < 0) ideflate(n)=0
@@ -473,6 +480,7 @@
         call ESMF_ConfigGetAttribute(config=CF,value=nbits(n),default=0,label ='nbits:',rc=rc)
         if (lprnt) then
             print *,'ideflate=',ideflate(n),' nbits=',nbits(n)
+            print *,'zstandard_level=',zstandard_level(n)
         end if
         ! nbits quantization level for lossy compression (must be between 1 and 31)
         ! 1 is most compression, 31 is least. If outside this range, set to zero


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Provide a detailed description of what this PR does.  

New model_configure configuration parameter has been added (zstandard_level). Valid values are 0-19 (default is 0). Value 0 turns off compression, values 1-19 specify the level of compression (1=fastest compression, 19=best compression ratio),  

What bug does it fix, or what feature does it add?  Add option to enable zstandard compression.


Is a change of answers expected from this PR?  No.

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes https://github.com/ufs-community/ufs-weather-model/issues/1927

## Testing

How were these changes tested?  Regression test on Hera and Acorn
What compilers / HPCs was it tested with?  Inetl, GNU
Are the changes covered by regression tests? No. Currently `nccmp`can not compare netcdf files with zstandard compression enabled. The nccmp program needs to be updated.
  
Have the ufs-weather-model regression test been run? Yes. On what platform? Hera  
- Will the code updates change regression test baseline? No.
- Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch
