### PR TITLE
allow cpllnd to use inst lw and sw down

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = ufs/dev
-  url = https://github.com/DeniseWorthen/ccpp-physics
-  branch = feature/lndinst
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = ufs/dev
+  url = https://github.com/DeniseWorthen/ccpp-physics
+  branch = feature/lndinst
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -135,7 +135,7 @@ module GFS_typedefs
     integer,           pointer :: tracer_types(:) !< tracers types: 0=generic, 1=chem,prog, 2=chem,diag
     character(len=64) :: fn_nml                   !< namelist filename
     character(len=:), pointer, dimension(:) :: input_nml_file => null() !< character string containing full namelist
-                                                                        !< for use with internal file reads    
+                                                                        !< for use with internal file reads
  end type GFS_init_type
 
 
@@ -217,19 +217,19 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: lakedepth(:) => null()  !< lake  depth [ m ]
     real (kind=kind_phys), pointer :: clm_lakedepth(:) => null()  !< clm internal lake depth [ m ]
     integer,               pointer :: use_lake_model(:) => null()!1=run lake, 2=run lake&nsst, 0=no lake
-    real (kind=kind_phys), pointer :: lake_t2m (:)   => null()  !< 2 meter temperature from CLM Lake model 
+    real (kind=kind_phys), pointer :: lake_t2m (:)   => null()  !< 2 meter temperature from CLM Lake model
     real (kind=kind_phys), pointer :: lake_q2m (:)   => null()  !< 2 meter humidity from CLM Lake model
 
-    real (kind=kind_phys), pointer :: h_ML(:)      => null()  !Mixed Layer depth of lakes [m]  
-    real (kind=kind_phys), pointer :: t_ML(:)      => null()  !Mixing layer temperature in K 
-    real (kind=kind_phys), pointer :: t_mnw(:)     => null()  !Mean temperature of the water column [K] 
-    real (kind=kind_phys), pointer :: h_talb(:)    => null()  !the thermally active layer depth of the bottom sediments [m] 
-    real (kind=kind_phys), pointer :: t_talb(:)    => null()  !Temperature at the bottom of the sediment upper layer [K]  
-    real (kind=kind_phys), pointer :: t_bot1(:)    => null()  !Temperature at the water-bottom sediment interface [K] 
+    real (kind=kind_phys), pointer :: h_ML(:)      => null()  !Mixed Layer depth of lakes [m]
+    real (kind=kind_phys), pointer :: t_ML(:)      => null()  !Mixing layer temperature in K
+    real (kind=kind_phys), pointer :: t_mnw(:)     => null()  !Mean temperature of the water column [K]
+    real (kind=kind_phys), pointer :: h_talb(:)    => null()  !the thermally active layer depth of the bottom sediments [m]
+    real (kind=kind_phys), pointer :: t_talb(:)    => null()  !Temperature at the bottom of the sediment upper layer [K]
+    real (kind=kind_phys), pointer :: t_bot1(:)    => null()  !Temperature at the water-bottom sediment interface [K]
     real (kind=kind_phys), pointer :: t_bot2(:)    => null()  !Temperature for bottom layer of water [K]
-    real (kind=kind_phys), pointer :: c_t(:)       => null()  !Shape factor of water temperature vertical profile 
-    real (kind=kind_phys), pointer :: T_snow(:)    => null()  !temperature of snow on a lake [K] 
-    real (kind=kind_phys), pointer :: T_ice(:)     => null()  !temperature of ice on a lake [K] 
+    real (kind=kind_phys), pointer :: c_t(:)       => null()  !Shape factor of water temperature vertical profile
+    real (kind=kind_phys), pointer :: T_snow(:)    => null()  !temperature of snow on a lake [K]
+    real (kind=kind_phys), pointer :: T_ice(:)     => null()  !temperature of ice on a lake [K]
 
     real (kind=kind_phys), pointer :: tsfc   (:)   => null()  !< surface air temperature in K
     real (kind=kind_phys), pointer :: vegtype_frac (:,:) => null()  !< fractions [0:1] of veg. categories
@@ -525,7 +525,7 @@ module GFS_typedefs
 !   real (kind=kind_phys), pointer :: sfc_alb_vis_dif_cpl(:)  => null()   !< sfc vis albedo for diffuse rad
     !--- only variable needed for cplwav2atm=.TRUE.
 !   real (kind=kind_phys), pointer :: zorlwav_cpl(:)          => null()   !< roughness length from wave model
-    !--- also needed for ice/ocn coupling 
+    !--- also needed for ice/ocn coupling
     real (kind=kind_phys), pointer :: slimskin_cpl(:)=> null()   !< aoi_fld%slimskin(item,lan)
     !--- variables needed for use_med_flux =.TRUE.
     real (kind=kind_phys), pointer :: dusfcin_med(:)         => null()   !< sfc u momentum flux over ocean
@@ -604,7 +604,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: spp_wts_mp    (:,:) => null()  ! spp-mp-perts
     real (kind=kind_phys), pointer :: spp_wts_gwd   (:,:) => null()  ! spp-gwd-perts
     real (kind=kind_phys), pointer :: spp_wts_rad   (:,:) => null()  ! spp-rad-perts
-    real (kind=kind_phys), pointer :: spp_wts_cu_deep (:,:) => null()  ! spp-cu-deep-perts                        
+    real (kind=kind_phys), pointer :: spp_wts_cu_deep (:,:) => null()  ! spp-cu-deep-perts
 
     !--- aerosol surface emissions for Thompson microphysics
     real (kind=kind_phys), pointer :: nwfa2d  (:)     => null()  !< instantaneous water-friendly sfc aerosol source
@@ -837,7 +837,7 @@ module GFS_typedefs
                                             !< 1: K day-1 - 2: K s-1
     logical              :: inc_minor_gas   !< Include minor trace gases in RRTMG radiation calculation?
     integer              :: ipsd0           !< initial permutaion seed for mcica radiation
-    integer              :: ipsdlim         !< limit initial permutaion seed for mcica radiation 
+    integer              :: ipsdlim         !< limit initial permutaion seed for mcica radiation
     logical              :: lrseeds         !< flag to use host-provided random seeds
     integer              :: nrstreams       !< number of random number streams in host-provided random seed array
     logical              :: lextop          !< flag for using an extra top layer for radiation
@@ -869,10 +869,10 @@ module GFS_typedefs
     real(kind_phys)      :: lfnc_p0                 !<          Logistic function transition level (Pa)
     logical              :: doGP_lwscat             !< If true, include scattering in longwave cloud-optics, only compatible w/ GP cloud-optics
     logical              :: doGP_sgs_cnv            !< If true, include SubGridScale convective cloud in RRTMGP
-    logical              :: doGP_sgs_mynn           !< If true, include SubGridScale MYNN-EDMF cloud in RRTMGP 
+    logical              :: doGP_sgs_mynn           !< If true, include SubGridScale MYNN-EDMF cloud in RRTMGP
     integer              :: rrtmgp_lw_phys_blksz    !< Number of columns to pass to RRTMGP LW per block.
     integer              :: rrtmgp_sw_phys_blksz    !< Number of columns to pass to RRTMGP SW per block.
-    logical              :: doGP_smearclds          !< If true, include implicit SubGridScale clouds in RRTMGP 
+    logical              :: doGP_smearclds          !< If true, include implicit SubGridScale clouds in RRTMGP
     real(kind_phys)      :: minGPpres               !< Minimum pressure allowed in RRTMGP.
     real(kind_phys)      :: maxGPpres               !< Maximum pressure allowed in RRTMGP.
     real(kind_phys)      :: minGPtemp               !< Minimum temperature allowed in RRTMGP.
@@ -965,9 +965,9 @@ module GFS_typedefs
     real(kind=kind_phys) :: nssl_cccn      !<  CCN concentration (m-3)
     real(kind=kind_phys) :: nssl_alphah    !<  graupel shape parameter
     real(kind=kind_phys) :: nssl_alphahl   !<  hail shape parameter
-    real(kind=kind_phys) :: nssl_alphar    ! shape parameter for rain (imurain=1 only)                         
-    real(kind=kind_phys) :: nssl_ehw0      ! constant or max assumed graupel-droplet collection efficiency   
-    real(kind=kind_phys) :: nssl_ehlw0     ! constant or max assumed hail-droplet collection efficiency   
+    real(kind=kind_phys) :: nssl_alphar    ! shape parameter for rain (imurain=1 only)
+    real(kind=kind_phys) :: nssl_ehw0      ! constant or max assumed graupel-droplet collection efficiency
+    real(kind=kind_phys) :: nssl_ehlw0     ! constant or max assumed hail-droplet collection efficiency
     logical              :: nssl_hail_on   !<  NSSL flag to activate the hail category
     logical              :: nssl_ccn_on    !<  NSSL flag to activate the CCN category
     logical              :: nssl_invertccn !<  NSSL flag to treat CCN as activated (true) or unactivated (false)
@@ -1040,7 +1040,7 @@ module GFS_typedefs
     integer              :: iopt_tbot !lower boundary of soil temperature (1->zero-flux; 2->noah)
     integer              :: iopt_stc  !snow/soil temperature time scheme (only layer 1)
     integer              :: iopt_trs  !thermal roughness scheme (1-z0h=z0m; 2-czil; 3-ec;4-kb inversed)
-    integer              :: iopt_diag !2m t/q diagnostic approach (1->external GFS sfc_diag 2->original NoahMP 2-title 3->NoahMP 
+    integer              :: iopt_diag !2m t/q diagnostic approach (1->external GFS sfc_diag 2->original NoahMP 2-title 3->NoahMP
                                       !2-title + internal GFS sfc_diag  )
 
     ! -- RUC LSM options
@@ -1146,7 +1146,7 @@ module GFS_typedefs
     integer              :: imfshalcnv_ntiedtke = 4 !< flag for new Tiedtke scheme (CAPS)
     integer              :: imfshalcnv_c3       = 5 !< flag for the Community Convective Cloud (C3) scheme
     logical              :: hwrf_samfdeep           !< flag for HWRF SAMF deepcnv scheme (HWRF)
-    logical              :: progsigma               !< flag for prognostic area fraction in samf ddepcnv scheme (GFS)   
+    logical              :: progsigma               !< flag for prognostic area fraction in samf ddepcnv scheme (GFS)
     integer              :: imfdeepcnv      !< flag for mass-flux deep convection scheme
                                             !<     1: July 2010 version of SAS conv scheme
                                             !<           current operational version as of 2016
@@ -1212,7 +1212,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: bl_mynn_closure    !< flag to determine closure level of MYNN
     logical              :: sfclay_compute_flux!< flag for thermal roughness lengths over water in mynnsfclay
     logical              :: sfclay_compute_diag!< flag for computing surface diagnostics in mynnsfclay
-    integer              :: isftcflx           !< flag for thermal roughness lengths over water in mynnsfclay 
+    integer              :: isftcflx           !< flag for thermal roughness lengths over water in mynnsfclay
     integer              :: iz0tlnd            !< flag for thermal roughness lengths over land in mynnsfclay
     real(kind=kind_phys) :: var_ric
     real(kind=kind_phys) :: coef_ric_l
@@ -1365,7 +1365,7 @@ module GFS_typedefs
     integer              :: spp_gwd
     integer              :: spp_cu_deep
     integer              :: n_var_spp
-    character(len=10)    , pointer :: spp_var_list(:) 
+    character(len=10)    , pointer :: spp_var_list(:)
     real(kind=kind_phys), pointer :: spp_prt_list(:)
     real(kind=kind_phys), pointer :: spp_stddev_cutoff(:)
 
@@ -1429,7 +1429,7 @@ module GFS_typedefs
     integer              :: ntgv            !< tracer index for graupel particle volume
     integer              :: nthv            !< tracer index for hail particle volume
     integer              :: ntke            !< tracer index for kinetic energy
-    integer              :: ntsigma         !< tracer index for updraft area fraction  
+    integer              :: ntsigma         !< tracer index for updraft area fraction
     integer              :: nto             !< tracer index for oxygen ion
     integer              :: nto2            !< tracer index for oxygen
     integer              :: ntwa            !< tracer index for water friendly aerosol
@@ -1942,7 +1942,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: zmtnblck(:)    => null()   !<mountain blocking level
 
     ! dtend/dtidxt: Multitudinous 3d tendencies in a 4D array: (i,k,1:100+ntrac,nprocess)
-    ! Sparse in outermost two dimensions. dtidx(1:100+ntrac,nprocess) maps to dtend 
+    ! Sparse in outermost two dimensions. dtidx(1:100+ntrac,nprocess) maps to dtend
     ! outer dimension index.
     real (kind=kind_phys), pointer :: dtend (:,:,:)  => null()   !< tracer changes due to physics
 
@@ -2867,6 +2867,8 @@ module GFS_typedefs
 !   endif
 
     if (Model%cplflx .or. Model%cpllnd) then
+      allocate (Coupling%dlwsfci_cpl (IM))
+      allocate (Coupling%dswsfci_cpl (IM))
       allocate (Coupling%dlwsfc_cpl  (IM))
       allocate (Coupling%dswsfc_cpl  (IM))
       allocate (Coupling%psurfi_cpl  (IM))
@@ -2881,6 +2883,8 @@ module GFS_typedefs
       allocate (Coupling%nvisbm_cpl  (IM))
       allocate (Coupling%nvisdf_cpl  (IM))
 
+      Coupling%dlwsfci_cpl  = clear_val
+      Coupling%dswsfci_cpl  = clear_val
       Coupling%dlwsfc_cpl  = clear_val
       Coupling%dswsfc_cpl  = clear_val
       Coupling%psurfi_cpl  = clear_val
@@ -2971,8 +2975,6 @@ module GFS_typedefs
       allocate (Coupling%dvsfci_cpl  (IM))
       allocate (Coupling%dtsfci_cpl  (IM))
       allocate (Coupling%dqsfci_cpl  (IM))
-      allocate (Coupling%dlwsfci_cpl (IM))
-      allocate (Coupling%dswsfci_cpl (IM))
       allocate (Coupling%dnirbmi_cpl (IM))
       allocate (Coupling%dnirdfi_cpl (IM))
       allocate (Coupling%dvisbmi_cpl (IM))
@@ -2987,8 +2989,6 @@ module GFS_typedefs
       Coupling%dvsfci_cpl  = clear_val
       Coupling%dtsfci_cpl  = clear_val
       Coupling%dqsfci_cpl  = clear_val
-      Coupling%dlwsfci_cpl = clear_val
-      Coupling%dswsfci_cpl = clear_val
       Coupling%dnirbmi_cpl = clear_val
       Coupling%dnirdfi_cpl = clear_val
       Coupling%dvisbmi_cpl = clear_val
@@ -3083,13 +3083,13 @@ module GFS_typedefs
       Coupling%skebu_wts = clear_val
       Coupling%skebv_wts = clear_val
     endif
-    
+
     !--- stochastic land perturbation option
     if (Model%lndp_type /= 0) then
       allocate (Coupling%sfc_wts  (IM,Model%n_var_lndp))
       Coupling%sfc_wts = clear_val
     endif
-    
+
     !--- stochastic spp perturbation option
     if (Model%do_spp) then
       allocate (Coupling%spp_wts_pbl  (IM,Model%levs))
@@ -3324,7 +3324,7 @@ module GFS_typedefs
     logical              :: swhtr             = .true.       !< flag to output sw heating rate (Radtend%swhc)
     integer              :: rad_hr_units      = 2            !< heating rate units are K s-1
     logical              :: inc_minor_gas     = .true.       !< Include minor trace gases in RRTMG radiation calculation
-    integer              :: ipsd0             = 0            !< initial permutaion seed for mcica radiation 
+    integer              :: ipsd0             = 0            !< initial permutaion seed for mcica radiation
     integer              :: ipsdlim           = 1e8          !< limit initial permutaion seed for mcica radiation
     logical              :: lrseeds           = .false.      !< flag to use host-provided random seeds
     integer              :: nrstreams         = 2            !< number of random number streams in host-provided random seed array
@@ -3339,7 +3339,7 @@ module GFS_typedefs
     character(len=128)   :: sw_file_gas         = ''         !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
     character(len=128)   :: sw_file_clouds      = ''         !< RRTMGP file containing coefficients used to compute clouds optical properties
     integer              :: rrtmgp_nBandsSW     = -999       !< Number of RRTMGP SW bands.             # *NOTE*
-    integer              :: rrtmgp_nGptsSW      = -999       !< Number of RRTMGP SW spectral points.   # The RRTMGP spectral dimensions in the files 
+    integer              :: rrtmgp_nGptsSW      = -999       !< Number of RRTMGP SW spectral points.   # The RRTMGP spectral dimensions in the files
     integer              :: rrtmgp_nBandsLW     = -999       !< Number of RRTMGP LW bands.             # need to be provided via namelsit.
     integer              :: rrtmgp_nGptsLW      = -999       !< Number of RRTMGP LW spectral points.   #
     logical              :: doG_cldoptics       = .false.    !< Use legacy RRTMG cloud-optics?
@@ -3358,7 +3358,7 @@ module GFS_typedefs
     logical              :: doGP_sgs_mynn       = .false.    !< If true, include SubGridScale MYNN-EDMF cloud in RRTMGP
     integer              :: rrtmgp_lw_phys_blksz= 1          !< Number of columns for RRTMGP LW scheme to process at each instance.
     integer              :: rrtmgp_sw_phys_blksz= 1          !< Number of columns for RRTMGP SW scheme to process at each instance.
-    logical              :: doGP_smearclds      = .true.     !< If true, include implicit SubGridScale clouds in RRTMGP 
+    logical              :: doGP_smearclds      = .true.     !< If true, include implicit SubGridScale clouds in RRTMGP
 !--- Z-C microphysical parameters
     integer              :: imp_physics       =  99                !< choice of cloud scheme
     real(kind=kind_phys) :: psautco(2)        = (/6.0d-4,3.0d-4/)  !< [in] auto conversion coeff from ice to snow
@@ -3411,9 +3411,9 @@ module GFS_typedefs
     real(kind=kind_phys) :: nssl_cccn       = 0.6e9             !<  CCN concentration (m-3)
     real(kind=kind_phys) :: nssl_alphah     = 0.0               !<  graupel shape parameter
     real(kind=kind_phys) :: nssl_alphahl    = 1.0               !<  hail shape parameter
-    real(kind=kind_phys) :: nssl_alphar     = 0.0               ! shape parameter for rain (imurain=1 only)  
-    real(kind=kind_phys) :: nssl_ehw0       = 0.9               ! constant or max assumed graupel-droplet collection efficiency  
-    real(kind=kind_phys) :: nssl_ehlw0      = 0.9               ! constant or max assumed hail-droplet collection efficiency  
+    real(kind=kind_phys) :: nssl_alphar     = 0.0               ! shape parameter for rain (imurain=1 only)
+    real(kind=kind_phys) :: nssl_ehw0       = 0.9               ! constant or max assumed graupel-droplet collection efficiency
+    real(kind=kind_phys) :: nssl_ehlw0      = 0.9               ! constant or max assumed hail-droplet collection efficiency
     logical              :: nssl_hail_on    = .false.           !<  NSSL flag to activate the hail category
     logical              :: nssl_ccn_on     = .true.            !<  NSSL flag to activate the CCN category
     logical              :: nssl_invertccn  = .true.            !<  NSSL flag to treat CCN as activated (true) or unactivated (false)
@@ -3425,7 +3425,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: nsfullradar_diag  = -999.0          !< seconds between resetting radar reflectivity calculation, set to <0 for every time step
     real(kind=kind_phys) :: ttendlim       = -999.0             !< temperature tendency limiter, set to <0 to deactivate
     logical              :: ext_diag_thompson = .false.         !< flag for extended diagnostic output from Thompson
-    real(kind=kind_phys) :: dt_inner       = -999.0             !< time step for the inner loop 
+    real(kind=kind_phys) :: dt_inner       = -999.0             !< time step for the inner loop
     logical              :: sedi_semi      = .false.            !< flag for semi Lagrangian sedi of rain
     integer              :: decfl          = 8                  !< deformed CFL factor
 
@@ -3710,7 +3710,7 @@ module GFS_typedefs
     logical              :: thsfc_loc      = .true.          !< flag for local vs. standard potential temperature
 !--- flux method in 2-m diagnostics
     logical              :: diag_flux      = .false.         !< flag for flux method in 2-m diagnostics
-!--- flux method in 2-m diagnostics (for stable conditions) 
+!--- flux method in 2-m diagnostics (for stable conditions)
     logical              :: diag_log       = .false.         !< flag for log method in 2-m diagnostics (for stable conditions)
                                                              !<.true. means use local (gridpoint) surface pressure to define potential temperature
                                                              !<       this is the current GFS physics approach
@@ -3739,7 +3739,7 @@ module GFS_typedefs
     integer              :: nca            = 1
     integer              :: ncells         = 5
     integer              :: nlives         = 12
-    
+
     integer              :: nca_g          = 1
     integer              :: ncells_g       = 1
     integer              :: nlives_g       = 100
@@ -3840,7 +3840,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: radar_tten_limits(2) = (/ limit_unspecified, limit_unspecified /)
     integer :: itime
     integer :: w3kindreal,w3kindint
-    
+
 !--- END NAMELIST VARIABLES
 
     NAMELIST /gfs_physics_nml/                                                              &
@@ -4503,7 +4503,7 @@ module GFS_typedefs
       stop
     end if
     Model%lradar           = lradar
-    Model%nsfullradar_diag = nsfullradar_diag 
+    Model%nsfullradar_diag = nsfullradar_diag
     Model%ttendlim         = ttendlim
     Model%ext_diag_thompson= ext_diag_thompson
     if (dt_inner>0) then
@@ -4618,7 +4618,7 @@ module GFS_typedefs
       (Model%imp_physics /= Model%imp_physics_gfdl .and. Model%imp_physics /= Model%imp_physics_thompson .and. &
        Model%imp_physics /= Model%imp_physics_nssl )) then
       !see GFS_MP_generic_post.F90; exticeden is only compatible with GFDL,
-      !Thompson, or NSSL MP 
+      !Thompson, or NSSL MP
       print *,' Using exticeden = T is only valid when using GFDL, Thompson, or NSSL microphysics.'
       stop
     end if
@@ -4909,7 +4909,7 @@ module GFS_typedefs
       Model%lndp_var_list(:) = ''
       Model%lndp_prt_list(:) = clear_val
     end if
-    
+
     if (Model%do_spp) then
       allocate(Model%spp_var_list(Model%n_var_spp))
       allocate(Model%spp_prt_list(Model%n_var_spp))
@@ -4924,7 +4924,7 @@ module GFS_typedefs
     allocate(Model%vfact_ca(levs))
     if ( .not. ca_global ) nca_g=0
     if ( .not. ca_sgs ) nca=0
-     
+
     Model%nca              = nca
     Model%ncells           = ncells
     Model%nlives           = nlives
@@ -4976,7 +4976,7 @@ module GFS_typedefs
 #else
     Model%ntoz             = get_tracer_index(Model%tracer_names, 'o3mr',       Model%me, Model%master, Model%debug)
     if( Model%ntoz <= 0 )  &
-    Model%ntoz             =  get_tracer_index(Model%tracer_names, 'spo3',       Model%me, Model%master, Model%debug)  
+    Model%ntoz             =  get_tracer_index(Model%tracer_names, 'spo3',       Model%me, Model%master, Model%debug)
 #endif
     Model%ntcw             = get_tracer_index(Model%tracer_names, 'liq_wat',    Model%me, Model%master, Model%debug)
     Model%ntiw             = get_tracer_index(Model%tracer_names, 'ice_wat',    Model%me, Model%master, Model%debug)
@@ -5273,7 +5273,7 @@ module GFS_typedefs
           call fill_dtidx(Model,dtend_select,100+Model%ntoz,Model%index_of_process_photochem,have_oz_phys)
           call fill_dtidx(Model,dtend_select,100+Model%ntoz,Model%index_of_process_physics,.true.)
           call fill_dtidx(Model,dtend_select,100+Model%ntoz,Model%index_of_process_non_physics,.true.)
-          
+
           if(.not.Model%do_mynnedmf .and. .not. Model%satmedmf) then
             call fill_dtidx(Model,dtend_select,100+Model%ntqv,Model%index_of_process_pbl,have_pbl)
             call fill_dtidx(Model,dtend_select,100+Model%ntcw,Model%index_of_process_pbl,have_pbl)
@@ -5331,9 +5331,9 @@ module GFS_typedefs
             write(*,*) 'NSSL micro: CCNA is ON'
           ENDIF
         ENDIF
-    
+
       if (Model%me == Model%master) then
-        write(*,*) 'Model%nthl = ',Model%nthl 
+        write(*,*) 'Model%nthl = ',Model%nthl
       ENDIF
       IF ( ( Model%nthl < 1 ) ) THEN ! check if hail is in the field_table. If not, set flag so the microphysics knows.
         if (Model%me == Model%master) then
@@ -5343,9 +5343,9 @@ module GFS_typedefs
         nssl_hail_on = .false.
         Model%nssl_hail_on = .false.
         ! pretend that hail exists so that bad arrays are not passed to microphysics
-!         Model%nthl =  Max( 1, Model%ntgl ) 
-!         Model%nthv =  Max( 1, Model%ntgv ) 
-!         Model%nthnc = Max( 1, Model%ntgnc ) 
+!         Model%nthl =  Max( 1, Model%ntgl )
+!         Model%nthv =  Max( 1, Model%ntgv )
+!         Model%nthnc = Max( 1, Model%ntgnc )
       ELSE
         nssl_hail_on = .true.
         Model%nssl_hail_on = .true.
@@ -5378,16 +5378,16 @@ module GFS_typedefs
         ENDIF
       ENDIF
 
-        IF ( Model%ntgl < 1 .or. Model%ntgv < 1 .or. Model%ntgnc < 1 .or. & 
-             Model%ntsw < 1 .or. Model%ntsnc < 1 .or. & 
-             Model%ntrw < 1 .or. Model%ntrnc < 1 .or. & 
-             Model%ntiw < 1 .or. Model%ntinc < 1 .or. & 
-             Model%ntcw < 1 .or. Model%ntlnc < 1      & 
+        IF ( Model%ntgl < 1 .or. Model%ntgv < 1 .or. Model%ntgnc < 1 .or. &
+             Model%ntsw < 1 .or. Model%ntsnc < 1 .or. &
+             Model%ntrw < 1 .or. Model%ntrnc < 1 .or. &
+             Model%ntiw < 1 .or. Model%ntinc < 1 .or. &
+             Model%ntcw < 1 .or. Model%ntlnc < 1      &
              ) THEN
           if (Model%me == Model%master)  write(0,*) 'missing needed tracers for NSSL!'
            stop
         ENDIF
-        
+
 
     ENDIF !}
 
@@ -5858,7 +5858,7 @@ module GFS_typedefs
       Model%nleffr = 1
       Model%nieffr = 2
       Model%nseffr = 3
-      Model%nreffr = 4 
+      Model%nreffr = 4
       Model%lradar = .true.
       if (.not. Model%effr_in) then
         print *,' NSSL MP requires effr_in to be set to .true., changing value from false to true'
@@ -5896,7 +5896,7 @@ module GFS_typedefs
                                           ' ttendlim =',Model%ttendlim, &
                                           ' ext_diag_thompson =',Model%ext_diag_thompson, &
                                           ' dt_inner =',Model%dt_inner, &
-                                          ' sedi_semi=',Model%sedi_semi, & 
+                                          ' sedi_semi=',Model%sedi_semi, &
                                           ' decfl=',decfl, &
                                           ' effr_in =',Model%effr_in, &
                                           ' lradar =',Model%lradar, &
@@ -6063,7 +6063,7 @@ module GFS_typedefs
 
     ! Helper subroutine for initializing variables for radar-derived
     ! temperature tendency or convection suppression.
-    
+
     class(GFS_control_type) :: Model
     real(kind_phys) :: radar_tten_limits(2)
     integer :: i
@@ -6237,7 +6237,7 @@ module GFS_typedefs
 
 !--- local variables
     integer :: i
-    
+
     if (Model%me == Model%master) then
       print *, ' '
       print *, 'basic control parameters'
@@ -6442,8 +6442,8 @@ module GFS_typedefs
         print *, ' nssl_alphah - graupel shape parameter : ', Model%nssl_alphah
         print *, ' nssl_alphahl - hail shape parameter   : ', Model%nssl_alphahl
         print *, ' nssl_alphar - rain shape parameter : ', Model%nssl_alphar
-        print *, ' nssl_ehw0 - graupel-droplet collection effiency : ', Model%nssl_ehw0 
-        print *, ' nssl_ehlw0 - hail-droplet collection effiency : ', Model%nssl_ehlw0                              
+        print *, ' nssl_ehw0 - graupel-droplet collection effiency : ', Model%nssl_ehw0
+        print *, ' nssl_ehlw0 - hail-droplet collection effiency : ', Model%nssl_ehlw0
         print *, ' nssl_hail_on - hail activation flag   : ', Model%nssl_hail_on
         print *, ' lradar - radar refl. flag             : ', Model%lradar
         print *, ' lrefres                : ', Model%lrefres
@@ -7341,14 +7341,14 @@ module GFS_typedefs
     implicit none
     type(GFS_control_type), intent(inout) :: Model
     integer :: i
-    
+
     allocate(Model%dtend_var_labels(Model%ntracp100))
     allocate(Model%dtend_process_labels(Model%nprocess))
-    
+
     Model%dtend_var_labels(1)%name = 'unallocated'
     Model%dtend_var_labels(1)%desc = 'unallocated tracer'
     Model%dtend_var_labels(1)%unit = 'kg kg-1 s-1'
-    
+
     do i=2,Model%ntracp100
        Model%dtend_var_labels(i)%name = 'unknown'
        Model%dtend_var_labels(i)%desc = 'unspecified tracer'
@@ -7361,24 +7361,24 @@ module GFS_typedefs
        Model%dtend_process_labels(i)%mod_name = 'gfs_phys'
     enddo
   end subroutine allocate_dtend_labels_and_causes
-    
+
   subroutine label_dtend_tracer(Model,itrac,name,desc,unit)
     implicit none
     type(GFS_control_type), intent(inout) :: Model
     integer, intent(in) :: itrac
     character(len=*), intent(in) :: name, desc
     character(len=*), intent(in) :: unit
-    
+
     if(itrac<2) then
        ! Special index 1 is for unallocated tracers
        return
     endif
-    
+
     Model%dtend_var_labels(itrac)%name = name
     Model%dtend_var_labels(itrac)%desc = desc
     Model%dtend_var_labels(itrac)%unit = unit
   end subroutine label_dtend_tracer
-  
+
   subroutine label_dtend_cause(Model,icause,name,desc,mod_name,time_avg)
     implicit none
     type(GFS_control_type), intent(inout) :: Model
@@ -7386,7 +7386,7 @@ module GFS_typedefs
     character(len=*), intent(in) :: name, desc
     character(len=*), optional, intent(in) :: mod_name
     logical, optional, intent(in) :: time_avg
-      
+
     Model%dtend_process_labels(icause)%name=name
     Model%dtend_process_labels(icause)%desc=desc
     if(present(mod_name)) then
@@ -7770,7 +7770,7 @@ module GFS_typedefs
     Diag%evcw       = zero
     Diag%trans      = zero
     Diag%snowmt_land= zero
-    Diag%snowmt_ice = zero 
+    Diag%snowmt_ice = zero
     Diag%soilm      = zero
     Diag%tmpmin     = Model%huge
     Diag%tmpmax     = zero

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -2541,7 +2541,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_surface_flux_coupling)
+  active = (flag_for_surface_flux_coupling .or. flag_for_land_coupling)
 [dswsfci_cpl]
   standard_name = surface_downwelling_shortwave_flux_for_coupling
   long_name = instantaneous sfc downward sw flux
@@ -2549,7 +2549,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_surface_flux_coupling)
+  active = (flag_for_surface_flux_coupling .or. flag_for_land_coupling)
 [dnirbmi_cpl]
   standard_name = surface_downwelling_direct_nir_shortwave_flux_for_coupling
   long_name = instantaneous sfc nir beam downward sw flux
@@ -2845,7 +2845,7 @@
   kind = kind_phys
   active = (do_stochastically_perturbed_parameterizations)
 [spp_wts_sfc]
-  standard_name = spp_weights_for_surface_layer_scheme 
+  standard_name = spp_weights_for_surface_layer_scheme
   long_name = spp weights for surface layer scheme
   units = 1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
@@ -2854,7 +2854,7 @@
   active = (do_stochastically_perturbed_parameterizations)
 [spp_wts_mp]
   standard_name = spp_weights_for_microphysics_scheme
-  long_name = spp weights for microphysics scheme 
+  long_name = spp weights for microphysics scheme
   units = 1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -2862,7 +2862,7 @@
   active = (do_stochastically_perturbed_parameterizations)
 [spp_wts_gwd]
   standard_name = spp_weights_for_gravity_wave_drag_scheme
-  long_name = spp weights for gravity wave drag scheme 
+  long_name = spp weights for gravity wave drag scheme
   units = 1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -2870,7 +2870,7 @@
   active = (do_stochastically_perturbed_parameterizations)
 [spp_wts_rad]
   standard_name = spp_weights_for_radiation_scheme
-  long_name = spp weights for radiation scheme 
+  long_name = spp weights for radiation scheme
   units = 1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -3672,7 +3672,7 @@
   type = integer
 [inc_minor_gas]
   standard_name = flag_to_include_minor_gases_in_rrtmg
-  long_name = flag to include minor trace gases in rrtmg 
+  long_name = flag to include minor trace gases in rrtmg
   units = flag
   dimensions = ()
   type = logical
@@ -6283,7 +6283,7 @@
   type = integer
 [ntbcl]
   standard_name = index_for_bcphilic
-  long_name = index for bcphilic 
+  long_name = index for bcphilic
   units = index
   dimensions = ()
   type = integer
@@ -6295,7 +6295,7 @@
   type = integer
 [ntocl]
   standard_name = index_for_ocphilic
-  long_name = index for ocphilic 
+  long_name = index for ocphilic
   units = index
   dimensions = ()
   type = integer

--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -298,7 +298,7 @@ module fv3atm_cap_mod
 
     noutput_fh = ESMF_ConfigGetLen(config=CF, label ='output_fh:',rc=rc)
 
-    if(mype == 0) print *,'af nems config,quilting=',quilting,' calendar=', trim(calendar),' iau_offset=',iau_offset, &
+    if(mype == 0) print *,'af ufs config,quilting=',quilting,' calendar=', trim(calendar),' iau_offset=',iau_offset, &
       ' noutput_fh=',noutput_fh
 !
     nfhout = 0 ; nfhmax_hf = 0 ; nfhout_hf = 0 ; nsout = 0
@@ -320,7 +320,7 @@ module fv3atm_cap_mod
                                    label ='isrcTermProcessing:',rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-      if(mype == 0) print *,'af nems config,quilting=',quilting,' write_groups=', &
+      if(mype == 0) print *,'af ufs config,quilting=',quilting,' write_groups=', &
         write_groups,wrttasks_per_group_from_parent,' isrcTermProcessing=', isrcTermProcessing
 !
       call ESMF_ConfigGetAttribute(config=CF,value=num_files, &
@@ -341,7 +341,7 @@ module fv3atm_cap_mod
       call ESMF_ConfigGetAttribute(config=CF, value=nsout,    label ='nsout:',    default=-1,rc=rc)
       nsout_io = nsout
 !
-      if(mype==0) print *,'af nems config,nfhout,nsout=',nfhout,nfhmax_hf,nfhout_hf, nsout,noutput_fh
+      if(mype==0) print *,'af ufs config,nfhout,nsout=',nfhout,nfhmax_hf,nfhout_hf, nsout,noutput_fh
 
       call ESMF_ConfigGetAttribute(config=CF, value=time_unlimited, label ='time_unlimited:', default=.false., rc=rc)
 
@@ -349,7 +349,7 @@ module fv3atm_cap_mod
 !
     call ESMF_ConfigGetAttribute(config=CF, value=dt_atmos, label ='dt_atmos:',   rc=rc)
     call ESMF_ConfigGetAttribute(config=CF, value=nfhmax,   label ='nhours_fcst:',rc=rc)
-    if(mype == 0) print *,'af nems config,dt_atmos=',dt_atmos,'nfhmax=',nfhmax
+    if(mype == 0) print *,'af ufs config,dt_atmos=',dt_atmos,'nfhmax=',nfhmax
 
     call ESMF_TimeIntervalSet(timeStep, s=dt_atmos, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -606,14 +606,14 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 
     num_restart_interval = ESMF_ConfigGetLen(config=CF, label ='restart_interval:',rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-    if (mype == 0) print *,'af nems config,num_restart_interval=',num_restart_interval
+    if (mype == 0) print *,'af ufs config,num_restart_interval=',num_restart_interval
     if (num_restart_interval<=0) num_restart_interval = 1
     allocate(restart_interval(num_restart_interval))
     restart_interval = 0
     call ESMF_ConfigGetAttribute(CF,valueList=restart_interval,label='restart_interval:', &
                                  count=num_restart_interval, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-    if (mype == 0) print *,'af nems config,restart_interval=',restart_interval
+    if (mype == 0) print *,'af ufs config,restart_interval=',restart_interval
 !
     call fms_init(fcst_mpi_comm)
     call mpp_init()


### PR DESCRIPTION
## Description

Moves the export fields ``dlwsfci_cpl`` and ``dswsfci_cpl`` inside the ``cpllnd`` block.


### Issue(s) addressed

- fixes #710 
- required by ufs-community/ufs-weather-model/issues/1800


## Testing

Baseslines for UWM are B4B. See logs posted at https://github.com/ufs-community/ufs-weather-model/pull/1947

## Dependencies

- waiting on https://github.com/ufs-community/ccpp-physics/pull/118
