### PR TITLE
Convective Reflectivity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics
-  hash = c0aa212dbc255ac5d77934c3cd6283c994bbfd99
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/ericaligo-NOAA/ccpp-physics
+  branch = feature/refconv
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = ufs/dev
-  url = https://github.com/ericaligo-NOAA/ccpp-physics
-  branch = feature/refconv
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  hash = c0aa212dbc255ac5d77934c3cd6283c994bbfd99
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

@RuiyuSun and I compute convective reflectivity for Thompson or NSSL microphysics and with GF deep, shallow or SAS deep convection. I removed the calculation that was in cu_gf_driver_post.F90 and cu_gf_driver_post.meta, and associated parameters, and added the code to GFS_MP_generic_post.F90.  The 3D refl_10cm array will be changed. In the process of creating a new baseline. I had to modify regional.nml.IN and change imfhalcnv and imfdeepconv from 2 to -1 otherwise the code would try to calculate convective reflectivity despite no calls for deep/shallow convection.

[RegressionTests_hera.log](https://github.com/NOAA-EMC/fv3atm/files/13420642/RegressionTests_hera.log)
[RegressionTests_hera_newbaseline.log](https://github.com/NOAA-EMC/fv3atm/files/13420643/RegressionTests_hera_newbaseline.log)



### Issue(s) addressed
https://github.com/ufs-community/ufs-weather-model/issues/1968
https://github.com/NOAA-EMC/fv3atm/issues/716
https://github.com/ufs-community/ccpp-physics/issues/123

## Testing

Tested initially in the RRFS configuration on hera.
RTs run on orion with intel compiler.

Since refl_10cm will change, running new baseline on orion. 

## Dependencies

None