### PR TITLE
Create 'coupler.res' log file in write grid comp. Explicitly specify chunk sizes in restart files 

### DIFF
--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -68,7 +68,7 @@
       integer,save      :: ngrids
 
       integer,save      :: wrt_mpi_comm                                   !<-- the mpi communicator in the write comp
-      integer,save      :: idate(7)
+      integer,save      :: idate(7), start_time(7)
       logical,save      :: write_nsflip
       logical,save      :: change_wrtidate=.false.
       integer,save      :: frestart(999) = -1
@@ -841,6 +841,7 @@
                                                         h=idate(4), m=idate(5), s=idate(6),rc=rc)
 !     if (lprnt) write(0,*) 'in wrt initial, io_baseline time=',idate,'rc=',rc
       idate(7) = 1
+      start_time = idate
       wrt_int_state%idate = idate
       wrt_int_state%fdate = idate
 ! update IO-BASETIME and idate on write grid comp when IAU is enabled
@@ -2450,7 +2451,7 @@
             open(newunit=nolog, file='RESTART/'//trim(time_restart)//'.coupler.res', status='new')
             write(nolog,"(i6,8x,a)") calendar_type , &
                  '(Calendar: no_calendar=0, thirty_day_months=1, julian=2, gregorian=3, noleap=4)'
-            write(nolog,"(6i6,8x,a)") wrt_int_state%idate(1:6), &
+            write(nolog,"(6i6,8x,a)") start_time(1:6), &
                  'Model start time:   year, month, day, hour, minute, second'
             write(nolog,"(6i6,8x,a)") wrt_int_state%fdate(1:6), &
                  'Current model time: year, month, day, hour, minute, second'

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -1366,8 +1366,8 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
           call atmos_model_restart(Atmos, timestamp)
           call write_stoch_restart_atm('RESTART/'//trim(timestamp)//'.atm_stoch.res.nc')
 
-          !----- write restart file ------
-          if (mpp_pe() == mpp_root_pe())then
+          !----- write coupler.res file ------
+          if (.not. quilting_restart .and. mpp_pe() == mpp_root_pe()) then
               call get_date (Atmos%Time, date(1), date(2), date(3), date(4), date(5), date(6))
               open( newunit=unit, file='RESTART/'//trim(timestamp)//'.coupler.res' )
               write( unit, '(i6,8x,a)' )calendar_type, &

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -921,11 +921,11 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 ! Add time Attribute to the exportState
       call ESMF_AttributeAdd(exportState, convention="NetCDF", purpose="FV3", &
         attrList=(/ "time               ", &
-                      "time:long_name     ", &
-                      "time:units         ", &
-                      "time:cartesian_axis", &
-                      "time:calendar_type ", &
-                      "time:calendar      " /), rc=rc)
+                    "time:long_name     ", &
+                    "time:units         ", &
+                    "time:cartesian_axis", &
+                    "time:calendar_type ", &
+                    "time:calendar      " /), rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
       call ESMF_AttributeSet(exportState, convention="NetCDF", purpose="FV3", &


### PR DESCRIPTION
## Description

When the restart files are written by the write grid component, the log file (coupler.res) must also be written by write grid comp to ensure that it is written after all other restart files have already be created.

The chunk sizes are now explicitly specified in restart file when quilting_restart is used, and are equal to the Nx x Ny in horizontal and 1 in all other dimensions.

No changes in baselines are expected.

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes https://github.com/ufs-community/ufs-weather-model/issues/2020



## Testing

How were these changes tested?  Regression test.
What compilers / HPCs was it tested with?  Intel/GNU on Hera
Are the changes covered by regression tests? Yes.  
Have the ufs-weather-model regression test been run? Yes.
On what platform?  Hera.

- Will the code updates change regression test baseline? No
- Please commit the regression test log files in your ufs-weather-model branch. Hera log file will be added to ufs-weather-model PR