### PR TITLE
Remove nfhout, nfhmax_hf, nfhout_hf etc configuration parameters

### DIFF
--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -101,7 +101,7 @@ use fv3atm_restart_io_mod,    only: fv3atm_restart_register, &
 use fv_ufs_restart_io_mod,    only: fv_dyn_restart_register, &
                                     fv_dyn_restart_output
 use fv_iau_mod,         only: iau_external_data_type,getiauforcing,iau_initialize
-use module_fv3_config,  only: first_kdt, nsout, output_fh,               &
+use module_fv3_config,  only: first_kdt, output_fh,                      &
                               fcst_mpi_comm, fcst_ntasks,                &
                               quilting_restart
 use module_block_data,  only: block_atmos_copy, block_data_copy,         &
@@ -976,7 +976,7 @@ subroutine update_atmos_model_state (Atmos, rc)
     call get_time (Atmos%Time - diag_time, isec)
     call get_time (Atmos%Time - Atmos%Time_init, seconds)
     call atmosphere_nggps_diag(Atmos%Time,ltavg=.true.,avg_max_length=avg_max_length)
-    if (ANY(nint(output_fh(:)*3600.0) == seconds) .or. (GFS_control%kdt == first_kdt) .or. nsout > 0) then
+    if (ANY(nint(output_fh(:)*3600.0) == seconds) .or. (GFS_control%kdt == first_kdt)) then
       if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds
       time_int = real(isec)
       if(Atmos%iau_offset > zero) then

--- a/io/module_fv3_io_def.F90
+++ b/io/module_fv3_io_def.F90
@@ -15,7 +15,7 @@ module module_fv3_io_def
   integer           :: n_group
   integer           :: num_files
   integer           :: nbdlphys
-  integer           :: nsout_io, iau_offset
+  integer           :: iau_offset
   logical           :: lflname_fulltime
   logical           :: time_unlimited
 

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -38,7 +38,6 @@
                                       imo,jmo,ichunk2d,jchunk2d,                &
                                       ichunk3d,jchunk3d,kchunk3d,               &
                                       quantize_mode,quantize_nsd,               &
-                                      nsout => nsout_io,                        &
                                       cen_lon, cen_lat,                         &
                                       lon1, lat1, lon2, lat2, dlon, dlat,       &
                                       stdlat1, stdlat2, dx, dy, iau_offset,     &
@@ -1876,7 +1875,7 @@
 
       if (nf_hours < 0) return
 
-      if (nsout > 0 .or. lflname_fulltime) then
+      if (lflname_fulltime) then
         ndig = max(log10(nf_hours+0.5)+1., 3.)
         write(cform, '("(I",I1,".",I1,",A1,I2.2,A1,I2.2)")') ndig, ndig
         write(cfhour, cform) nf_hours,'-',nf_minutes,'-',nf_seconds

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -2447,7 +2447,7 @@
 
           if (out_phase == 2 .and. restart_written .and. mype == lead_write_task) then
             !**  write coupler.res log file
-            open(newunit=nolog, file='RESTART/'//trim(time_restart)//'.coupler.res', status='new')
+            open(newunit=nolog, file='RESTART/'//trim(time_restart)//'.coupler.res')
             write(nolog,"(i6,8x,a)") calendar_type , &
                  '(Calendar: no_calendar=0, thirty_day_months=1, julian=2, gregorian=3, noleap=4)'
             write(nolog,"(6i6,8x,a)") start_time(1:6), &

--- a/module_fv3_config.F90
+++ b/module_fv3_config.F90
@@ -13,7 +13,7 @@
 
   implicit none
 !
-  integer                  :: nfhout, nfhout_hf, nsout, dt_atmos
+  integer                  :: dt_atmos
   integer                  :: first_kdt
   integer                  :: fcst_mpi_comm, fcst_ntasks
 !


### PR DESCRIPTION
## Description

Remove nfhout, nfhmax_hf, nfhout_hf and nsout model_configure parameters. The 'output_fh" is now used to control frequency of the history outputs.

No change of answers.


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #731


## Testing

How were these changes tested?  Regression test.
What compilers / HPCs was it tested with?  Intel and GNU on Hera
Are the changes covered by regression tests? Yes.  
Have the ufs-weather-model regression test been run? Yes.
On what platform? Hera  
Will the code updates change regression test baseline? No.

## Dependencies

N/A