### PR TITLE
 bug fix: disable concurrency in GFS_phys_time_vary_init NetCDF calls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
+  branch = init-concurrency-bug
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
-  branch = init-concurrency-bug
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -101,7 +101,7 @@ use fv3atm_restart_io_mod,    only: fv3atm_restart_register, &
 use fv_ufs_restart_io_mod,    only: fv_dyn_restart_register, &
                                     fv_dyn_restart_output
 use fv_iau_mod,         only: iau_external_data_type,getiauforcing,iau_initialize
-use module_fv3_config,  only: first_kdt, nsout, output_fh,               &
+use module_fv3_config,  only: first_kdt, output_fh,                      &
                               fcst_mpi_comm, fcst_ntasks,                &
                               quilting_restart
 use module_block_data,  only: block_atmos_copy, block_data_copy,         &
@@ -976,7 +976,7 @@ subroutine update_atmos_model_state (Atmos, rc)
     call get_time (Atmos%Time - diag_time, isec)
     call get_time (Atmos%Time - Atmos%Time_init, seconds)
     call atmosphere_nggps_diag(Atmos%Time,ltavg=.true.,avg_max_length=avg_max_length)
-    if (ANY(nint(output_fh(:)*3600.0) == seconds) .or. (GFS_control%kdt == first_kdt) .or. nsout > 0) then
+    if (ANY(nint(output_fh(:)*3600.0) == seconds) .or. (GFS_control%kdt == first_kdt)) then
       if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds
       time_int = real(isec)
       if(Atmos%iau_offset > zero) then

--- a/io/module_fv3_io_def.F90
+++ b/io/module_fv3_io_def.F90
@@ -15,7 +15,7 @@ module module_fv3_io_def
   integer           :: n_group
   integer           :: num_files
   integer           :: nbdlphys
-  integer           :: nsout_io, iau_offset
+  integer           :: iau_offset
   logical           :: lflname_fulltime
   logical           :: time_unlimited
 

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -38,7 +38,6 @@
                                       imo,jmo,ichunk2d,jchunk2d,                &
                                       ichunk3d,jchunk3d,kchunk3d,               &
                                       quantize_mode,quantize_nsd,               &
-                                      nsout => nsout_io,                        &
                                       cen_lon, cen_lat,                         &
                                       lon1, lat1, lon2, lat2, dlon, dlat,       &
                                       stdlat1, stdlat2, dx, dy, iau_offset,     &
@@ -1876,7 +1875,7 @@
 
       if (nf_hours < 0) return
 
-      if (nsout > 0 .or. lflname_fulltime) then
+      if (lflname_fulltime) then
         ndig = max(log10(nf_hours+0.5)+1., 3.)
         write(cform, '("(I",I1,".",I1,",A1,I2.2,A1,I2.2)")') ndig, ndig
         write(cfhour, cform) nf_hours,'-',nf_minutes,'-',nf_seconds

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -2447,7 +2447,7 @@
 
           if (out_phase == 2 .and. restart_written .and. mype == lead_write_task) then
             !**  write coupler.res log file
-            open(newunit=nolog, file='RESTART/'//trim(time_restart)//'.coupler.res', status='new')
+            open(newunit=nolog, file='RESTART/'//trim(time_restart)//'.coupler.res')
             write(nolog,"(i6,8x,a)") calendar_type , &
                  '(Calendar: no_calendar=0, thirty_day_months=1, julian=2, gregorian=3, noleap=4)'
             write(nolog,"(6i6,8x,a)") start_time(1:6), &

--- a/module_fv3_config.F90
+++ b/module_fv3_config.F90
@@ -13,7 +13,7 @@
 
   implicit none
 !
-  integer                  :: nfhout, nfhout_hf, nsout, dt_atmos
+  integer                  :: dt_atmos
   integer                  :: first_kdt
   integer                  :: fcst_mpi_comm, fcst_ntasks
 !


### PR DESCRIPTION
## Description
Occasionally, the model will fail in GFS_phys_time_vary.fv3.F90 during the first physics timestep. This is caused by heap corruption earlier, during gfs_phys_time_vary_init. After much debugging, I tracked down the problem.

The NetCDF library is not thread-safe:

- https://docs.unidata.ucar.edu/netcdf-c/current/faq.html#Are-the-netCDF-libraries-thread-safe
> The C-based libraries are not thread-safe. C-based libraries are those that depend on the C library, which currently include all language interfaces except for the Java interface

We're calling a non-thread-safe library in a threaded region. There are multiple NetCDF calls going concurrently. The fix is  to read the NetCDF files one at a time.

### Issue(s) addressed

- fixes https://github.com/ufs-community/ccpp-physics/issues/136

## Testing

#### How were these changes tested?  

A failing C768 test case on Hera.
Also, running the regression tests on Hera.

#### What compilers / HPCs was it tested with?  

Intel Hera.

GNU tests on Hera led to network errors at large node counts. This is an unrelated issue. Most likely, it is caused by choosing buggy libraries in Spack Stack.

#### Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  

Testing this requires running a gigantic test. A hundred fifty nodes at least. It isn't feasible to put that in the regression tests.

#### Have the ufs-weather-model regression test been run? On what platform?  

NOAA Hera.

#### Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.

No.

#### Please commit the regression test log files in your ufs-weather-model branch

Yes.

## Dependencies

- waiting on https://github.com/ufs-community/ccpp-physics/pull/138
