### PR TITLE
fix crash when using clm lake and GFS PBL/sfclay

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/JiliDong-NOAA/ccpp-physics 
+  branch = clm_lake_ice_fix 
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/CCPP_typedefs.F90
+++ b/ccpp/data/CCPP_typedefs.F90
@@ -140,7 +140,7 @@ module CCPP_typedefs
     logical,               pointer      :: flag_cice(:)       => null()  !<
     logical,               pointer      :: flag_guess(:)      => null()  !<
     logical,               pointer      :: flag_iter(:)       => null()  !<
-    logical,               pointer      :: lake_freeze(:)     => null()  !<
+    logical,               pointer      :: flag_lakefreeze(:) => null()  !<
     real (kind=kind_phys), pointer      :: ffmm_ice(:)        => null()  !<
     real (kind=kind_phys), pointer      :: ffmm_land(:)       => null()  !<
     real (kind=kind_phys), pointer      :: ffmm_water(:)      => null()  !<
@@ -608,7 +608,7 @@ contains
     allocate (Interstitial%flag_cice       (IM))
     allocate (Interstitial%flag_guess      (IM))
     allocate (Interstitial%flag_iter       (IM))
-    allocate (Interstitial%lake_freeze     (IM))
+    allocate (Interstitial%flag_lakefreeze (IM))
     allocate (Interstitial%ffmm_ice        (IM))
     allocate (Interstitial%ffmm_land       (IM))
     allocate (Interstitial%ffmm_water      (IM))
@@ -1299,7 +1299,7 @@ contains
     Interstitial%flag_cice       = .false.
     Interstitial%flag_guess      = .false.
     Interstitial%flag_iter       = .true.
-    Interstitial%lake_freeze     = .false.
+    Interstitial%flag_lakefreeze = .false.
     Interstitial%ffmm_ice        = Model%huge
     Interstitial%ffmm_land       = Model%huge
     Interstitial%ffmm_water      = Model%huge

--- a/ccpp/data/CCPP_typedefs.F90
+++ b/ccpp/data/CCPP_typedefs.F90
@@ -140,6 +140,7 @@ module CCPP_typedefs
     logical,               pointer      :: flag_cice(:)       => null()  !<
     logical,               pointer      :: flag_guess(:)      => null()  !<
     logical,               pointer      :: flag_iter(:)       => null()  !<
+    logical,               pointer      :: lake_freeze(:)     => null()  !<
     real (kind=kind_phys), pointer      :: ffmm_ice(:)        => null()  !<
     real (kind=kind_phys), pointer      :: ffmm_land(:)       => null()  !<
     real (kind=kind_phys), pointer      :: ffmm_water(:)      => null()  !<
@@ -607,6 +608,7 @@ contains
     allocate (Interstitial%flag_cice       (IM))
     allocate (Interstitial%flag_guess      (IM))
     allocate (Interstitial%flag_iter       (IM))
+    allocate (Interstitial%lake_freeze     (IM))
     allocate (Interstitial%ffmm_ice        (IM))
     allocate (Interstitial%ffmm_land       (IM))
     allocate (Interstitial%ffmm_water      (IM))
@@ -1297,6 +1299,7 @@ contains
     Interstitial%flag_cice       = .false.
     Interstitial%flag_guess      = .false.
     Interstitial%flag_iter       = .true.
+    Interstitial%lake_freeze     = .false.
     Interstitial%ffmm_ice        = Model%huge
     Interstitial%ffmm_land       = Model%huge
     Interstitial%ffmm_water      = Model%huge

--- a/ccpp/data/CCPP_typedefs.meta
+++ b/ccpp/data/CCPP_typedefs.meta
@@ -890,7 +890,7 @@
   units = flag
   dimensions = (horizontal_loop_extent)
   type = logical
-[lake_freeze]
+[flag_lakefreeze]
   standard_name = flag_for_lake_water_freeze
   long_name = flag for lake water freeze
   units = flag

--- a/ccpp/data/CCPP_typedefs.meta
+++ b/ccpp/data/CCPP_typedefs.meta
@@ -890,6 +890,12 @@
   units = flag
   dimensions = (horizontal_loop_extent)
   type = logical
+[lake_freeze]
+  standard_name = flag_for_lake_water_freeze
+  long_name = flag for lake water freeze
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = logical
 [ffmm_water]
   standard_name = Monin_Obukhov_similarity_function_for_momentum_over_water
   long_name = Monin-Obukhov similarity function for momentum over water


### PR DESCRIPTION
## Description

This PR is to fix the RRFS ensemble member crash when combining clm lake and GFS PBL/sfclay:

https://github.com/NOAA-EMC/fv3atm/issues/741

A new flag is created to track new freezing lake ice and let sfc_diff to calculate stability variables over the new icy grids for GFS PBL in the second surface loop, which otherwise will remain as missing values.


### Issue(s) addressed

https://github.com/NOAA-EMC/fv3atm/issues/741


## Testing

No RT baseline changed

## Dependencies
https://github.com/ufs-community/ccpp-physics/pull/148