### PR TITLE
Sync support to integrate PR #743 to Use MPI_Bcast instead of multiple p2p messages to update nest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+#  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+#  branch = dev/emc
+  url = https://github.com/dkokron/GFDL_atmos_cubed_sphere
+  branch = hafs-BcastFillNestedGridCpl
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Provide a detailed description of what this PR does.  
- This PR is replacing #743 due to the sync issue of the PR #743 feature branch 
Is a change of answers expected from this PR?  No 

## Dependencies

Do PRs in upstream repositories need to be merged first?
This PR depends on merging of PR 272 into the GFDL_atmos_cubed_sphere
https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/272

