### PR TITLE
Fix out of bound errors in block_atmos_copy routines

### DIFF
--- a/cpl/module_block_data.F90
+++ b/cpl/module_block_data.F90
@@ -365,7 +365,7 @@ contains
         jb = block%index(block_index)%jj(ix)
         i = ib - block%isc + 1
         j = jb - block%jsc + 1
-        destin_ptr(i,j) = factor * source_arr(ib,jb)
+        destin_ptr(i,j) = factor * source_arr(i,j)
       enddo
       localrc = ESMF_SUCCESS
     end if
@@ -440,7 +440,7 @@ contains
           jb = block%index(block_index)%jj(ix)
           i = ib - block%isc + 1
           j = jb - block%jsc + 1
-          destin_ptr(i,j,k) = factor * source_arr(ib,jb,k)
+          destin_ptr(i,j,k) = factor * source_arr(i,j,k)
         enddo
       enddo
       localrc = ESMF_SUCCESS
@@ -523,7 +523,7 @@ contains
             jb = block%index(block_index)%jj(ix)
             i = ib - block%isc + 1
             j = jb - block%jsc + 1
-            destin_ptr(i,j,k) = factor * source_arr(ib,jb,k,slice)
+            destin_ptr(i,j,k) = factor * source_arr(i,j,k,slice)
           enddo
         enddo
         localrc = ESMF_SUCCESS
@@ -1004,7 +1004,7 @@ contains
         jb = block%index(block_index)%jj(ix)
         i = ib - block%isc + 1
         j = jb - block%jsc + 1
-        destin_ptr(i,j) = factor * source_arr(ib,jb)
+        destin_ptr(i,j) = factor * source_arr(i,j)
       enddo
       localrc = ESMF_SUCCESS
     end if
@@ -1079,7 +1079,7 @@ contains
           jb = block%index(block_index)%jj(ix)
           i = ib - block%isc + 1
           j = jb - block%jsc + 1
-          destin_ptr(i,j,k) = factor * source_arr(ib,jb,k)
+          destin_ptr(i,j,k) = factor * source_arr(i,j,k)
         enddo
       enddo
       localrc = ESMF_SUCCESS
@@ -1162,7 +1162,7 @@ contains
             jb = block%index(block_index)%jj(ix)
             i = ib - block%isc + 1
             j = jb - block%jsc + 1
-            destin_ptr(i,j,k) = factor * source_arr(ib,jb,k,slice)
+            destin_ptr(i,j,k) = factor * source_arr(i,j,k,slice)
           enddo
         enddo
         localrc = ESMF_SUCCESS


### PR DESCRIPTION
## Description

This PR fixes out of bounds array access in 6 overloaded block_atmos_copy subroutines in module_block_data (cpl/module_block_data.F90). See #776 for details.


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #776



## Testing

How were these changes tested?  Yes
What compilers / HPCs was it tested with?  Intel/Hera
Are the changes covered by regression tests? I'm not sure but probably not, otherwise we would notice this issue earlier. fv3atm component must be coupled with another component that advertises one of the arrays what are copied by one of these 6 routines. 
Have the ufs-weather-model regression test been run? Yes. On what platform?  Hera 
- Will the code updates change regression test baseline? No.
- Please commit the regression test log files in your ufs-weather-model branch. Ok.


## Dependencies

N/A
