### PR TITLE
[production/AQM.v7] More EE2 compliance for removal of -nowarn in non-debug builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = production/AQM.v7
-  url = https://github.com/BrianCurtis-NOAA/ccpp-physics
-  branch = rmv_nowarn_nondebug
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = production/AQM.v7
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/AQM.v7
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = production/AQM.v7
+  url = https://github.com/BrianCurtis-NOAA/ccpp-physics
+  branch = rmv_nowarn_nondebug
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -675,7 +675,8 @@ module FV3GFS_io_mod
      implicit none
      type(GFS_control_type),    intent(in) :: Model
      integer, intent(in) :: nvar_s2m
-     character(len=32),intent(out) :: sfc_name2(:), sfc_name3(:)
+     character(len=32),intent(out) :: sfc_name2(:)
+     character(len=32),intent(inout) :: sfc_name3(:)
      logical, intent(in) :: warm_start
      integer :: nt
 


### PR DESCRIPTION
## Description
Taking care of warnings after removing '-nowarn' from non-debug builds

Most variable issues were from being unused and unset, so switching from OUT to INOUT fixed the warnings.

This is not a permanent solution, as a permanent solution will come into the develop branch later. 

### Issue(s) addressed
None - emergency fix

## Testing
Changes tested via ufs-weather-model PR.


## Dependencies
- waiting on ufs-community/ccpp-physics/pull/170
