### PR TITLE
[production/RRFS.v1] Updates .gitmodules to point at production/RRFS.v1 branches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+  branch = production/RRFS.v1
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework
-  branch = main
+  branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  branch = production/RRFS.v1
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

Simply updates the .gitmodules file to point at production/RRFS.v1 branches for GFDL_atmos_cubed_sphere and the two CCPP physics repositories.



### Issue(s) addressed





## Testing

How were these changes tested? 

Ran a small subset of RRFS regression tests within the UFS WM (https://github.com/MatthewPyle-NOAA/ufs-weather-model/blob/feature/modulefileupdate/tests/rt.conf_rrfs) 

What compilers / HPCs was it tested with?  

Intel compilers on WCOSS.

Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  

Yes - really no changes associated with this PR (just formalizing what subcomponents are being used).

Have the ufs-weather-model regression test been run? On what platform?  

As mentioned above, ran a subset of regression tests on WCOSS.

- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
No.

- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Is associated with https://github.com/MatthewPyle-NOAA/ufs-weather-model/tree/feature/modulefileupdate

Do PRs in upstream repositories need to be merged first? No
If so add the "waiting for other repos" label and list the upstream PRs
