### PR TITLE
physics update for RRFS.v1 code freeze

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/haiqinli/ccpp-physics
-  branch = production/RRFS.v1-codefreeze
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = production/RRFS.v1
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/RRFS.v1
+  url = https://github.com/haiqinli/ccpp-physics
+  branch = production/RRFS.v1-codefreeze
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This PR includes the following updates:
1). MYNN updates;
2). RUC LSM updates (https://github.com/ufs-community/ccpp-physics/pull/163);
3). GF updates for humidity DA; restore scale-awareness in the 1st hour; suppress weak radar reflectivity over water;
4). smoke plume rise updates for stability on WCOSS2.

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>

## Testing

How were these changes tested?  
-- There changes were tested with standard regression test.

What compilers / HPCs was it tested with?  
-- Intel and GNU compilers on Hera.

Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) 
-- Yes 
Have the ufs-weather-model regression test been run? On what platform?  

Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
-- Yes, due to the physics updates. (/scratch2/BMC/acomp/Haiqin.Li/stmp4/Haiqin.Li/FV3_RT/rt_261277) 

Please commit the regression test log files in your ufs-weather-model branch
-- Yes, will do.


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
