### PR TITLE
[production/AQM.v7] Removing -nowarn from ACS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  #url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-  #branch = production/AQM.v7
-  url = https://github.com/BrianCurtis-NOAA/GFDL_atmos_cubed_sphere
-  branch = remove_nowarn_acs 
+  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+  branch = production/AQM.v7
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-  branch = production/AQM.v7
+  #url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+  #branch = production/AQM.v7
+  url = https://github.com/BrianCurtis-NOAA/GFDL_atmos_cubed_sphere
+  branch = remove_nowarn_acs 
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description
[production/AQM.v7] atmos_cubed_sphere still had a -nowarn in their non-debug build. NCO wishes that removed, and this PR brings in the code changes to fix any warning messages coming from removing that build option.

### Issue(s) addressed
None

## Testing
Builds for debug and nondebug were successful, debug was run for 2 hours without failure, and non-debug was run to completion without a change to baselines.

## Dependencies
* ACS - https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/85
