### PR TITLE
[production/RRFS.v1] Thompson-Eidhammer microphysics code formatting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = production/RRFS.v1
-  url = https://github.com/grantfirl/ccpp-physics
-  branch = thompson_refactor_RRFS
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = production/RRFS.v1
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/RRFS.v1
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = production/RRFS.v1
+  url = https://github.com/grantfirl/ccpp-physics
+  branch = thompson_refactor_RRFS
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -9,7 +9,8 @@ module GFS_typedefs
                                        con_csol, con_epsqs, con_rocp, con_rog,         &
                                        con_omega, con_rerth, con_psat, karman, rainmin,&
                                        con_c, con_plnk, con_boltz, con_solr_2008,      &
-                                       con_solr_2002, con_thgni, con_1ovg
+                                       con_solr_2002, con_thgni, con_1ovg, con_rgas,   &
+                                       con_avgd, con_amd, con_amw
 
    use module_radsw_parameters,  only: topfsw_type, sfcfsw_type
    use module_radlw_parameters,  only: topflw_type, sfcflw_type

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -10388,3 +10388,31 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[con_rgas]
+  standard_name = molar_gas_constant
+  long_name = universal ideal molar gas constant
+  units = J K-1 mol-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[con_avgd]
+  standard_name = avogadro_consant
+  long_name = Avogadro constant
+  units = mol-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[con_amd]
+  standard_name = molecular_weight_of_dry_air
+  long_name = molecular weight of dry air
+  units = g mol-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[con_amw]
+  standard_name = molecular_weight_of_water_vapor
+  long_name = molecular weight of water vapor
+  units = g mol-1
+  dimensions = ()
+  type = real
+  kind = kind_phys


### PR DESCRIPTION
## Description

This is @AndersJensen-NOAA work. This PR replaces https://github.com/NOAA-EMC/fv3atm/pull/740 and is targeted at the RRFS release branch.

This PR points to changes to Thompson-Eidhammer microphysics ->

This PR is the first of many that will modernized, modularize, and streamline Thompson-Eidhammer microphysics.

This PR includes:

The addition of parameterized kind: REAL -> real(kind_phys)
Consistent indentation
Removal of GOTO statements  
Adding metadata for physical constants needed by Thompson MP


### Issue(s) addressed

None



## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/2161


## Dependencies
https://github.com/ufs-community/ccpp-physics/pull/179
