### PR TITLE
Bug fix for unallocated array sfcprop%wetness in GFS_diagnostics.F90

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  #url = https://github.com/NCAR/ccpp-framework
-  ##branch = main
-  url = https://github.com/climbfuji/ccpp-framework
-  branch = bugfix/ccpp_prebuild_chunked_array_support_20240228
+  url = https://github.com/NCAR/ccpp-framework
+  branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  url = https://github.com/NCAR/ccpp-framework
-  branch = main
+  #url = https://github.com/NCAR/ccpp-framework
+  ##branch = main
+  url = https://github.com/climbfuji/ccpp-framework
+  branch = bugfix/ccpp_prebuild_chunked_array_support_20240228
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -4094,17 +4094,19 @@ module GFS_diagnostics
       ExtDiag(idx)%data(nb)%var2 => sfcprop(nb)%vfrac(:)
     enddo
 
-    idx = idx + 1
-    ExtDiag(idx)%axes = 2
-    ExtDiag(idx)%name = 'wetness'
-    ExtDiag(idx)%desc = 'soil moisture availability in top soil layer'
-    ExtDiag(idx)%unit = 'fraction'
-    ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%cnvfac = cn_100
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop(nb)%wetness(:)
-    enddo
+    if (Model%lsm==Model%lsm_ruc) then
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'wetness'
+      ExtDiag(idx)%desc = 'soil moisture availability in top soil layer'
+      ExtDiag(idx)%unit = 'fraction'
+      ExtDiag(idx)%mod_name = 'gfs_sfc'
+      ExtDiag(idx)%cnvfac = cn_100
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => sfcprop(nb)%wetness(:)
+      enddo
+    end if
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2


### PR DESCRIPTION
## Description

Resolves https://github.com/NOAA-EMC/fv3atm/issues/791 (see issue for more details).

I decided to still output this field another time, because it's got a different name and different unit than the already existing one.

### Issue(s) addressed

Resolves https://github.com/NOAA-EMC/fv3atm/issues/791

## Testing

Tested extensively in my (yet to be created) PRs that convert all UFS DDTs from blocked data structures to chunked arrays.

## Dependencies

This is part of a set of (independent) PRs:
- waiting on https://github.com/NCAR/ccpp-framework/pull/538
- https://github.com/NOAA-EMC/fv3atm/pull/792
- https://github.com/ufs-community/ufs-weather-model/pull/2164
