### PR TITLE
Updates of ccpp-framework and ccpp-physics (merge ccpp-framework feature/capgen into main/20240308)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  url = https://github.com/NCAR/ccpp-framework
-  branch = main
+  #url = https://github.com/NCAR/ccpp-framework
+  #branch = main
+  url = https://github.com/climbfuji/ccpp-framework
+  branch = feature/merge_feature_capgen_into_main_20240308
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,16 +4,12 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  #url = https://github.com/NCAR/ccpp-framework
-  #branch = main
-  url = https://github.com/climbfuji/ccpp-framework
-  branch = feature/merge_feature_capgen_into_main_20240308
+  url = https://github.com/NCAR/ccpp-framework
+  branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = ufs/dev
-  url = https://github.com/climbfuji/ccpp-physics
-  branch = feature/fix_units_flashes_per_5min
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,8 +10,10 @@
   branch = feature/merge_feature_capgen_into_main_20240308
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = ufs/dev
+  url = https://github.com/climbfuji/ccpp-physics
+  branch = feature/fix_units_flashes_per_5min
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -9953,8 +9953,8 @@
   kind = kind_phys
 [ltg1_max]
   standard_name = lightning_threat_index_1
-  long_name = lightning threat index 1
-  units = flashes 5 min-1
+  long_name = lightning threat index 1 in flashes per 5 minutes
+  units = flashes min-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
@@ -9962,8 +9962,8 @@
   active = (do_lightning_threat_index_calculations)
 [ltg2_max]
   standard_name = lightning_threat_index_2
-  long_name = lightning threat index 2
-  units = flashes 5 min-1
+  long_name = lightning threat index 2 in flashes per 5 minutes
+  units = flashes min-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
@@ -9971,8 +9971,8 @@
   active = (do_lightning_threat_index_calculations)
 [ltg3_max]
   standard_name = lightning_threat_index_3
-  long_name = lightning threat index 3
-  units = flashes 5 min-1
+  long_name = lightning threat index 3 in flashes per 5 minutes
+  units = flashes min-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -9953,7 +9953,7 @@
   kind = kind_phys
 [ltg1_max]
   standard_name = lightning_threat_index_1
-  long_name = lightning threat index 1 in flashes per 5 minutes
+  long_name = lightning threat index 1
   units = flashes min-1
   dimensions = (horizontal_loop_extent)
   type = real
@@ -9962,7 +9962,7 @@
   active = (do_lightning_threat_index_calculations)
 [ltg2_max]
   standard_name = lightning_threat_index_2
-  long_name = lightning threat index 2 in flashes per 5 minutes
+  long_name = lightning threat index 2
   units = flashes min-1
   dimensions = (horizontal_loop_extent)
   type = real
@@ -9971,7 +9971,7 @@
   active = (do_lightning_threat_index_calculations)
 [ltg3_max]
   standard_name = lightning_threat_index_3
-  long_name = lightning threat index 3 in flashes per 5 minutes
+  long_name = lightning threat index 3
   units = flashes min-1
   dimensions = (horizontal_loop_extent)
   type = real

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -5069,6 +5069,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Max Lightning Threat 1'
       ExtDiag(idx)%unit = 'flashes/(5 min)'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
+      ! CCPP physics units are flashes per minute
+      ExtDiag(idx)%cnvfac = 5.0_kind_phys
       allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
         ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%ltg1_max
@@ -5080,6 +5082,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Max Lightning Threat 2'
       ExtDiag(idx)%unit = 'flashes/(5 min)'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
+      ! CCPP physics units are flashes per minute
+      ExtDiag(idx)%cnvfac = 5.0_kind_phys
       allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
         ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%ltg2_max
@@ -5091,6 +5095,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Max Lightning Threat 3'
       ExtDiag(idx)%unit = 'flashes/(5 min)'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
+      ! CCPP physics units are flashes per minute
+      ExtDiag(idx)%cnvfac = 5.0_kind_phys
       allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
         ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%ltg3_max


### PR DESCRIPTION
## Description

This PR updates the submodule pointers for ccpp-framework and ccpp-physics for the changes described in the associated PRs below. Note that this is not yet switching to `capgen`, but it's a requirement for the transition further down the road.

One change is necessary in `GFS_typedefs.meta`:  change units `flashes 5 min-1` to `flashes min-1`. See https://github.com/NCAR/ccpp-physics/issues/1047 for a discussion of this change.

### Issue(s) addressed

n/a

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/2181

## Dependencies

- waiting on https://github.com/ufs-community/ccpp-physics/pull/182
- waiting on https://github.com/NCAR/ccpp-framework/pull/546
- downstream ufs-weather-model PR https://github.com/ufs-community/ufs-weather-model/pull/2181
