### PR TITLE
[production/RRFS.v1] fix zero cloud fraction for RRFS ensemble members

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/RRFS.v1
+  url = https://github.com/JiliDong-NOAA/ccpp-physics
+  branch = cldfra_fix_refs_sgscld 
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = production/RRFS.v1
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1197,7 +1197,9 @@ module GFS_typedefs
     integer              :: ichoice         = 0 !< flag for closure of C3/GF deep convection
     integer              :: ichoicem        = 13!< flag for closure of C3/GF mid convection
     integer              :: ichoice_s       = 3 !< flag for closure of C3/GF shallow convection
-
+    integer              :: conv_cf_opt      !< option for convection scheme cloud fraction computation
+                                             !< 0: Chaboureau-Bechtold
+                                             !< 1: Xu-Randall
     integer              :: nmtvr           !< number of topographic variables such as variance etc
                                             !< used in the GWD parameterization - 10 more added if
                                             !< GSL orographic drag scheme is used
@@ -3984,6 +3986,7 @@ module GFS_typedefs
                                                                       !<     2: scale- & aerosol-aware mass-flux deep conv scheme (2017)
                                                                       !<     3: scale- & aerosol-aware Grell-Freitas scheme (GSD)
                                                                       !<     4: New Tiedtke scheme (CAPS)
+
     integer              :: isatmedmf      =  0                       !< flag for scale-aware TKE-based moist edmf scheme
                                                                       !<     0: initial version of satmedmf (Nov. 2018)
                                                                       !<     1: updated version of satmedmf (as of May 2019)
@@ -3992,6 +3995,9 @@ module GFS_typedefs
     logical              :: hwrf_samfdeep     = .false.               !< flag for HWRF SAMF deepcnv scheme
     logical              :: hwrf_samfshal     = .false.               !< flag for HWRF SAMF shalcnv scheme
     logical              :: progsigma         = .false.               !< flag for prognostic updraft area fraction closure in saSAS or Unified conv.
+    integer              :: conv_cf_opt       =  0                    !< option for convection scheme cloud fraction computation 
+                                                                      !< 0: Chaboureau-Bechtold
+                                                                      !< 1: Xu-Randall
     logical              :: do_mynnedmf       = .false.               !< flag for MYNN-EDMF
     logical              :: do_mynnsfclay     = .false.               !< flag for MYNN Surface Layer Scheme
     ! DH* TODO - move to MYNN namelist section
@@ -4349,7 +4355,7 @@ module GFS_typedefs
                                betadcu,h2o_phys, pdfcld, shcnvcw, redrag, hybedmf, satmedmf,&
                                shinhong, do_ysu, dspheat, lheatstrg, lseaspray, cnvcld,     &
                                random_clds, shal_cnv, imfshalcnv, imfdeepcnv, isatmedmf,    &
-                               do_deep, jcap,                                               &
+                               conv_cf_opt,do_deep, jcap,                                   &
                                cs_parm, flgmin, cgwf, ccwf, cdmbgwd, sup, ctei_rm, crtrh,   &
                                dlqf, rbcr, shoc_parm, psauras, prauras, wminras,            &
                                do_sppt, do_shum, do_skeb,                                   &
@@ -5190,6 +5196,7 @@ module GFS_typedefs
     Model%imfdeepcnv        = imfdeepcnv
     Model%isatmedmf         = isatmedmf
     Model%do_deep           = do_deep
+    Model%conv_cf_opt       = conv_cf_opt
     Model%nmtvr             = nmtvr
     Model%jcap              = jcap
     Model%flgmin            = flgmin
@@ -7066,6 +7073,7 @@ module GFS_typedefs
       print *, ' imfshalcnv        : ', Model%imfshalcnv
       print *, ' imfdeepcnv        : ', Model%imfdeepcnv
       print *, ' do_deep           : ', Model%do_deep
+      print *, ' conv_cf_opt        : ', Model%conv_cf_opt
       print *, ' nmtvr             : ', Model%nmtvr
       print *, ' jcap              : ', Model%jcap
       print *, ' cs_parm           : ', Model%cs_parm

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -5550,6 +5550,12 @@
   units = none
   dimensions = ()
   type = integer
+[conv_cf_opt]
+  standard_name = option_for_convection_scheme_cloud_fraction_computation
+  long_name = option for convection scheme cloud fraction computation
+  units = flag
+  dimensions = ()
+  type = integer
 [nmtvr]
   standard_name = number_of_statistical_measures_of_subgrid_orography
   long_name = number of topographic variables in GWD

--- a/ccpp/suites/suite_RRFSens_phy1.xml
+++ b/ccpp/suites/suite_RRFSens_phy1.xml
@@ -13,12 +13,14 @@
   <group name="radiation">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
       <scheme>rrtmg_sw</scheme>
       <scheme>rrtmg_sw_post</scheme>
       <scheme>rrtmg_lw</scheme>
+      <scheme>sgscloud_radpost</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>

--- a/ccpp/suites/suite_RRFSens_phy4.xml
+++ b/ccpp/suites/suite_RRFSens_phy4.xml
@@ -13,12 +13,14 @@
   <group name="radiation">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
       <scheme>rrtmg_sw</scheme>
       <scheme>rrtmg_sw_post</scheme>
       <scheme>rrtmg_lw</scheme>
+      <scheme>sgscloud_radpost</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>


### PR DESCRIPTION
## Description

This PR will address zero cloud fraction issue for RRFS ensemble members using GFS PBL and G-F convection by adding SGS cloud to ccpp SDF and changing conv_cf_opt to Xu-Randall for convective cloud fraction computation for those members.

The change to fv3atm is to add conv_cf_opt as an input namelist parameter for runtime switch (conv_cf_opt=1 for GFS PBL members) and add sgs cloud to related ccpp SDFs.

### Issue(s) addressed

https://github.com/NOAA-EMC/fv3atm/issues/800


## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Intel on Hera.
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
No. No RTs using RRFS ensemble physics suites.
Have the ufs-weather-model regression test been run? On what platform?  
Not yet. But no changes expected for RT baseline.
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
No
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

https://github.com/ufs-community/ccpp-physics/pull/186
