### PR TITLE
Update github workflow

### DIFF
--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -58,6 +58,7 @@ jobs:
         spack config add "packages:mpi:require:'${{ matrix.mpi }}'"
         spack concretize |& tee ${SPACK_ENV}/log.concretize
         spack install -j2 --fail-fast
+        spack clean --all
 
     - name: build-fv3atm
       run: |

--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -26,14 +26,14 @@ jobs:
     steps:
 
     - name: checkout-fv3atm
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: ${{ github.workspace }}/fv3atm
         submodules: recursive
 
     - name: cache-spack
       id: cache-spack
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/spack-develop
         key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}
@@ -72,14 +72,14 @@ jobs:
         sudo apt-get install doxygen graphviz
 
     - name: checkout-fv3atm
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: ${{ github.workspace }}/fv3atm
         submodules: recursive
 
     - name: cache-spack
       id: cache-spack
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/spack-develop
         key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}
@@ -102,16 +102,16 @@ jobs:
         make -j2
         ls -l /home/runner/work/fv3atm/fv3atm/fv3atm/io
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: docs
+        name: docs-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}-${{ matrix.cmake_opts }}
         path: |
           build/docs/html
 
     - name: debug-artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
-        name: ccpp_prebuild_logs
+        name: ccpp_prebuild_logs-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}-${{ matrix.cmake_opts }}
         path: ${{ github.workspace }}/build/ccpp/ccpp_prebuild.*
 

--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -31,6 +31,12 @@ jobs:
         path: ${{ github.workspace }}/fv3atm
         submodules: recursive
 
+    - name: install-cmake
+      run: | 
+        cd ${{ github.workspace }}
+        curl -f -s -S -R -L https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-Linux-x86_64.tar.gz | tar -zx
+        echo "${{ github.workspace }}/cmake-3.29.2-linux-x86_64/bin" >> $GITHUB_PATH
+
     - name: cache-spack
       id: cache-spack
       uses: actions/cache@v4
@@ -70,6 +76,12 @@ jobs:
     - name: install-doxygen
       run: |
         sudo apt-get install doxygen graphviz
+
+    - name: install-cmake
+      run: | 
+        cd ${{ github.workspace }}
+        curl -f -s -S -R -L https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-Linux-x86_64.tar.gz | tar -zx
+        echo "${{ github.workspace }}/cmake-3.29.2-linux-x86_64/bin" >> $GITHUB_PATH
 
     - name: checkout-fv3atm
       uses: actions/checkout@v4

--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -98,6 +98,7 @@ jobs:
         export CC=mpicc
         export CXX=mpicxx
         export FC=mpif90
+        cat /home/runner/work/fv3atm/fv3atm/spack-develop/opt/spack/linux-ubuntu22.04-zen2/gcc-12.3.0/fms-2023.04-*/lib/cmake/fms/fms-config.cmake
         cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_TESTING=ON ${{ matrix.cmake_opts }} -DENABLE_DOCS=ON
         make -j2
         ls -l /home/runner/work/fv3atm/fv3atm/fv3atm/io

--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         gcc_ver: ["12"]
-        mpi: ["openmpi"]
+        mpi: ["mpich", "openmpi"]
 
     steps:
 
@@ -63,7 +63,7 @@ jobs:
       matrix:
         cmake_opts: ["-D32BIT=ON", "-D32BIT=OFF"]
         gcc_ver: ["12"]
-        mpi: ["openmpi"]
+        mpi: ["mpich", "openmpi"]
 
     steps:
 

--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -15,7 +15,48 @@ on:
     - develop
 
 jobs:
-  GCC:
+  build_spack:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        gcc_ver: ["12"]
+        mpi: ["openmpi"]
+
+    steps:
+
+    - name: checkout-fv3atm
+      uses: actions/checkout@v3
+      with:
+        path: ${{ github.workspace }}/fv3atm
+        submodules: recursive
+
+    - name: cache-spack
+      id: cache-spack
+      uses: actions/cache@v3
+      with:
+        path: ${{ github.workspace }}/spack-develop
+        key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}
+
+    # Building dependencies takes 40+ min
+    - name: spack-install
+      if: steps.cache-spack.outputs.cache-hit != 'true'
+      run: |
+        wget --no-verbose https://github.com/spack/spack/archive/refs/heads/develop.zip
+        unzip develop.zip -d ${GITHUB_WORKSPACE}/ &> unzip.out
+        . ${GITHUB_WORKSPACE}/spack-develop/share/spack/setup-env.sh
+        spack env create gcc${{ matrix.gcc_ver }} ${GITHUB_WORKSPACE}/fv3atm/ci/spack.yaml
+        spack env activate gcc${{ matrix.gcc_ver }}
+        spack compiler find | grep gcc@${{ matrix.gcc_ver }}
+        spack external find gmake cmake git git-lfs perl python ${{ matrix.mpi }}
+        spack config add "packages:all:require:['%gcc@${{ matrix.gcc_ver }}']"
+        spack config add "packages:mpi:require:'${{ matrix.mpi }}'"
+        spack concretize |& tee ${SPACK_ENV}/log.concretize
+        spack install -j2 --fail-fast
+        spack clean --all
+
+  build_fv3atm:
+    needs: build_spack
     runs-on: ubuntu-latest
 
     strategy:
@@ -41,24 +82,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/spack-develop
-        key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}-${{ matrix.cmake_opts }}
-
-    # Building dependencies takes 40+ min
-    - name: spack-install
-      if: steps.cache-spack.outputs.cache-hit != 'true'
-      run: |
-        wget --no-verbose https://github.com/spack/spack/archive/refs/heads/develop.zip
-        unzip develop.zip -d ${GITHUB_WORKSPACE}/ &> unzip.out
-        . ${GITHUB_WORKSPACE}/spack-develop/share/spack/setup-env.sh
-        spack env create gcc${{ matrix.gcc_ver }} ${GITHUB_WORKSPACE}/fv3atm/ci/spack.yaml
-        spack env activate gcc${{ matrix.gcc_ver }}
-        spack compiler find | grep gcc@${{ matrix.gcc_ver }}
-        spack external find gmake cmake git git-lfs perl python ${{ matrix.mpi }}
-        spack config add "packages:all:require:['%gcc@${{ matrix.gcc_ver }}']"
-        spack config add "packages:mpi:require:'${{ matrix.mpi }}'"
-        spack concretize |& tee ${SPACK_ENV}/log.concretize
-        spack install -j2 --fail-fast
-        spack clean --all
+        key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}
 
     - name: build-fv3atm
       run: |

--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -79,7 +79,7 @@ jobs:
 
     - name: cache-spack
       id: cache-spack
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/spack-develop
         key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}

--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -21,15 +21,15 @@ jobs:
     strategy:
       matrix:
         cmake_opts: ["-D32BIT=ON", "-D32BIT=OFF"]
-        gcc_ver: ["11"]
-        mpi: ["mpich"]
+        gcc_ver: ["12"]
+        mpi: ["openmpi"]
 
     steps:
 
     - name: install-doxygen
       run: |
         sudo apt-get install doxygen graphviz
-        
+
     - name: checkout-fv3atm
       uses: actions/checkout@v3
       with:
@@ -41,7 +41,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/spack-develop
-        key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-2-${{ matrix.cmake_opts }}-${{ matrix.mpich }}
+        key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}-${{ matrix.cmake_opts }}
 
     # Building dependencies takes 40+ min
     - name: spack-install
@@ -70,6 +70,9 @@ jobs:
         mkdir ${GITHUB_WORKSPACE}/build
         sed -i 's/doc /upp_doc /' upp/docs/CMakeLists.txt
         cd ${GITHUB_WORKSPACE}/build
+        export CC=mpicc
+        export CXX=mpicxx
+        export FC=mpif90
         cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_TESTING=ON ${{ matrix.cmake_opts }} -DENABLE_DOCS=ON
         make -j2
         ls -l /home/runner/work/fv3atm/fv3atm/fv3atm/io
@@ -79,7 +82,7 @@ jobs:
         name: docs
         path: |
           build/docs/html
-          
+
     - name: debug-artifacts
       uses: actions/upload-artifact@v3
       if: ${{ failure() }}


### PR DESCRIPTION
## Description

- Updated the gcc compiler version from 11 to 12.
- Add 'spack clean --all' to reduce the size of the github cache file, Currently cache file is about 3.5 GB, after this change cache file is about 150 - 200 MB.
- Split GCC workflow into two steps, the first step only builds spack, the second step builds the fv3atm. Currently spack stack is built for each combination of compile/mpi/cmake_flags even though spack does not depend on cmake flags (those are fv3atm specific flags).

### Issue(s) addressed

- fixes #804


## Testing

How were these changes tested?  GitHub CI
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

N/A
