### PR TITLE
Update dycore to remove compiler warnings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  #url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  #branch = dev/emc
+  url = https://github.com/bensonr/GFDL_atmos_cubed_sphere
+  branch = comp_warn
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  #url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  #branch = dev/emc
-  url = https://github.com/bensonr/GFDL_atmos_cubed_sphere
-  branch = comp_warn
+  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(ENABLE_DOCS "Enable generation of doxygen-based documentation." OFF)
 # Determine whether or not to generate documentation.
 if(ENABLE_DOCS)
   find_package(Doxygen REQUIRED)
-  add_subdirectory(docs)  
+  add_subdirectory(docs)
 endif()
 
 # Enable CI build & unit testing:
@@ -38,6 +38,7 @@ if(MOVING_NEST)
   set(MOVING_NEST ON)
 endif()
 add_subdirectory(atmos_cubed_sphere)
+target_compile_definitions(fv3 PRIVATE BYPASS_BREED_SLP_INLINE)
 
 ###############################################################################
 ### fv3atm

--- a/io/post_fv3.F90
+++ b/io/post_fv3.F90
@@ -136,7 +136,7 @@ module post_fv3
                          wrt_int_state%out_grid_info(grid_id)%jm, &
                          wrt_int_state%out_grid_info(grid_id)%lm, &
                          mype,wrttasks_per_group,lead_write, &
-                         mpicomp,jts,jte,jstagrp,jendgrp,its,ite,istagrp,iendgrp)
+                         mpicomp%mpi_val,jts,jte,jstagrp,jendgrp,its,ite,istagrp,iendgrp)
 !
 !-----------------------------------------------------------------------
 !*** read namelist for pv,th,po


### PR DESCRIPTION
## Description

This PR updates atmos_cubed_sphere submodule to bring code updates which remove compiler warning when code is compiled without `-nowarn` compiler flag.

See: https://github.com/ufs-community/ufs-weather-model/issues/1984

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/324

Do PRs in upstream repositories need to be merged first? No
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/fv3atm/pull/<pr_number>
