### PR TITLE
Update submodule atmos_cubed_sphere to fix a typo/bug when printing out the nest grid corner locations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-# url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-# branch = dev/emc
-  url = https://github.com/hafs-community/GFDL_atmos_cubed_sphere
-  branch = feature/grid_corner_jc_fix
+  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+# url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+# branch = dev/emc
+  url = https://github.com/hafs-community/GFDL_atmos_cubed_sphere
+  branch = feature/grid_corner_jc_fix
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Provide a detailed description of what this PR does.  
What bug does it fix, or what feature does it add?  
Is a change of answers expected from this PR?  

Update submodule atmos_cubed_sphere to fix a typo/bug when printing out the nest grid corner locations.

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes NOAA-GFDL/GFDL_atmos_cubed_sphere/issues/333


## Testing

This fix has been tested with the UFS HAFS application.

## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/341
- needed by ufs-community/ufs-weather-model/pull/2323
