### PR TITLE
Refactor NRL h2o photochemical scheme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/dustinswales/ccpp-physics
+  branch = feature/refactor_h2ophys
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -21,6 +21,7 @@ VARIABLE_DEFINITION_FILES = [
     'physics/physics/Radiation/RRTMG/radlw_param.f',
     'physics/physics/photochem/h2o_def.f',
     'physics/physics/photochem/module_ozphys.F90',
+    'physics/physics/photochem/module_h2ophys.F90',
     'data/CCPP_typedefs.F90',
     'data/GFS_typedefs.F90',
     'data/CCPP_data.F90',
@@ -44,6 +45,10 @@ TYPEDEFS_NEW_METADATA = {
     'module_ozphys' : {
         'module_ozphys' : '',
         'ty_ozphys'     : '',
+        },
+    'module_h2ophys' : {
+        'module_h2ophys' : '',
+        'ty_h2ophys'     : '',
         },
     'CCPP_typedefs' : {
         'GFS_interstitial_type' : 'GFS_Interstitial(cdata%thrd_no)',
@@ -86,6 +91,7 @@ SCHEME_FILES = [
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_SCNV_generic_post.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_debug.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.F90',
+    'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_photochemistry.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rad_time_vary.fv3.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_radiation_surface.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_post.F90',
@@ -151,7 +157,7 @@ SCHEME_FILES = [
     'physics/physics/GWD/gwdc_post.f',
     'physics/physics/GWD/gwdps.f',
     'physics/physics/GWD/rayleigh_damp.f',
-    'physics/physics/photochem/h2ophys.f',
+    'physics/physics/photochem/module_h2ophys.F90',
     'physics/physics/photochem/module_ozphys.F90',
     'physics/physics/MP/Ferrier_Aligo/mp_fer_hires.F90',
     'physics/physics/MP/GFDL/gfdl_cloud_microphys.F90',

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -19,7 +19,6 @@ VARIABLE_DEFINITION_FILES = [
     'physics/physics/hooks/machine.F',
     'physics/physics/Radiation/RRTMG/radsw_param.f',
     'physics/physics/Radiation/RRTMG/radlw_param.f',
-    'physics/physics/photochem/h2o_def.f',
     'physics/physics/photochem/module_ozphys.F90',
     'physics/physics/photochem/module_h2ophys.F90',
     'data/CCPP_typedefs.F90',

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1015,6 +1015,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: dt_inner        !< time step for the inner loop in s
     logical              :: sedi_semi       !< flag for semi Lagrangian sedi of rain
     integer              :: decfl           !< deformed CFL factor
+    logical              :: thpsnmp_is_init !< Local scheme initialization flag
 
     !--- GFDL microphysical paramters
     logical              :: lgfdlmprad      !< flag for GFDL mp scheme and radiation consistency
@@ -3555,6 +3556,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: dt_inner       = -999.0             !< time step for the inner loop
     logical              :: sedi_semi      = .false.            !< flag for semi Lagrangian sedi of rain
     integer              :: decfl          = 8                  !< deformed CFL factor
+    logical              :: thpsnmp_is_init = .false.           !< Local scheme initialization flag 
 
     !--- GFDL microphysical parameters
     logical              :: lgfdlmprad     = .false.            !< flag for GFDLMP radiation interaction

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -5334,6 +5334,12 @@
   units = mixed
   dimensions = ()
   type = ty_ozphys
+[h2ophys]
+  standard_name = dataset_for_h2o_photochemistry_physics
+  long_name = dataset for NRL h2o photochemistry physics
+  units = mixed
+  dimensions = ()
+  type = ty_h2ophys
 [h2o_phys]
   standard_name = flag_for_stratospheric_water_vapor_physics
   long_name = flag for stratospheric water vapor physics
@@ -7009,6 +7015,18 @@
   standard_name = number_of_coefficients_in_ozone_data
   long_name = number of coefficients in ozone forcing data
   units = count
+  dimensions = ()
+  type = integer
+[levh2o]
+  standard_name = vertical_dimension_of_h2o_forcing_data
+  long_name = number of vertical layers in h2o forcing data
+  units = count
+  dimensions = ()
+  type = integer
+[h2o_coeff]
+  standard_name = number_of_coefficients_in_h2o_forcing_data
+  long_name = number of coefficients in h2o forcing data
+  units = index
   dimensions = ()
   type = integer
 [ipt]
@@ -10025,7 +10043,7 @@
   relative_path = ../physics/physics/
   dependencies = hooks/machine.F,hooks/physcons.F90
   dependencies = Radiation/RRTMG/radlw_param.f,Radiation/RRTMG/radsw_param.f
-  dependencies = photochem/h2o_def.f,photochem/module_ozphys.F90
+  dependencies = photochem/module_ozphys.F90,photochem/module_h2ophys.F90
   dependencies = MP/GFDL/GFDL_parse_tracers.F90
 
 [ccpp-arg-table]

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -4825,6 +4825,7 @@
   standard_name = flag_for_thompson_mp_scheme_initialization
   long_name = flag carrying scheme initialization status
   units = flag
+  dimensions = ()
   type = logical
 [lgfdlmprad]
   standard_name = flag_for_GFDL_microphysics_radiation_interaction

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -4821,6 +4821,11 @@
   units = count
   dimensions = ()
   type = integer
+[thpsnmp_is_init]
+  standard_name = flag_for_thompson_mp_scheme_initialization
+  long_name = flag carrying scheme initialization status
+  units = flag
+  type = logical
 [lgfdlmprad]
   standard_name = flag_for_GFDL_microphysics_radiation_interaction
   long_name = flag for GFDL microphysics-radiation interaction

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
@@ -59,7 +59,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_suite_interstitial_4</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -65,7 +65,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16.xml
@@ -65,7 +65,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -60,7 +60,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_flake.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_flake.xml
@@ -66,7 +66,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
@@ -58,7 +58,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_ras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_ras.xml
@@ -65,7 +65,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
@@ -61,7 +61,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
@@ -61,7 +61,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
@@ -59,7 +59,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
@@ -61,7 +61,7 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8.xml
@@ -61,7 +61,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
@@ -62,7 +62,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
@@ -63,7 +63,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
@@ -61,7 +61,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
@@ -60,7 +60,7 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
@@ -65,7 +65,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
@@ -63,7 +63,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
@@ -60,7 +60,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
@@ -58,7 +58,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
@@ -60,7 +60,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -58,7 +58,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_suite_interstitial_4</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_c3.xml
+++ b/ccpp/suites/suite_FV3_HRRR_c3.xml
@@ -58,7 +58,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf.xml
@@ -58,7 +58,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
@@ -55,7 +55,7 @@
       <scheme>mynnedmf_wrapper</scheme>
       <scheme>rrfs_smoke_postpbl</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_RAP.xml
+++ b/ccpp/suites/suite_FV3_RAP.xml
@@ -58,7 +58,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
@@ -59,7 +59,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_RAP_clm_lake.xml
+++ b/ccpp/suites/suite_FV3_RAP_clm_lake.xml
@@ -59,7 +59,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_RAP_flake.xml
+++ b/ccpp/suites/suite_FV3_RAP_flake.xml
@@ -59,7 +59,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah.xml
@@ -59,7 +59,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
@@ -60,7 +60,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
+++ b/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
@@ -58,7 +58,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
@@ -59,7 +59,7 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1beta.xml
@@ -60,7 +60,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_suite_interstitial_4</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
@@ -60,7 +60,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_MP_generic_pre</scheme>
       <scheme>mp_nssl</scheme>

--- a/ccpp/suites/suite_FV3_WoFS_v0.xml
+++ b/ccpp/suites/suite_FV3_WoFS_v0.xml
@@ -60,7 +60,7 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_MP_generic_pre</scheme>
       <scheme>mp_nssl</scheme>

--- a/ccpp/suites/suite_FV3_global_nest_v1.xml
+++ b/ccpp/suites/suite_FV3_global_nest_v1.xml
@@ -60,7 +60,7 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_RRFSens_phy1.xml
+++ b/ccpp/suites/suite_RRFSens_phy1.xml
@@ -57,7 +57,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_RRFSens_phy2.xml
+++ b/ccpp/suites/suite_RRFSens_phy2.xml
@@ -56,7 +56,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_RRFSens_phy3.xml
+++ b/ccpp/suites/suite_RRFSens_phy3.xml
@@ -56,7 +56,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_RRFSens_phy4.xml
+++ b/ccpp/suites/suite_RRFSens_phy4.xml
@@ -57,7 +57,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>

--- a/ccpp/suites/suite_RRFSens_phy5.xml
+++ b/ccpp/suites/suite_RRFSens_phy5.xml
@@ -56,7 +56,7 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>h2ophys</scheme>
+      <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>


### PR DESCRIPTION
## Description
Included in this PR are changes to NRL's stratospheric h2o photochemistry scheme to make it "safe across multiple CCPP instances". These changes are identical to the reorganization that [o3 photochemistry scheme underwent in the fall of 2023.](https://github.com/ufs-community/ccpp-physics/pull/75). 

Both schemes are called from a new module, GFS_photochemistry, at the start of the time-split section of the suite. Previously, the ozone scheme was called from GFS_stateout_update, and the h2o scheme was called just after.

### Issue(s) addressed
N/A

## Testing

No changes to RT's on Hera with Intel

## Dependencies

