### PR TITLE
Add an option in dynamics to calculate omega in non-hydrostatic runs similar to hydrostatic method

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  url = https://github.com/XiaqiongZhou-NOAA/GFDL_atmos_cubed_sphere
+  branch = cherry_pick_omga
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/XiaqiongZhou-NOAA/GFDL_atmos_cubed_sphere
-  branch = cherry_pick_omga
+  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description

This update is to update dynamics. A new parameter, pass_full_omega_to_physics_in_non_hydrostatic_mode, has been added in dynamics. When set to true, the omega calculation will match that of hydrostatic runs, using the formula omega = dp/dt. The default value is false, where the calculation remains omega = w * dp/dz as before.



### Issue(s) addressed
None.


## Testing
This update is tested on Hercules with both intel and gnu compiler and all UFS regression tests produced identical results with default setting.


## Dependencies

- waiting on NOAA-GFDL/GFDL_atmos_cubed_sphere PR#344 (https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere)(https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/344/)
- related to ufs-community/ufs-weather-model PR#2327 (https://github.com/ufs-community/ufs-weather-model/pull/2327)
