### PR TITLE
HR4 and SFS baseline update: Improve convection/radiation interaction in the GFS physics suite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,7 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  url = https://github.com/lisa-bengtsson/ccpp-physics
+  url = https://github.com/ufs-community/ccpp-physics
   branch = ufs/dev
 [submodule "upp"]
   path = upp

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
+  #url = https://github.com/ufs-community/ccpp-physics
+  url = https://github.com/lisa-bengtsson/ccpp-physics
   branch = ufs/dev
 [submodule "upp"]
   path = upp


### PR DESCRIPTION
## Description
The GFS physics suite at 100km yields too large cloud cover and optical depth, causing too much cloud shielding and a drift in Sea Surface Temperatures, SST for seasonal prediction. This is an issue for the Seasonal Forecast System baseline. The issue was identified to be related to too much convective cloud condensate passed in from the cumulus convection scheme.

A scale adaptive solution is proposed and tested for SFS and GFS resolutions, outputting updraft values of in-cloud condensate. We propose to add this change to SFS baselines as well as the HR4 prototype of the GFS. In testing we also tune the minimum background diffusivity in the inversion layer near the PBL top (xkinv1) from xkinv1=0.4 to xkinv1=0.15 in order to not reduce convective clouds too much in marine stratocumulus.


### Issue(s) addressed
- fixes https://github.com/ufs-community/ufs-weather-model/issues/2339

- uses https://github.com/ufs-community/ccpp-physics/pull/216

