### PR TITLE
Land surface upgrades for HR4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/HelinWei-NOAA/ccpp-physics
-  branch = land_upgrade_hr4 
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/HelinWei-NOAA/ccpp-physics
+  branch = land_upgrade_hr4 
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This PR mainly involves changes in ccpp-physics

To address some concerns from HR3 especially the surface cold biases we have finalized some land surface upgrades after carrying out extensive tests and evaluation.

- remove vegetation type-dependent for the diagnostic option (opt_diag) used in HR3
- use radiative temperature as skin temperature
- use single loop alternative approach to address some flux inconsistence below and above the canopy
- fix the thermal roughness bug (the one for bared portion in the composition is not the same as the one used in the bared title)
- adjust some momentum roughness length
- use the interpolated temp between the skin temp and the first soil temp to get the initial snow temp based on snow depth
- use constant snow thermal conductivity to reduce the snow insulation effects
- fix radiation parameter bugs for grassland/cropland
- adjust albedo parameter for each soil color category

This PR will change results on those suites using NoahMP




The changes have undergone extensive testing within the HR3 framework
The changes are covered by regression tests
the ufs-weather-model regression test has been run on wcoss2
the code updates will change regression test baseline



## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on ufs-community/ccpp-physics [PR #219](https://github.com/ufs-community/ccpp-physics/pull/219)

