### PR TITLE
Add soil temperature and moisture IAU

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = ufs/dev
-  url = https://github.com/tsga/ccpp-physics
-  branch = feature/lnd_iau
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = ufs/dev
+  url = https://github.com/tsga/ccpp-physics
+  branch = feature/lnd_iau
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -21,6 +21,7 @@ VARIABLE_DEFINITION_FILES = [
     'physics/physics/Radiation/RRTMG/radlw_param.f',
     'physics/physics/photochem/module_ozphys.F90',
     'physics/physics/photochem/module_h2ophys.F90',
+    'physics/physics/SFC_Models/Land/Noahmp/lnd_iau_mod.F90',
     'data/CCPP_typedefs.F90',
     'data/GFS_typedefs.F90',
     'data/CCPP_data.F90',
@@ -48,6 +49,12 @@ TYPEDEFS_NEW_METADATA = {
     'module_h2ophys' : {
         'module_h2ophys' : '',
         'ty_h2ophys'     : '',
+        },
+    'land_iau_mod' : {
+        'land_iau_mod' : '',
+        'land_iau_external_data_type' : '',
+        'land_iau_state_type' : '',
+        'land_iau_control_type' : '',
         },
     'CCPP_typedefs' : {
         'GFS_interstitial_type' : 'GFS_Interstitial(cdata%thrd_no)',

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -17,8 +17,7 @@ module GFS_typedefs
    use module_ozphys,            only: ty_ozphys
    use module_h2ophys,           only: ty_h2ophys
    use land_iau_mod,             only: land_iau_external_data_type, land_iau_control_type, &
-                                       land_iau_state_type  
-   use land_iau_mod,             only: land_iau_mod_set_control
+                                       land_iau_state_type, land_iau_mod_set_control
 
    implicit none
 

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -16,6 +16,8 @@ module GFS_typedefs
    use module_radlw_parameters,  only: topflw_type, sfcflw_type
    use module_ozphys,            only: ty_ozphys
    use module_h2ophys,           only: ty_h2ophys
+   use land_iau_mod,             only: land_iau_external_data_type, land_iau_control_type, &
+                                       land_iau_state_type  
 
    implicit none
 
@@ -480,7 +482,12 @@ module GFS_typedefs
 
     !--- For smoke and dust auxiliary inputs
     real (kind=kind_phys), pointer :: fire_in   (:,:)   => null()  !< fire auxiliary inputs
-
+    
+    !--- Land IAU DDTs
+    type(land_iau_external_data_type) :: land_iau_data
+    type(land_iau_control_type)       :: land_iau_control
+    type(land_iau_state_type)         :: land_iau_state
+                                        
     contains
       procedure :: create  => sfcprop_create  !<   allocate array data
   end type GFS_sfcprop_type

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -18,6 +18,7 @@ module GFS_typedefs
    use module_h2ophys,           only: ty_h2ophys
    use land_iau_mod,             only: land_iau_external_data_type, land_iau_control_type, &
                                        land_iau_state_type  
+   use land_iau_mod,             only: land_iau_mod_set_control
 
    implicit none
 
@@ -1651,6 +1652,19 @@ module GFS_typedefs
     type(ty_h2ophys) :: h2ophys        !< DDT with data needed by h2o photchemistry physics.
     integer          :: levh2o         !< Number of vertical layers in stratospheric h2o data.
     integer          :: h2o_coeff      !< Number of coefficients in stratospheric h2o data.
+
+! !--- Land IAU
+!   !> land iau setting read from namelist
+!     logical               :: do_land_iau               
+!     real(kind=kind_phys)  :: land_iau_delthrs                  
+!     character(len=240)    :: land_iau_inc_files(7)             
+!     real(kind=kind_phys)  :: land_iau_fhrs(7)              
+!     logical               :: land_iau_filter_increments 
+!     integer               :: lsoil_incr 
+!     logical               :: land_iau_upd_stc
+!     logical               :: land_iau_upd_slc 
+!     logical               :: land_iau_do_stcsmc_adjustment 
+!     real(kind=kind_phys)  :: land_iau_min_T_increment 
     
     contains
       procedure :: init            => control_initialize
@@ -2315,6 +2329,9 @@ module GFS_typedefs
     type(GFS_control_type), intent(in) :: Model
     integer :: IM
 
+    character(len=512)                 :: errmsg
+    integer                            :: errflg
+
     IM = Model%ncols
 
     !--- physics and radiation
@@ -2888,6 +2905,20 @@ module GFS_typedefs
       Sfcprop%smoke_fire = zero
     endif
 
+    ! land iau control setting
+    call land_iau_mod_set_control(Sfcprop%land_iau_control, &
+            Model%fn_nml, Model%input_nml_file, Model%me, Model%master, &
+            Model%isc,  Model%jsc,  Model%nx,  Model%ny,  Model%tile_num,  Model%nblks,  Model%blksz, &
+            Model%lsoil, Model%lsnow_lsm, Model%dtp, Model%fhour, errmsg, errflg)
+
+    if (errflg/=0) then
+      if (Model%me==Model%master) then
+        write(0,'(a)') "Error inside sfcprop_create"
+        write(0,'(a)') trim(errmsg)
+        stop
+      endif
+    endif   
+    
   end subroutine sfcprop_create
 
 
@@ -4021,6 +4052,18 @@ module GFS_typedefs
     real(kind=kind_phys) :: radar_tten_limits(2) = (/ limit_unspecified, limit_unspecified /)
     integer :: itime
 
+  ! !> land iau setting read from namelist
+  !   logical               :: do_land_iau                   = .false.
+  !   real(kind=kind_phys)  :: land_iau_delthrs              = 0           
+  !   character(len=240)    :: land_iau_inc_files(7)         = ''          
+  !   real(kind=kind_phys)  :: land_iau_fhrs(7)              = -1          
+  !   logical               :: land_iau_filter_increments    = .false.     
+  !   integer               :: lsoil_incr                    = 4
+  !   logical               :: land_iau_upd_stc              = .false.
+  !   logical               :: land_iau_upd_slc              = .false.
+  !   logical               :: land_iau_do_stcsmc_adjustment = .false.
+  !   real(kind=kind_phys)  :: land_iau_min_T_increment      = 0.0001
+
 !--- END NAMELIST VARIABLES
 
     NAMELIST /gfs_physics_nml/                                                              &
@@ -4177,7 +4220,13 @@ module GFS_typedefs
                           !          and (maybe) convection suppression
                                fh_dfi_radar, radar_tten_limits, do_cap_suppress,            &
                           !--- GSL lightning threat indices
-                               lightning_threat
+                               lightning_threat !,                                            &
+                          ! !--- land_iau_nml
+                          !      do_land_iau, land_iau_delthrs, land_iau_inc_files,           & 
+                          !      land_iau_fhrs, land_iau_filter_increments, lsoil_incr,       &
+                          !      land_iau_upd_stc, land_iau_upd_slc,                          &
+                          !      land_iau_do_stcsmc_adjustment, land_iau_min_T_increment                                    
+   
 
 !--- other parameters
     integer :: nctp    =  0                !< number of cloud types in CS scheme
@@ -6292,6 +6341,18 @@ module GFS_typedefs
       endif
     endif
 !--- END CODE FROM GLOOPB
+
+! !---Land IAU Settings
+!     Model%do_land_iau = do_land_iau
+!     Model%iau_delthrs = land_iau_delthrs
+!     Model%iau_inc_files = land_iau_inc_files
+!     Model%iaufhrs = land_iau_fhrs   
+!     Model%iau_filter_increments = land_iau_filter_increments
+!     Model%lsoil_incr = lsoil_incr
+!     Model%upd_stc = land_iau_upd_stc
+!     Model%upd_slc = land_iau_upd_slc
+!     Model%do_stcsmc_adjustment = land_iau_do_stcsmc_adjustment
+!     Model%min_T_increment = land_iau_min_T_increment
 
     call Model%print ()
 

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -2387,6 +2387,24 @@
   type = real
   kind = kind_phys
   active = (do_fire_coupling)
+[land_iau_data]
+  standard_name = land_data_assimilation_data
+  long_name = land data assimilation data
+  units = mixed
+  dimensions = ()
+  type = land_iau_external_data_type
+[land_iau_control]
+  standard_name = land_data_assimilation_control
+  long_name = land data assimilation control
+  units = mixed
+  dimensions = ()
+  type = land_iau_control_type
+[land_iau_state]
+  standard_name = land_data_assimilation_interpolated_data
+  long_name = land data assimilation space- and time-interpolated
+  units = mixed
+  dimensions = ()
+  type = land_iau_state_type
 
 ########################################################################
 [ccpp-table-properties]

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -10091,7 +10091,7 @@
   dependencies = hooks/machine.F,hooks/physcons.F90
   dependencies = Radiation/RRTMG/radlw_param.f,Radiation/RRTMG/radsw_param.f
   dependencies = photochem/module_ozphys.F90,photochem/module_h2ophys.F90
-  dependencies = MP/GFDL/GFDL_parse_tracers.F90
+  dependencies = SFC_Models/Land/Noahmp/lnd_iau_mod.F90,MP/GFDL/GFDL_parse_tracers.F90
 
 [ccpp-arg-table]
   name = GFS_typedefs

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -132,6 +132,14 @@ module CCPP_driver
         return
       end if
 
+      ! call timestep_init for "physics"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="physics", ierr=ierr)
+      if (ierr/=0) then
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group physics"
+        write(0,'(a)') trim(cdata_domain%errmsg)
+        return
+      end if      
+            
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       ! DH* 20210104 - this block of code will be removed once the CCPP framework    !
       ! fully supports handling diagnostics through its metadata, work in progress   !
@@ -213,6 +221,14 @@ module CCPP_driver
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
+
+      ! call timestep_finalize for "physics"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="physics", ierr=ierr)
+      if (ierr/=0) then
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group physics"
+        write(0,'(a)') trim(cdata_domain%errmsg)
+        return
+      end if      
 
     ! Physics finalize
     else if (trim(step)=="physics_finalize") then


### PR DESCRIPTION
## Description

The atmospheric DA applies IAU increments on temperature (among other variables), while the land surface increments are applied once at the start of the DA (cycle?) window. This could lead to the land surface (soil and snow) temperature being out of sync with near surface atmospheric temperature



### Issue(s) addressed

- fixes https://github.com/ufs-community/ccpp-physics/issues/190#issue-2205993682)
- fixes https://github.com/NOAA-EMC/fv3atm/issues/867



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch

Regression tests for ATM only and coupled (S2S) configurations pass in hera.

Additional land-IAU specific test to be added: control_c48_intel_land_iau (based on the "control_c48_intel" test, with the only difference being the turning on of land IAU and soil temperature increment files inside INPUT directory). The test inputs are at:
/scratch1/NCEPDEV/da/Tseganeh.Gichamo/ccpp-physics/test/control_c48_intel_land_iau


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs


# Requirements before merging
- [x] All new code in this PR is tested by at least one unit test
- [x] All new code in this PR includes Doxygen documentation
- [x] All new code in this PR does not add new compilation warnings (check CI output)
