### PR TITLE
[production/RRFS.v1] fix RRFS_sas_nogwd suite name inconsistency

### DIFF
--- a/ccpp/suites/suite_RRFS_sas_nogwd.xml
+++ b/ccpp/suites/suite_RRFS_sas_nogwd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="RRFS_sas" version="1">
+<suite name="RRFS_sas_nogwd" version="1">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">


### PR DESCRIPTION
## Description

This PR will fix the ccpp suite definition file name inconsistency for RRFS_sas_nogwd. It is not expected to change any result.


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>

# Requirements before merging
- [ ] All new code in this PR is tested by at least one unit test
- [ ] All new code in this PR includes Doxygen documentation
- [ ] All new code in this PR does not add new compilation warnings (check CI output)
