### PR TITLE
[production/RRFS.v1] saSAS sigmab initialization changes to reduce large initial reflectivity in RRFS and inline post bug fix for RUC LSM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/RRFS.v1
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = production/RRFS.v1
+  url = https://github.com/JiliDong-NOAA/ccpp-physics 
+  branch = sigmab_fix 
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = production/RRFS.v1
-  url = https://github.com/JiliDong-NOAA/ccpp-physics 
-  branch = sigmab_fix 
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = production/RRFS.v1
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1231,6 +1231,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: betascu         !< Tuning parameter for prog. closure shallow clouds
     real(kind=kind_phys) :: betamcu         !< Tuning parameter for prog. closure midlevel clouds 
     real(kind=kind_phys) :: betadcu         !< Tuning parameter for prog. closure deep clouds 
+    logical              :: sigmab_coldstart !< flag to cold start sigmab
 
     !--- MYNN parameters/switches
     logical              :: do_mynnedmf
@@ -4036,6 +4037,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: betascu           = 8.0 !< Tuning parameter for prog. closure shallow clouds
     real(kind=kind_phys) :: betamcu           = 1.0 !< Tuning parameter for prog. closure midlevel clouds
     real(kind=kind_phys) :: betadcu           = 2.0 !< Tuning parameter for prog. closure deep clouds
+    logical              :: sigmab_coldstart  = .false. !< flag to cold start sigmab
     ! *DH
     logical              :: do_myjsfc         = .false.               !< flag for MYJ surface layer scheme
     logical              :: do_myjpbl         = .false.               !< flag for MYJ PBL scheme
@@ -4367,6 +4369,7 @@ module GFS_typedefs
                                do_myjsfc, do_myjpbl,                                        &
                                hwrf_samfdeep, hwrf_samfshal,progsigma,betascu,betamcu,      &
                                betadcu,h2o_phys, pdfcld, shcnvcw, redrag, hybedmf, satmedmf,&
+                               sigmab_coldstart,                                            &
                                shinhong, do_ysu, dspheat, lheatstrg, lseaspray, cnvcld,     &
                                random_clds, shal_cnv, imfshalcnv, imfdeepcnv, isatmedmf,    &
                                conv_cf_opt, do_deep, jcap,                                  &
@@ -5176,6 +5179,7 @@ module GFS_typedefs
     Model%betascu = betascu
     Model%betamcu = betamcu
     Model%betadcu = betadcu
+    Model%sigmab_coldstart = sigmab_coldstart 
 
     if (oz_phys .and. oz_phys_2015) then
        write(*,*) 'Logic error: can only use one ozone physics option (oz_phys or oz_phys_2015), not both. Exiting.'
@@ -7202,6 +7206,7 @@ module GFS_typedefs
       print *, 'betascu            : ', Model%betascu
       print *, 'betamcu            : ', Model%betamcu
       print *, 'betadcu            : ', Model%betadcu
+      print *, 'sigmab_coldstart   : ', Model%sigmab_coldstart
       print *, ' '
       print *, 'cellular automata'
       print *, ' nca               : ', Model%nca

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -5566,6 +5566,12 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[sigmab_coldstart]
+  standard_name = flag_to_cold_start_for_sigmab_init
+  long_name = flag to cold start for sigmab initialization
+  units = flag
+  dimensions = ()
+  type = logical
 [isatmedmf]
   standard_name = choice_of_scale_aware_TKE_moist_EDMF_PBL
   long_name = choice of scale-aware TKE moist EDMF PBL scheme

--- a/io/fv3atm_history_io.F90
+++ b/io/fv3atm_history_io.F90
@@ -186,7 +186,7 @@ CONTAINS
     hist%fhzero = nint(Model%fhzero)
     !   hist%ncld   = Model%ncld
     hist%ncld   = Model%imp_physics
-    hist%nsoil  = Model%lsoil
+    hist%nsoil  = Model%lsoil_lsm
     hist%dtp    = Model%dtp
     hist%imp_physics  = Model%imp_physics
     hist%landsfcmdl  = Model%lsm

--- a/io/module_write_internal_state.F90
+++ b/io/module_write_internal_state.F90
@@ -98,6 +98,7 @@ module write_internal_state
       integer                  :: ncld !< Number of hydrometeors.
       integer                  :: nsoil !< Number of soil layers.
       integer                  :: imp_physics !< Choice of microphysics scheme.
+      integer                  :: landsfcmdl !< Choice of land surface model
       integer                  :: dtp !< Physics timestep.
       real,dimension(:),allocatable :: ak !< a parameter for sigma pressure level calculations.
       real,dimension(:),allocatable :: bk !< b parameter for sigma pressure level calculations.

--- a/io/post_fv3.F90
+++ b/io/post_fv3.F90
@@ -430,6 +430,7 @@ module post_fv3
             if (trim(attName) == 'nsoil')  wrt_int_state%nsoil=varival
             if (trim(attName) == 'fhzero') wrt_int_state%fhzero=varival
             if (trim(attName) == 'imp_physics') wrt_int_state%imp_physics=varival
+            if (trim(attName) == 'landsfcmdl') wrt_int_state%landsfcmdl=varival
           endif
         else if (typekind==ESMF_TYPEKIND_R4) then
           if(n==1) then
@@ -592,6 +593,7 @@ module post_fv3
 !
       integer i, ip1, j, l, k, n, iret, ibdl, rc, kstart, kend
       integer i1,i2,j1,j2,k1,k2
+      integer landsfcmdl
       integer fieldDimCount,gridDimCount,ncount_field,bundle_grid_id
       integer jdate(8)
       logical foundland, foundice, found, mvispresent
@@ -624,7 +626,7 @@ module post_fv3
 !
       imp_physics = wrt_int_state%imp_physics       !set GFS mp physics to 99 for Zhao scheme
       dtp         = wrt_int_state%dtp
-      iSF_SURFACE_PHYSICS = 2
+      iSF_SURFACE_PHYSICS = wrt_int_state%landsfcmdl 
       spval = 9.99e20
 !
 ! nems gfs has zhour defined
@@ -1589,7 +1591,6 @@ module post_fv3
               sllevel(7) = 1.0
               sllevel(8) = 1.6
               sllevel(9) = 3.0
-              iSF_SURFACE_PHYSICS = 3 
             endif 
 
             ! liquid volumetric soil mpisture in fraction

--- a/io/post_fv3.F90
+++ b/io/post_fv3.F90
@@ -1589,6 +1589,7 @@ module post_fv3
               sllevel(7) = 1.0
               sllevel(8) = 1.6
               sllevel(9) = 3.0
+              iSF_SURFACE_PHYSICS = 3 
             endif 
 
             ! liquid volumetric soil mpisture in fraction

--- a/io/post_fv3.F90
+++ b/io/post_fv3.F90
@@ -593,7 +593,6 @@ module post_fv3
 !
       integer i, ip1, j, l, k, n, iret, ibdl, rc, kstart, kend
       integer i1,i2,j1,j2,k1,k2
-      integer landsfcmdl
       integer fieldDimCount,gridDimCount,ncount_field,bundle_grid_id
       integer jdate(8)
       logical foundland, foundice, found, mvispresent


### PR DESCRIPTION
## Description

1. This PR follows Jongil's suggestion and aims to reduce the large convective reflectivity caused by saSAS adjustment in the first timestep during a warm start. The issue is likely related to the inconsistency when DA updates the moisture at t but not the moisture from the previous timestep (t-36s). The moisture from the previous timestep is needed for initializing sigmab (updraft area fraction) when calculating qadv (q advection or tendency term).

The PR forces qadv to zero in the first timestep when a namelist parameter sigmab_coldstart is set to .true. It also reduces the lower limit of sigmab from 0.01 to 0.0 in the first timestep.

dependent on ccpp-physics PR:

https://github.com/ufs-community/ccpp-physics/pull/225

2. Two bug fixes for LSM soil output with inline post are added in this PR:
2.1 https://github.com/NOAA-EMC/fv3atm/pull/877
2.2 @ericaligo-NOAA identified and fixed another bug with inline post when "lsoil" is different from "lsoil_lsm" which can happen when cold starting from Noah LSM input but running forecast with RUC LSM. In the above example, lsoil=4 and lsoil_lsm=9. There is no soil variables from inline post. The fix will set the correct "nsoil" based on lsoil_lsm and recover the LSM soil output.


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>

# Requirements before merging
- [ ] All new code in this PR is tested by at least one unit test
- [ ] All new code in this PR includes Doxygen documentation
- [ ] All new code in this PR does not add new compilation warnings (check CI output)
