### PR TITLE
Update calculation of time-averaged radiation variables

### DIFF
--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -975,6 +975,7 @@ subroutine update_atmos_model_state (Atmos, rc)
 !--- local variables
   integer :: i, localrc, sec_lastfhzerofh
   integer :: isec, seconds, isec_fhzero
+  integer :: datm_temp
   logical :: tmpflag_fhzero
   real(kind=GFS_kind_phys) :: time_int, time_intfull
 !
@@ -1021,11 +1022,11 @@ subroutine update_atmos_model_state (Atmos, rc)
       endif
       if (mpp_pe() == mpp_root_pe()) write(6,*) ' gfs diags time since last bucket empty: ',time_int/3600.,'hrs'
       call atmosphere_nggps_diag(Atmos%Time)
+      call get_time ( Atmos%Time_step, dtatm_temp)
       call fv3atm_diag_output(Atmos%Time, GFS_Diag, Atm_block, GFS_control%nx, GFS_control%ny, &
                             GFS_control%levs, 1, 1, 1.0_GFS_kind_phys, time_int, time_intfull, &
-                            GFS_control%fhswr, GFS_control%fhlwr)
+                            GFS_control%fhswr, GFS_control%fhlwr, datm_temp)
     endif
-
     !---  find current fhzero
     if( GFS_Control%fhzero_array(1) > 0. ) then
       fhzero_loop: do i=1,size(GFS_Control%fhzero_array)

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -1022,7 +1022,7 @@ subroutine update_atmos_model_state (Atmos, rc)
       endif
       if (mpp_pe() == mpp_root_pe()) write(6,*) ' gfs diags time since last bucket empty: ',time_int/3600.,'hrs'
       call atmosphere_nggps_diag(Atmos%Time)
-      call get_time ( Atmos%Time_step, dtatm_temp)
+      call get_time ( Atmos%Time_step, datm_temp)
       call fv3atm_diag_output(Atmos%Time, GFS_Diag, Atm_block, GFS_control%nx, GFS_control%ny, &
                             GFS_control%levs, 1, 1, 1.0_GFS_kind_phys, time_int, time_intfull, &
                             GFS_control%fhswr, GFS_control%fhlwr, datm_temp)

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -975,7 +975,7 @@ subroutine update_atmos_model_state (Atmos, rc)
 !--- local variables
   integer :: i, localrc, sec_lastfhzerofh
   integer :: isec, seconds, isec_fhzero
-  integer :: datm_temp
+  integer :: dtatm_temp
   logical :: tmpflag_fhzero
   real(kind=GFS_kind_phys) :: time_int, time_intfull
 !
@@ -1022,10 +1022,10 @@ subroutine update_atmos_model_state (Atmos, rc)
       endif
       if (mpp_pe() == mpp_root_pe()) write(6,*) ' gfs diags time since last bucket empty: ',time_int/3600.,'hrs'
       call atmosphere_nggps_diag(Atmos%Time)
-      call get_time ( Atmos%Time_step, datm_temp)
+      call get_time ( Atmos%Time_step, dtatm_temp)
       call fv3atm_diag_output(Atmos%Time, GFS_Diag, Atm_block, GFS_control%nx, GFS_control%ny, &
                             GFS_control%levs, 1, 1, 1.0_GFS_kind_phys, time_int, time_intfull, &
-                            GFS_control%fhswr, GFS_control%fhlwr, datm_temp)
+                            GFS_control%fhswr, GFS_control%fhlwr, dtatm_temp)
     endif
     !---  find current fhzero
     if( GFS_Control%fhzero_array(1) > 0. ) then


### PR DESCRIPTION
## Description

This PR fixes incorrect diagnostic output for fhzero-averaged radiation output variables. Presently, there is a significant "sawtooth" appearance to these fields (such as dswrf_ave and ulwrf_avetoa) when we expect smoother lines with jumps only at fhzero diagnostic reset times. Here is an example of the present (OLD) result and the result from the current PR (FIX) from a 24-hour S2S regression test forecast.

![iTerm2 RaUnsB rads_fhzero6_fix](https://github.com/user-attachments/assets/9f584f3f-5e03-4e93-85dc-d1e98e1d4d08)


### Issue(s) addressed

- fixes an problem found in investigating ufs-weather-model/[#1767](https://github.com/ufs-community/ufs-weather-model/issues/1767)

## Testing

Ran full regression test suite on Hera. See log files here: /scratch1/NAGAPE/hpc-wof1/lreames/ufs-weather-model-38a29a6/tests/logs/log_hera
All regression tests fail as sfcf*.nc files are not identical.  New baselines will be necessary.

## Dependencies

N/A. All changes are contained in fv3atm.


# Requirements before merging
- [ ] All new code in this PR is tested by at least one unit test
- [ ] All new code in this PR includes Doxygen documentation
- [ ] All new code in this PR does not add new compilation warnings (check CI output)
