### PR TITLE
Update chunksizes for cubed sphere grid

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  #url = https://github.com/NCAR/ccpp-framework
-  #branch = main
-  url = https://github.com/climbfuji/ccpp-framework
-  branch = bugfix/unit_conv_invalid_allocation_prebuild
+  url = https://github.com/NCAR/ccpp-framework
+  branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  url = https://github.com/NCAR/ccpp-framework
-  branch = main
+  #url = https://github.com/NCAR/ccpp-framework
+  #branch = main
+  url = https://github.com/climbfuji/ccpp-framework
+  branch = bugfix/unit_conv_invalid_allocation_prebuild
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics

--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -398,14 +398,14 @@ contains
             par_access = NF90_COLLECTIVE
             if (rank == 2 .and. ichunk2d(grid_id) > 0 .and. jchunk2d(grid_id) > 0) then
                if (is_cubed_sphere) then
-                  chunksizes = [im, jm, tileCount, 1]
+                  chunksizes = [im, jm, 1, 1]
                else
                   chunksizes = [ichunk2d(grid_id), jchunk2d(grid_id),            1]
                end if
                ncerr = nf90_def_var_chunking(ncid, varids(i), NF90_CHUNKED, chunksizes) ; NC_ERR_STOP(ncerr)
             else if (rank == 3 .and. ichunk3d(grid_id) > 0 .and. jchunk3d(grid_id) > 0 .and. kchunk3d(grid_id) > 0) then
                if (is_cubed_sphere) then
-                  chunksizes = [im, jm, lm, tileCount, 1]
+                  chunksizes = [im, jm, 1, 1, 1]
                else
                   chunksizes = [ichunk3d(grid_id), jchunk3d(grid_id), min(kchunk3d(grid_id),fldlev(i)), 1]
                end if


### PR DESCRIPTION
## Description

Change the default chunking for the cubed sphere history files to use only the horizontal grid size of each of the tiles. 

What bug does it fix, or what feature does it add?  Slow writing of native grid history files, especially with c768 configurations.
Is a change of answers expected from this PR?  No.

This PR should be combined with other PR that does not change baselines.



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes ufs-community/ufs-weather-model/issues/2439



## Testing

How were these changes tested?  Yes.
What compilers / HPCs was it tested with? Intel/Hera 
Are the changes covered by regression tests? Yes.
Have the ufs-weather-model regression test been run? Yes. On what platform?  Hera
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

No.

# Requirements before merging
- [x] All new code in this PR is tested by at least one unit test
- [x] All new code in this PR includes Doxygen documentation
- [x] All new code in this PR does not add new compilation warnings (check CI output)
