### PR TITLE
[production/RRFS.v1] fix for inline post when using RUC LSM

### DIFF
--- a/io/module_write_internal_state.F90
+++ b/io/module_write_internal_state.F90
@@ -98,6 +98,7 @@ module write_internal_state
       integer                  :: ncld !< Number of hydrometeors.
       integer                  :: nsoil !< Number of soil layers.
       integer                  :: imp_physics !< Choice of microphysics scheme.
+      integer                  :: landsfcmdl !< Choice of land surface model
       integer                  :: dtp !< Physics timestep.
       real,dimension(:),allocatable :: ak !< a parameter for sigma pressure level calculations.
       real,dimension(:),allocatable :: bk !< b parameter for sigma pressure level calculations.

--- a/io/post_fv3.F90
+++ b/io/post_fv3.F90
@@ -430,6 +430,7 @@ module post_fv3
             if (trim(attName) == 'nsoil')  wrt_int_state%nsoil=varival
             if (trim(attName) == 'fhzero') wrt_int_state%fhzero=varival
             if (trim(attName) == 'imp_physics') wrt_int_state%imp_physics=varival
+            if (trim(attName) == 'landsfcmdl') wrt_int_state%landsfcmdl=varival
           endif
         else if (typekind==ESMF_TYPEKIND_R4) then
           if(n==1) then
@@ -592,6 +593,7 @@ module post_fv3
 !
       integer i, ip1, j, l, k, n, iret, ibdl, rc, kstart, kend
       integer i1,i2,j1,j2,k1,k2
+      integer landsfcmdl
       integer fieldDimCount,gridDimCount,ncount_field,bundle_grid_id
       integer jdate(8)
       logical foundland, foundice, found, mvispresent
@@ -624,7 +626,7 @@ module post_fv3
 !
       imp_physics = wrt_int_state%imp_physics       !set GFS mp physics to 99 for Zhao scheme
       dtp         = wrt_int_state%dtp
-      iSF_SURFACE_PHYSICS = 2
+      iSF_SURFACE_PHYSICS = wrt_int_state%landsfcmdl 
       spval = 9.99e20
 !
 ! nems gfs has zhour defined
@@ -1589,7 +1591,6 @@ module post_fv3
               sllevel(7) = 1.0
               sllevel(8) = 1.6
               sllevel(9) = 3.0
-              iSF_SURFACE_PHYSICS = 3 
             endif 
 
             ! liquid volumetric soil mpisture in fraction

--- a/io/post_fv3.F90
+++ b/io/post_fv3.F90
@@ -1589,6 +1589,7 @@ module post_fv3
               sllevel(7) = 1.0
               sllevel(8) = 1.6
               sllevel(9) = 3.0
+              iSF_SURFACE_PHYSICS = 3 
             endif 
 
             ! liquid volumetric soil mpisture in fraction

--- a/io/post_fv3.F90
+++ b/io/post_fv3.F90
@@ -593,7 +593,6 @@ module post_fv3
 !
       integer i, ip1, j, l, k, n, iret, ibdl, rc, kstart, kend
       integer i1,i2,j1,j2,k1,k2
-      integer landsfcmdl
       integer fieldDimCount,gridDimCount,ncount_field,bundle_grid_id
       integer jdate(8)
       logical foundland, foundice, found, mvispresent


### PR DESCRIPTION
## Description

@ericaligo-NOAA found an issue where inline post does not correctly output soil temperature and moisture in grib2 when using RUC LSM. We tracked this to post_fv3 where iSF_SURFACE_PHYSICS is not updated for RUC LSM. This parameter is used in UPP SURFACE.f for soil variables output. The initial iSF_SURFACE_PHYSICS = 2 in post_fv3 and should be updated to 3 when RUC LSM is used. In this PR we set iSF_SURFACE_PHYSICS =3 when nsoil=9 and successfully output the 9 level soil variables.   

A PR to ufs-weather-model will be submitted later.

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>

# Requirements before merging
- [ ] All new code in this PR is tested by at least one unit test
- [ ] All new code in this PR includes Doxygen documentation
- [ ] All new code in this PR does not add new compilation warnings (check CI output)
