### PR TITLE
Submodule pointer update for ccpp-framework PR 600 (bug fix for unit conversion error in ccpp_prebuild.py )

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  url = https://github.com/NCAR/ccpp-framework
-  branch = main
+  #url = https://github.com/NCAR/ccpp-framework
+  #branch = main
+  url = https://github.com/climbfuji/ccpp-framework
+  branch = bugfix/unit_conv_invalid_allocation_prebuild
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics


### PR DESCRIPTION
## Description

This PR updates the submodule pointer for ccpp-framework for the changes described in https://github.com/NCAR/ccpp-framework/pull/600 (Bug fix for unit conversion error in ccpp_prebuild.py (variables that are slices of a n+1 dimensional array have wrong allocation). The bug that is being fixed did not affect the UFS Weather Model, hence there are no answer changes associated with this update.

### Issue(s) addressed

Resolves https://github.com/NCAR/ccpp-framework/issues/598

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/2464 (ufs-weather-model regression tests passed against exising baseline on Hera).

## Dependencies

- [ ] waiting on https://github.com/NCAR/ccpp-framework/pull/600

# Requirements before merging
- [x] All new code in this PR is tested by at least one unit test
- [ ] ~~All new code in this PR includes Doxygen documentation~~
- [x] All new code in this PR does not add new compilation warnings (check CI output)
