### PR TITLE
Fifth reconciliation PR from production/RRFS.v1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = ufs/dev
-  url = https://github.com/grantfirl/ccpp-physics
-  branch = rrfsv1-to-ufs/dev5
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -4971,7 +4971,7 @@ module GFS_diagnostics
       endif
 
       endif  extended_smoke_dust_diagnostics
-
+      
       idx = idx + 1
       ExtDiag(idx)%axes = 3
       ExtDiag(idx)%name = 'ebu_smoke'
@@ -4980,7 +4980,7 @@ module GFS_diagnostics
       ExtDiag(idx)%mod_name = 'gfs_phys'
       allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var3 => Coupling(nb)%ebu_smoke(:,:)
+       ExtDiag(idx)%data(nb)%var3 => Coupling%ebu_smoke(Model%chunk_begin(nb):Model%chunk_end(nb),:)
       enddo
 
       idx = idx + 1
@@ -5043,17 +5043,6 @@ module GFS_diagnostics
       enddo
 
       endif smoke_forecast_mode
-
-      idx = idx + 1
-      ExtDiag(idx)%axes = 3
-      ExtDiag(idx)%name = 'ebu_smoke'
-      ExtDiag(idx)%desc = 'smoke emission'
-      ExtDiag(idx)%unit = 'ug/m2/s'
-      ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
-      do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var3 => Coupling%ebu_smoke(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
 
       idx = idx + 1
       ExtDiag(idx)%axes = 3

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -4972,6 +4972,16 @@ module GFS_diagnostics
 
       endif  extended_smoke_dust_diagnostics
 
+      idx = idx + 1
+      ExtDiag(idx)%axes = 3
+      ExtDiag(idx)%name = 'ebu_smoke'
+      ExtDiag(idx)%desc = 'smoke emission'
+      ExtDiag(idx)%unit = 'ug/m2/s'
+      ExtDiag(idx)%mod_name = 'gfs_phys'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+       ExtDiag(idx)%data(nb)%var3 => Coupling(nb)%ebu_smoke(:,:)
+      enddo
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2

--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -407,7 +407,7 @@ contains
                if (is_cubed_sphere) then
                   chunksizes = [im, jm, 1, 1, 1]
                else
-                  chunksizes = [ichunk3d(grid_id), jchunk3d(grid_id), fldlev(i), 1]
+                  chunksizes = [ichunk3d(grid_id), jchunk3d(grid_id), min(kchunk3d(grid_id),fldlev(i)), 1]
                end if
                ncerr = nf90_def_var_chunking(ncid, varids(i), NF90_CHUNKED, chunksizes) ; NC_ERR_STOP(ncerr)
             end if

--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -407,7 +407,11 @@ contains
                if (is_cubed_sphere) then
                   chunksizes = [im, jm, 1, 1, 1]
                else
+<<<<<<< HEAD
                   chunksizes = [ichunk3d(grid_id), jchunk3d(grid_id), min(kchunk3d(grid_id),fldlev(i)), 1]
+=======
+                  chunksizes = [ichunk3d(grid_id), jchunk3d(grid_id), fldlev(i), 1]
+>>>>>>> c01786de (Update io/module_write_netcdf.F90 (#810))
                end if
                ncerr = nf90_def_var_chunking(ncid, varids(i), NF90_CHUNKED, chunksizes) ; NC_ERR_STOP(ncerr)
             end if

--- a/io/module_write_netcdf.F90
+++ b/io/module_write_netcdf.F90
@@ -407,11 +407,7 @@ contains
                if (is_cubed_sphere) then
                   chunksizes = [im, jm, 1, 1, 1]
                else
-<<<<<<< HEAD
-                  chunksizes = [ichunk3d(grid_id), jchunk3d(grid_id), min(kchunk3d(grid_id),fldlev(i)), 1]
-=======
                   chunksizes = [ichunk3d(grid_id), jchunk3d(grid_id), fldlev(i), 1]
->>>>>>> c01786de (Update io/module_write_netcdf.F90 (#810))
                end if
                ncerr = nf90_def_var_chunking(ncid, varids(i), NF90_CHUNKED, chunksizes) ; NC_ERR_STOP(ncerr)
             end if


### PR DESCRIPTION
## Description

This is the same as https://github.com/NOAA-EMC/fv3atm/pull/812, but targeting the develop branch.

This is @jordanschnell's work and his description is as follows:
For ebb_dcycle==1 (retrospective fire emissions), the 3-d emissions were incorrectly assgined assigned at all levels using the surface data.

### Issue(s) addressed

fixes Issue https://github.com/ufs-community/ccpp-physics/issues/188

## Testing

This was tested using UWM RTs on Hera. See https://github.com/ufs-community/ufs-weather-model/pull/2485 for results.


## Dependencies

https://github.com/ufs-community/ccpp-physics/pull/231

# Requirements before merging
- [ ] All new code in this PR is tested by at least one unit test
- [ ] All new code in this PR includes Doxygen documentation
- [ ] All new code in this PR does not add new compilation warnings (check CI output)
