### PR TITLE
Minor modification and bug fix in GFS cumulus convection schemes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/rhaesung/ccpp-physics
+  branch = conv_hr5update
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/rhaesung/ccpp-physics
+  branch = hr5
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,7 +11,7 @@
 #  url = https://github.com/ufs-community/ccpp-physics
 #  branch = ufs/dev
   url = https://github.com/rhaesung/ccpp-physics
-  branch = hr5
+  branch = conv_hr5update
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = ufs/dev
-  url = https://github.com/rhaesung/ccpp-physics
-  branch = conv_hr5update
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  url =	https://github.com/laurenchilutti/GFDL_atmos_cubed_sphere
+  branch = remap_io_emc
+#  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+#  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,19 +1,15 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url =	https://github.com/laurenchilutti/GFDL_atmos_cubed_sphere
-  branch = remap_io_emc
-#  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-#  branch = dev/emc
+  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = ufs/dev
-  url = https://github.com/rhaesung/ccpp-physics
-  branch = conv_hr5update
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/CCPP_typedefs.F90
+++ b/ccpp/data/CCPP_typedefs.F90
@@ -1068,6 +1068,7 @@ contains
       do n=2,Model%ntrac
         ltest = ( n /= Model%ntcw  .and. n /= Model%ntiw  .and. n /= Model%ntclamt .and. &
                   n /= Model%ntrw  .and. n /= Model%ntsw  .and. n /= Model%ntrnc   .and. &
+                  n /= Model%ntlnc .and. n /= Model%ntinc                          .and. &
                   n /= Model%ntsnc .and. n /= Model%ntgl  .and. n /= Model%ntgnc   .and. &
                   n /= Model%nthl  .and. n /= Model%nthnc .and. n /= Model%ntgv    .and. &
                   n /= Model%nthv  .and. n /= Model%ntccn .and. n /= Model%ntccna  .and. &

--- a/ccpp/data/CCPP_typedefs.F90
+++ b/ccpp/data/CCPP_typedefs.F90
@@ -285,6 +285,7 @@ module CCPP_typedefs
     real (kind=kind_phys), pointer      :: t2mmp(:)           => null()  !<
     real (kind=kind_phys), pointer      :: theta(:)           => null()  !<
     real (kind=kind_phys), pointer      :: tlvl(:,:)          => null()  !<
+    real (kind=kind_phys), pointer      :: tkeh(:,:)          => null()  !< vertical turbulent kinetic energy (m2/s2) at the model layer interfaces
     real (kind=kind_phys), pointer      :: tlyr(:,:)          => null()  !<
     real (kind=kind_phys), pointer      :: tprcp_ice(:)       => null()  !<
     real (kind=kind_phys), pointer      :: tprcp_land(:)      => null()  !<
@@ -696,6 +697,7 @@ contains
     allocate (Interstitial%stress_land     (IM))
     allocate (Interstitial%stress_water    (IM))
     allocate (Interstitial%theta           (IM))
+    allocate (Interstitial%tkeh            (IM,Model%levs+1)) !Vertical turbulent kinetic energy at model layer interfaces
     allocate (Interstitial%tlvl            (IM,Model%levr+1+LTP))
     allocate (Interstitial%tlyr            (IM,Model%levr+LTP))
     allocate (Interstitial%tprcp_ice       (IM))
@@ -1347,6 +1349,7 @@ contains
     Interstitial%stress_land     = Model%huge
     Interstitial%stress_water    = Model%huge
     Interstitial%theta           = clear_val
+    Interstitial%tkeh            = 0
     Interstitial%tprcp_ice       = Model%huge
     Interstitial%tprcp_land      = Model%huge
     Interstitial%tprcp_water     = Model%huge

--- a/ccpp/data/CCPP_typedefs.meta
+++ b/ccpp/data/CCPP_typedefs.meta
@@ -2836,6 +2836,13 @@
   units = count
   dimensions = ()
   type = integer
+[tkeh]
+   standard_name = vertical_turbulent_kinetic_energy_at_interface
+   long_name = vertical turbulent kinetic energy at model layer interfaces
+   units = m2 s-2
+   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
+   type = real
+   kind = kind_phys
 
 ########################################################################
 [ccpp-table-properties]

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1962,6 +1962,9 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: tsnowpb(:)     => null()   !< accumulated surface snowfall in bucket (m)
     real (kind=kind_phys), pointer :: rhonewsn1(:)   => null()   !< precipitation ice density outside RUC LSM (kg/m3)
 
+    !--- TKE used by convection schemes
+    real (kind=kind_phys), pointer :: tkeh(:,:)      => null()   !< vertical turbulent kinetic energy (m2/s2) at the model layer interfaces
+
     !--- MYNN variables
     real (kind=kind_phys), pointer :: edmf_a     (:,:)   => null()  !
     real (kind=kind_phys), pointer :: edmf_w     (:,:)   => null()  !
@@ -7898,6 +7901,9 @@ module GFS_typedefs
     allocate (Diag%refl_10cm(IM,Model%levs))
     allocate (Diag%max_hail_diam_sfc(IM))
 
+    !--- Vertical turbulent kinetic energy at model layer interfaces
+    allocate (Diag%tkeh(IM,Model%levs))
+
     !--- New PBL Diagnostics
     allocate (Diag%dkt(IM,Model%levs))
     allocate (Diag%dku(IM,Model%levs))
@@ -8246,6 +8252,9 @@ module GFS_typedefs
 
 !
 !-----------------------------
+
+! Vertical turbulent kinetic energy at modle layer interfaces
+    Diag%tkeh = zero
 
 ! Extra PBL diagnostics
     Diag%dkt = zero

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1993,9 +1993,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: tsnowpb(:)     => null()   !< accumulated surface snowfall in bucket (m)
     real (kind=kind_phys), pointer :: rhonewsn1(:)   => null()   !< precipitation ice density outside RUC LSM (kg/m3)
 
-    !--- TKE used by convection schemes
-    real (kind=kind_phys), pointer :: tkeh(:,:)      => null()   !< vertical turbulent kinetic energy (m2/s2) at the model layer interfaces
-
     !--- MYNN variables
     real (kind=kind_phys), pointer :: edmf_a     (:,:)   => null()  !
     real (kind=kind_phys), pointer :: edmf_w     (:,:)   => null()  !
@@ -7955,9 +7952,6 @@ module GFS_typedefs
     allocate (Diag%refl_10cm(IM,Model%levs))
     allocate (Diag%max_hail_diam_sfc(IM))
 
-    !--- Vertical turbulent kinetic energy at model layer interfaces
-    allocate (Diag%tkeh(IM,Model%levs))
-
     !--- New PBL Diagnostics
     allocate (Diag%dkt(IM,Model%levs))
     allocate (Diag%dku(IM,Model%levs))
@@ -8294,9 +8288,6 @@ module GFS_typedefs
 
 !
 !-----------------------------
-
-! Vertical turbulent kinetic energy at modle layer interfaces
-    Diag%tkeh = zero
 
 ! Extra PBL diagnostics
     Diag%dkt = zero

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -9378,7 +9378,7 @@
   long_name = vertical turbulent kinetic energy at model layer interfaces
   units = m2 s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
-  type = real 
+  type = real
   kind = kind_phys
 [dkt]
   standard_name = atmosphere_heat_diffusivity

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -9440,13 +9440,6 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
-[tkeh]
-  standard_name = vertical_turbulent_kinetic_energy_at_interface
-  long_name = vertical turbulent kinetic energy at model layer interfaces
-  units = m2 s-2
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
-  type = real
-  kind = kind_phys
 [dkt]
   standard_name = atmosphere_heat_diffusivity
   long_name = atmospheric heat diffusivity

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -9373,6 +9373,13 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
+[tkeh]
+  standard_name = vertical_turbulent_kinetic_energy_at_interface
+  long_name = vertical turbulent kinetic energy at model layer interfaces
+  units = m2 s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real 
+  kind = kind_phys
 [dkt]
   standard_name = atmosphere_heat_diffusivity
   long_name = atmospheric heat diffusivity


### PR DESCRIPTION
## Description

This PR mainly involves changes in ccpp-physics, and the code was provided by @JongilHan66.

1. Modified prognostic updraft fraction (sigmab) calculation in 'progsigma_calc.f90' which is physically more sound:
    a) moisture convergence calculation: integrate from the convection source level rather than from the cloud base
    b) 2D advection of sigmab:  sigmab advection averaged over the cloud layers rather than taking a maximum sigmab advection from k=2 to the model top
   c) To suppress unrealistically large reflectivity in the model first time step, minimum sigmab at the first time step is set to zero

2. Fix in missing vertical transport of turbulent kinetic energy (TKE) when aerosol transport is turned on (samfdeepcnv.f & samfshalcnv.f)

3. Introduce TKE at model layer interfaces (tkeh) for use in convection schemes (CCPP_typedefs.F90, CCPP_typedefs.meta, satmedmfvdifq.F, satmedmfvdifq.meta, samfdeepcnv.f, samfdeepcnv.meta, samfshalcnv.f, and samfshalcnv.meta)

4. Vertical transports of hydrometeor variables are currently not allowed in the convection schemes. But vertical transports of number concentrations of only cloud water and ice are mistakenly allowed, which is fixed in this update (CCPP_typedefs.F90)

5. All the modifications and bug fixes above had neutral impacts on the GFS forecasts

## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on ufs-community/ccpp-physics  #https://github.com/ufs-community/ccpp-physics/pull/232
