### PR TITLE
Feature/vegtype export

### DIFF
--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -1342,7 +1342,7 @@ subroutine update_atmos_chemistry(state, rc)
   real(ESMF_KIND_R8), dimension(:,:), pointer :: aod, area, canopy, cmm,  &
     dqsfc, dtsfc, fice, flake, focn, fsnow, hpbl, nswsfc, oro, psfc, &
     q2m, rain, rainc, rca, shfsfc, slmsk, stype, swet, t2m, tsfc,    &
-    u10m, uustar, v10m, vfrac, xlai, zorl
+    u10m, uustar, v10m, vfrac, xlai, zorl, vtype, nvegcat, fvtype
 
 ! logical, parameter :: diag = .true.
 
@@ -3344,7 +3344,7 @@ end subroutine update_atmos_chemistry
             !--- Instantaneous quantities
             ! Instantaneous mean layer pressure (Pa)
             case ('inst_pres_levels')
-              call block_data_copy_or_fill(datar83d, GFS_statein%prsl, zeror8, Atm_block, nb, offset=GFS_Control%chunk_begin(nb), rc=localrc)  
+              call block_data_copy_or_fill(datar83d, GFS_statein%prsl, zeror8, Atm_block, nb, offset=GFS_Control%chunk_begin(nb), rc=localrc)
             ! Instantaneous geopotential at model layer centers (m2 s-2)
             case ('inst_geop_levels')
               call block_data_copy_or_fill(datar83d, GFS_statein%phil, zeror8, Atm_block, nb, offset=GFS_Control%chunk_begin(nb), rc=localrc)
@@ -3356,7 +3356,7 @@ end subroutine update_atmos_chemistry
               call block_data_copy_or_fill(datar83d, GFS_statein%vgrs, zeror8, Atm_block, nb, offset=GFS_Control%chunk_begin(nb), rc=localrc)
             ! Instantaneous surface roughness length (cm)
             case ('inst_surface_roughness')
-              call block_data_copy(datar82d, GFS_sfcprop%zorl, Atm_block, nb, offset=GFS_Control%chunk_begin(nb), rc=localrc)            
+              call block_data_copy(datar82d, GFS_sfcprop%zorl, Atm_block, nb, offset=GFS_Control%chunk_begin(nb), rc=localrc)
             ! Instantaneous u wind (m/s) 10 m above ground
             case ('inst_zonal_wind_height10m')
               call block_data_copy(datar82d, GFS_coupling%u10mi_cpl, Atm_block, nb, offset=GFS_Control%chunk_begin(nb), rc=localrc)

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -1342,7 +1342,7 @@ subroutine update_atmos_chemistry(state, rc)
   real(ESMF_KIND_R8), dimension(:,:), pointer :: aod, area, canopy, cmm,  &
     dqsfc, dtsfc, fice, flake, focn, fsnow, hpbl, nswsfc, oro, psfc, &
     q2m, rain, rainc, rca, shfsfc, slmsk, stype, swet, t2m, tsfc,    &
-    u10m, uustar, v10m, vfrac, xlai, zorl, vtype, nvegcat, fvtype
+    u10m, uustar, v10m, vfrac, xlai, zorl, vtype
 
 ! logical, parameter :: diag = .true.
 
@@ -1600,6 +1600,10 @@ subroutine update_atmos_chemistry(state, rc)
         if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, file=__FILE__, rcToReturn=rc)) return
 
+        call cplFieldGet(state,'vegetation_type', farrayPtr2d=vtype, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, file=__FILE__, rcToReturn=rc)) return
+
       else
 
         call cplFieldGet(state,'inst_liq_nonconv_tendency_levels', &
@@ -1725,6 +1729,7 @@ subroutine update_atmos_chemistry(state, rc)
         !  stype(i,j) = real(int( GFS_Data(nb)%Sfcprop%stype(ix)+0.5 ), kind=ESMF_KIND_R8)
         !endif
         stype = real(int(reshape(GFS_Sfcprop%stype, shape(stype))+0.5), kind=ESMF_KIND_R8)
+        vtype = real(int(reshape(GFS_Sfcprop%vtype, shape(vtype))+0.5), kind=ESMF_KIND_R8)
         if (GFS_Control%isot == 1) then
           where (slmsk == 2) stype = 16._ESMF_KIND_R8
         else
@@ -1811,6 +1816,7 @@ subroutine update_atmos_chemistry(state, rc)
           write(6,'("update_atmos: vfrac  - min/max/avg",3g16.6)') minval(vfrac),  maxval(vfrac),  sum(vfrac)/size(vfrac)
           write(6,'("update_atmos: xlai   - min/max/avg",3g16.6)') minval(xlai),   maxval(xlai),   sum(xlai)/size(xlai)
           write(6,'("update_atmos: stype  - min/max/avg",3g16.6)') minval(stype),  maxval(stype),  sum(stype)/size(stype)
+          write(6,'("update_atmos: vtype  - min/max/avg",3g16.6)') minval(vtype),  maxval(vtype),  sum(vtype)/size(vtype)
         else
           write(6,'("update_atmos: flake  - min/max/avg",3g16.6)') minval(flake),  maxval(flake),  sum(flake)/size(flake)
           write(6,'("update_atmos: focn   - min/max/avg",3g16.6)') minval(focn),   maxval(focn),   sum(focn)/size(focn)

--- a/cpl/module_cplfields.F90
+++ b/cpl/module_cplfields.F90
@@ -125,6 +125,8 @@ module module_cplfields
     FieldInfo("inst_temp_height_lowest_from_phys        ", "s"), &
     FieldInfo("inst_exner_function_height_lowest        ", "s"), &
     FieldInfo("surface_friction_velocity                ", "s"), &
+    ! FieldInfo("fraction_of_vegetation_category          ", "s"), &
+    ! FieldInfo("number_of_vegetation_categories          ", "s"), &
 
 
     !  For JEDI
@@ -274,7 +276,10 @@ module module_cplfields
     "leaf_area_index                 ", &
     "soil_type                       ", &
     "temperature_of_soil_layer       ", &
-    "height                          "  &
+    "height                          ", &
+    "vegetation_type                 " &
+    ! "number_of_vegetation_categories ", &
+    ! "fraction_of_vegetation_category "  &
     ]
 
   ! Methods


### PR DESCRIPTION
## Description
This pull request includes updates to the `update_atmos_chemistry` subroutine in `atmos_model.F90` and modifications in the `module_cplfields` module in `cpl/module_cplfields.F90`. The changes primarily focus on incorporating the `vtype` (vegetation type) variable into the atmospheric chemistry update process.

Updates to `atmos_model.F90`:

* Added `vtype` to the list of variables in `update_atmos_chemistry` subroutine.
* Included a call to `cplFieldGet` to retrieve the `vegetation_type` field and assign it to `vtype`.
* Updated the reshaping and type conversion logic to include `vtype`.
* Added logging for `vtype` to output its min, max, and average values.

Modifications to `cpl/module_cplfields.F90`:

* Commented out the `fraction_of_vegetation_category` and `number_of_vegetation_categories` fields in the `FieldInfo` list.
* Added `vegetation_type` to the list of fields, and commented out `number_of_vegetation_categories` and `fraction_of_vegetation_category`.

closes #889 
This PR goes along with https://github.com/NOAA-EMC/AQM/pull/106

### Issue(s) addressed

- fixes [#102](https://github.com/NOAA-EMC/AQM/issues/102)



## Testing


## Dependencies

Should be paired with bbakernoaa/aqm/feature/vegtype

# Requirements before merging
- [ ] All new code in this PR is tested by at least one unit test
- [ ] All new code in this PR includes Doxygen documentation
- [ ] All new code in this PR does not add new compilation warnings (check CI output)
