### PR TITLE
Add CCPP host variable to track initialization of GFS_phys_time_vary, fix bug for MP Thompson init flag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = ufs/dev
+  url = https://github.com/climbfuji/ccpp-physics
+  branch = feature/gfs_phys_time_vary_nrl_multiinstance
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -807,6 +807,8 @@ module GFS_typedefs
                                             !< (yr, mon, day, t-zone, hr, min, sec, mil-sec)
     integer              :: idate(4)        !< initial date with different size and ordering
                                             !< (hr, mon, day, yr)
+    logical              :: gfs_phys_time_vary_is_init=.false. !< GFS_phys_time_vary interstitial initialization flag 
+
 !--- radiation control parameters
     real(kind=kind_phys) :: fhswr           !< frequency for shortwave radiation (secs)
     real(kind=kind_phys) :: fhlwr           !< frequency for longwave radiation (secs)
@@ -1033,7 +1035,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: dt_inner        !< time step for the inner loop in s
     logical              :: sedi_semi       !< flag for semi Lagrangian sedi of rain
     integer              :: decfl           !< deformed CFL factor
-    logical              :: thpsnmp_is_init !< Local scheme initialization flag
+    logical              :: thompson_mp_is_init=.false. !< Local scheme initialization flag
 
     !--- GFDL microphysical paramters
     logical              :: lgfdlmprad      !< flag for GFDL mp scheme and radiation consistency
@@ -3591,7 +3593,6 @@ module GFS_typedefs
     real(kind=kind_phys) :: dt_inner       = -999.0             !< time step for the inner loop
     logical              :: sedi_semi      = .false.            !< flag for semi Lagrangian sedi of rain
     integer              :: decfl          = 8                  !< deformed CFL factor
-    logical              :: thpsnmp_is_init = .false.           !< Local scheme initialization flag 
 
     !--- GFDL microphysical parameters
     logical              :: lgfdlmprad     = .false.            !< flag for GFDLMP radiation interaction

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -4911,9 +4911,15 @@
   units = count
   dimensions = ()
   type = integer
-[thpsnmp_is_init]
+[thompson_mp_is_init]
   standard_name = flag_for_thompson_mp_scheme_initialization
   long_name = flag carrying scheme initialization status
+  units = flag
+  dimensions = ()
+  type = logical
+[gfs_phys_time_vary_is_init]
+  standard_name = flag_for_gfs_phys_time_vary_interstitial_initialization
+  long_name = flag carrying interstitial initialization status
   units = flag
   dimensions = ()
   type = logical


### PR DESCRIPTION
## Description

This PR goes together with https://github.com/ufs-community/ccpp-physics/pull/242 and is needed to support multiple instances of CCPP physics within one host model execution.

While adding the `is_init` flag for the `GFS_phys_time_vary` scheme, I noticed a bug for the corresponding flag for Thompson microphysics. Instead of initializing the GFS_control DDT member, the existing code initializes a _local_ copy of the flag to false. This doesn't have any effect in the UFS, because any uninitialized logical flag is `.false.` by default.

### Issue(s) addressed

This PR and associated PRs below form the last set of PRs to replace https://github.com/NCAR/ccpp-physics/pull/1000, which was created to support the case of multiple CCPP physics instances in one model run.

## Testing

- Compiled UFS S2S application on my laptop with spack-stack (`gcc@13.3.0`, `openmpi@5.0.5`).
- For UFS regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/2544

## Dependencies

- Waiting on https://github.com/ufs-community/ccpp-physics/pull/242
- Downstream ufs-weather-model PR: https://github.com/ufs-community/ufs-weather-model/pull/2544

# Requirements before merging
- [ ] ~~All new code in this PR is tested by at least one unit test~~ not applicable
- [ ] ~~All new code in this PR includes Doxygen documentation~~ not applicable
- [x] All new code in this PR does not add new compilation warnings (check CI output)
