### PR TITLE
fix the documentation build for fv3atm, getting the CI to work

### DIFF
--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -74,8 +74,8 @@ jobs:
 
     steps:
 
-    # Only do Doxygen and gcovr build for one job
-    - name: decide-doc-gcovr-build
+    # Only do gcovr build for one job
+    - name: decide-gcovr-build
       run: |
         if [[ "${{ matrix.cmake_opts }}" == "-D32BIT=ON" && "${{ matrix.gcc_ver }}" == 12 && "${{ matrix.mpi }}" == mpich ]]; then
           echo 'devbuild=ON' | tee -a ${GITHUB_ENV}
@@ -86,7 +86,6 @@ jobs:
 
     - name: install-utilities
       run: |
-        sudo apt-get install doxygen graphviz
         python3 -m pip install gcovr
 
     - name: install-cmake
@@ -121,7 +120,7 @@ jobs:
         export CC=mpicc
         export CXX=mpicxx
         export FC=mpif90
-        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_TESTING=ON ${{ matrix.cmake_opts }} -DENABLE_DOCS=ON ${{ env.gcov_cmake }}
+        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_TESTING=ON ${{ matrix.cmake_opts }} ${{ env.gcov_cmake }}
         make -j2
 
     - name: run-tests
@@ -143,14 +142,6 @@ jobs:
         path: |
               ${{ github.workspace }}/build/*.html 
               ${{ github.workspace }}/build/*.css
-
-    - name: upload-docs
-      uses: actions/upload-artifact@v4
-      if: ${{ env.devbuild == 'ON' }}
-      with:
-        name: docs-fv3atm
-        path: |
-          build/docs/html
 
     - name: debug-artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,160 @@
+# This is a CI workflow for the fv3atm project.
+#
+# This workflow builds and tests the fv3atm library using GCC, and it tests
+# different CMake build options.
+#
+# Alex Richert, 6 Dec 2023
+
+name: GCC
+on:
+  push:
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
+
+jobs:
+  build_spack:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        gcc_ver: ["12"]
+        mpi: ["mpich", "openmpi"]
+
+    steps:
+        
+    - name: checkout-fv3atm
+      uses: actions/checkout@v4
+      with:
+        path: ${{ github.workspace }}/fv3atm
+        submodules: recursive
+
+    - name: install-cmake
+      run: |
+        cd ${{ github.workspace }}
+        curl -f -s -S -R -L https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-Linux-x86_64.tar.gz | tar -zx
+        echo "${{ github.workspace }}/cmake-3.29.2-linux-x86_64/bin" >> $GITHUB_PATH
+
+    - name: cache-spack
+      id: cache-spack
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/spack-develop
+        key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}
+
+    # Building dependencies takes 40+ min
+    - name: spack-install
+      if: steps.cache-spack.outputs.cache-hit != 'true'
+      run: |
+        wget --no-verbose https://github.com/spack/spack/archive/refs/heads/develop.zip
+        unzip develop.zip -d ${GITHUB_WORKSPACE}/ &> unzip.out
+        . ${GITHUB_WORKSPACE}/spack-develop/share/spack/setup-env.sh
+        spack env create gcc${{ matrix.gcc_ver }} ${GITHUB_WORKSPACE}/fv3atm/ci/spack.yaml
+        spack env activate gcc${{ matrix.gcc_ver }}
+        spack compiler find | grep gcc@${{ matrix.gcc_ver }}
+        spack external find gmake cmake git git-lfs perl python ${{ matrix.mpi }}
+        spack config add "packages:all:require:['%gcc@${{ matrix.gcc_ver }}']"
+        spack config add "packages:mpi:require:'${{ matrix.mpi }}'"
+        spack concretize |& tee ${SPACK_ENV}/log.concretize
+        spack install -j2 --fail-fast
+        echo "spackrc=$?" >> ${GITHUB_ENV}
+        spack clean --all
+
+  build_fv3atm:
+    needs: build_spack
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        cmake_opts: ["-D32BIT=ON", "-D32BIT=OFF"]
+        gcc_ver: ["12"]
+        mpi: ["mpich", "openmpi"]
+
+    steps:
+
+    # Only do Doxygen and gcovr build for one job
+    - name: decide-doc-gcovr-build
+      run: |
+        if [[ "${{ matrix.cmake_opts }}" == "-D32BIT=ON" && "${{ matrix.gcc_ver }}" == 12 && "${{ matrix.mpi }}" == mpich ]]; then
+          echo 'devbuild=ON' | tee -a ${GITHUB_ENV}
+          echo 'gcov_cmake="-DCMAKE_Fortran_FLAGS=-fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"' | tee -a ${GITHUB_ENV}
+        else
+          echo 'devbuild=OFF' | tee -a ${GITHUB_ENV}
+        fi
+
+    - name: install-utilities
+      run: |
+        sudo apt-get install doxygen graphviz
+        python3 -m pip install gcovr
+
+    - name: install-cmake
+      run: |
+        cd ${{ github.workspace }}
+        curl -f -s -S -R -L https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-Linux-x86_64.tar.gz | tar -zx
+        echo "${{ github.workspace }}/cmake-3.29.2-linux-x86_64/bin" >> $GITHUB_PATH
+
+    - name: checkout-fv3atm
+      uses: actions/checkout@v4
+      with:
+        path: ${{ github.workspace }}/fv3atm
+        submodules: recursive
+
+    - name: cache-spack
+      id: cache-spack
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ github.workspace }}/spack-develop
+        key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}
+
+    - name: build-fv3atm
+      run: |
+        . ${GITHUB_WORKSPACE}/spack-develop/share/spack/setup-env.sh
+        spack env activate gcc${{ matrix.gcc_ver }}
+        spack load $(spack find --format "{name}")
+        cd ${GITHUB_WORKSPACE}/fv3atm
+        git clone https://github.com/NOAA-EMC/CMakeModules
+        git clone --recurse-submodules https://github.com/NOAA-PSL/stochastic_physics stochastic_physics_repo
+        mkdir ${GITHUB_WORKSPACE}/build
+        cd ${GITHUB_WORKSPACE}/build
+        export CC=mpicc
+        export CXX=mpicxx
+        export FC=mpif90
+        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_TESTING=ON ${{ matrix.cmake_opts }} -DENABLE_DOCS=ON ${{ env.gcov_cmake }}
+        make -j2
+
+    - name: run-tests
+      run: |
+        cd $GITHUB_WORKSPACE/build
+        ctest -j2 --output-on-failure --rerun-failed
+
+    - name: get-test-coverage
+      if: ${{ env.devbuild == 'ON' }}
+      run: |
+        cd $GITHUB_WORKSPACE/build
+        gcovr -r .. -v --html-details --gcov-executable gcov-12 --exclude $GITHUB_WORKSPACE/fv3atm/tests --exclude $GITHUB_WORKSPACE/fv3atm/stochastic_physics_repo --exclude $GITHUB_WORKSPACE/fv3atm/build/ccpp --exclude $GITHUB_WORKSPACE/fv3atm/ccpp/physics --exclude $GITHUB_WORKSPACE/fv3atm/ccpp/framework --exclude $GITHUB_WORKSPACE/fv3atm/atmos_cubed_sphere  --exclude CMakeFiles --print-summary -o test-coverage.html
+
+    - name: upload-test-coverage
+      uses: actions/upload-artifact@v4
+      if: ${{ env.devbuild == 'ON' }}
+      with:
+        name: test-coverage-fv3atm-${{ github.sha }}
+        path: |
+              ${{ github.workspace }}/build/*.html 
+              ${{ github.workspace }}/build/*.css
+
+    - name: upload-docs
+      uses: actions/upload-artifact@v4
+      if: ${{ env.devbuild == 'ON' }}
+      with:
+        name: docs-fv3atm
+        path: |
+          build/docs/html
+
+    - name: debug-artifacts
+      uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: ccpp_prebuild_logs-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}-${{ matrix.cmake_opts }}
+        path: ${{ github.workspace }}/build/ccpp/ccpp_prebuild.*

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -119,7 +119,7 @@ jobs:
         export CC=mpicc
         export CXX=mpicxx
         export FC=mpif90
-        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_TESTING=ON ${{ matrix.cmake_opts }} -DENABLE_DOCS=ON ${{ env.gcov_cmake }}
+        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_TESTING=ON ${{ matrix.cmake_opts }} -DENABLE_FV3ATM_DOCS=ON ${{ env.gcov_cmake }}
         make -j2
 
     - name: upload-docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -106,7 +106,7 @@ jobs:
         path: ${{ github.workspace }}/spack-develop
         key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}
 
-    - name: docs-build-fv3atm
+    - name: docs-build
       run: |
         . ${GITHUB_WORKSPACE}/spack-develop/share/spack/setup-env.sh
         spack env activate gcc${{ matrix.gcc_ver }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
         echo "spackrc=$?" >> ${GITHUB_ENV}
         spack clean --all
 
-  build_fv3atm:
+  build_docs:
     needs: build_spack
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -120,7 +120,7 @@ jobs:
         export CXX=mpicxx
         export FC=mpif90
         cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_TESTING=ON ${{ matrix.cmake_opts }} -DENABLE_FV3ATM_DOCS=ON ${{ env.gcov_cmake }}
-        make -j2
+        make doxygen_doc
 
     - name: upload-docs
       uses: actions/upload-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,9 +68,9 @@ jobs:
 
     strategy:
       matrix:
-        cmake_opts: ["-D32BIT=ON", "-D32BIT=OFF"]
+        cmake_opts: ["-D32BIT=ON"]
         gcc_ver: ["12"]
-        mpi: ["mpich", "openmpi"]
+        mpi: ["mpich"]
 
     steps:
 
@@ -87,7 +87,6 @@ jobs:
     - name: install-utilities
       run: |
         sudo apt-get install doxygen graphviz
-        python3 -m pip install gcovr
 
     - name: install-cmake
       run: |
@@ -108,7 +107,7 @@ jobs:
         path: ${{ github.workspace }}/spack-develop
         key: spack-${{ hashFiles('fv3atm/ci/spack.yaml') }}-gcc${{ matrix.gcc_ver }}-${{ matrix.mpi }}
 
-    - name: build-fv3atm
+    - name: docs-build-fv3atm
       run: |
         . ${GITHUB_WORKSPACE}/spack-develop/share/spack/setup-env.sh
         spack env activate gcc${{ matrix.gcc_ver }}
@@ -123,26 +122,6 @@ jobs:
         export FC=mpif90
         cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_TESTING=ON ${{ matrix.cmake_opts }} -DENABLE_DOCS=ON ${{ env.gcov_cmake }}
         make -j2
-
-    - name: run-tests
-      run: |
-        cd $GITHUB_WORKSPACE/build
-        ctest -j2 --output-on-failure --rerun-failed
-
-    - name: get-test-coverage
-      if: ${{ env.devbuild == 'ON' }}
-      run: |
-        cd $GITHUB_WORKSPACE/build
-        gcovr -r .. -v --html-details --gcov-executable gcov-12 --exclude $GITHUB_WORKSPACE/fv3atm/tests --exclude $GITHUB_WORKSPACE/fv3atm/stochastic_physics_repo --exclude $GITHUB_WORKSPACE/fv3atm/build/ccpp --exclude $GITHUB_WORKSPACE/fv3atm/ccpp/physics --exclude $GITHUB_WORKSPACE/fv3atm/ccpp/framework --exclude $GITHUB_WORKSPACE/fv3atm/atmos_cubed_sphere  --exclude CMakeFiles --print-summary -o test-coverage.html
-
-    - name: upload-test-coverage
-      uses: actions/upload-artifact@v4
-      if: ${{ env.devbuild == 'ON' }}
-      with:
-        name: test-coverage-fv3atm-${{ github.sha }}
-        path: |
-              ${{ github.workspace }}/build/*.html 
-              ${{ github.workspace }}/build/*.css
 
     - name: upload-docs
       uses: actions/upload-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,10 @@
 # This is a CI workflow for the fv3atm project.
 #
-# This workflow builds and tests the fv3atm library using GCC, and it tests
-# different CMake build options.
+# This workflow builds the fv3atm doxygen documentation.
 #
-# Alex Richert, 6 Dec 2023
+# Ed Hartnett, 1/9/25
 
-name: GCC
+name: docs
 on:
   push:
     branches:
@@ -21,7 +20,7 @@ jobs:
     strategy:
       matrix:
         gcc_ver: ["12"]
-        mpi: ["mpich", "openmpi"]
+        mpi: ["mpich"]
 
     steps:
         

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@
 cmake_minimum_required(VERSION 3.19)
 
 # Handle user build options.
-option(ENABLE_DOCS "Enable generation of doxygen-based documentation." OFF)
+option(ENABLE_FV3ATM_DOCS "Enable generation of doxygen-based documentation." OFF)
 
 # Determine whether or not to generate documentation.
-if(ENABLE_DOCS)
+if(ENABLE_FV3ATM_DOCS)
   find_package(Doxygen REQUIRED)
   add_subdirectory(docs)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option(ENABLE_FV3ATM_DOCS "Enable generation of doxygen-based documentation." OF
 
 # Determine whether or not to generate documentation.
 if(ENABLE_FV3ATM_DOCS)
+  message(STATUS "We will build the fv3atm doxygen documentation.")
   find_package(Doxygen REQUIRED)
   add_subdirectory(docs)
 endif()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -2,16 +2,12 @@
 #
 # Ed Hartnett 12/28/23
 
-IF(ENABLE_DOCS)
-
-  # Create doxyfile.
-  SET(abs_top_srcdir "${CMAKE_SOURCE_DIR}")
-  SET(abs_top_builddir "${CMAKE_BINARY_DIR}")
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-  ADD_CUSTOM_TARGET(doxygen_doc ALL
-    ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    COMMENT "Generating API Documentation with Doxygen" VERBATIM)
-
-ENDIF(ENABLE_DOCS)
+# Create doxyfile.
+SET(abs_top_srcdir "${CMAKE_SOURCE_DIR}")
+SET(abs_top_builddir "${CMAKE_BINARY_DIR}")
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+ADD_CUSTOM_TARGET(doxygen_doc ALL
+  ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMENT "Generating API Documentation with Doxygen" VERBATIM)
 

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -865,7 +865,6 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @abs_top_srcdir@/docs/user_guide.md \
-                         @abs_top_srcdir@ \
                          @abs_top_srcdir@/ccpp \
                          @abs_top_srcdir@/cpl \
                          @abs_top_srcdir@/io \

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -864,6 +864,10 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
+# Note EJH: Add @abs_top_srcdir@ after doxygenating those code
+# files. The comments in one of them are activating a bug in doxygen
+# and need to be cleaned up to get a doxygen build working.
+
 INPUT                  = @abs_top_srcdir@/docs/user_guide.md \
                          @abs_top_srcdir@/ccpp \
                          @abs_top_srcdir@/cpl \


### PR DESCRIPTION
## Description

In this PR I change the CMake option ENABLE_DOCS to ENABLE_FV3ATM_DOCS, in order to avoid invoking the documentation build of UPP.

I also add a new CI workflow called "docs", and take the documentation build out of the GCC workflow. This will be more useful to programmers because having the "docs" CI run fail is pretty obvious.

There are no code changes in this PR; this is documentation and CI only.

### Issue(s) addressed

Fixes #904


## Testing

CI testing. No code changes in this PR.

## Dependencies

N/A

# Requirements before merging
- [x] All new code in this PR is tested by at least one unit test
- [x] All new code in this PR includes Doxygen documentation
- [x] All new code in this PR does not add new compilation warnings (check CI output)
