### PR TITLE
Introduce prognostic updraft velocity in saSAS and C3 convection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
+#  url = https://github.com/ufs-community/ccpp-physics
+  url = https://github.com/lisa-bengtsson/ccpp-physics
   branch = ufs/dev
 [submodule "upp"]
   path = upp

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,7 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-  url = https://github.com/lisa-bengtsson/ccpp-physics
+  url = https://github.com/ufs-community/ccpp-physics
   branch = ufs/dev
 [submodule "upp"]
   path = upp

--- a/ccpp/data/CCPP_typedefs.F90
+++ b/ccpp/data/CCPP_typedefs.F90
@@ -1016,15 +1016,23 @@ contains
     if (Model%ntke > 0) Interstitial%ntkev = Interstitial%nvdiff
 
     if (Model%ntiw > 0) then
-      if (Model%ntclamt > 0 .and. Model%ntsigma <= 0) then
-        Interstitial%nn = Model%ntrac - 2
-      elseif (Model%ntclamt <= 0 .and. Model%ntsigma > 0) then
-        Interstitial%nn = Model%ntrac - 2
-      elseif  (Model%ntclamt > 0 .and. Model%ntsigma > 0) then
-        Interstitial%nn = Model%ntrac - 3
-      else
-        Interstitial%nn = Model%ntrac - 1
-      endif
+        if (Model%ntclamt > 0 .and. Model%ntsigma > 0 .and. Model%ntomega > 0) then
+           Interstitial%nn = Model%ntrac - 4
+        elseif (Model%ntclamt > 0 .and. Model%ntsigma > 0 .and. Model%ntomega <= 0) then
+           Interstitial%nn = Model%ntrac - 3
+        elseif (Model%ntclamt > 0 .and. Model%ntsigma <= 0 .and. Model%ntomega > 0) then
+           Interstitial%nn = Model%ntrac - 3
+        elseif (Model%ntclamt > 0 .and. Model%ntsigma <= 0 .and. Model%ntomega <= 0) then
+           Interstitial%nn = Model%ntrac - 2
+        elseif (Model%ntclamt <= 0 .and. Model%ntsigma > 0 .and. Model%ntomega > 0) then
+           Interstitial%nn = Model%ntrac - 3
+        elseif (Model%ntclamt <= 0 .and. Model%ntsigma > 0 .and. Model%ntomega <= 0) then
+           Interstitial%nn = Model%ntrac - 2
+        elseif (Model%ntclamt <= 0 .and. Model%ntsigma <= 0 .and. Model%ntomega > 0) then
+           Interstitial%nn = Model%ntrac - 2
+        else
+           Interstitial%nn = Model%ntrac - 1
+        endif
     elseif (Model%ntcw > 0) then
       Interstitial%nn = Model%ntrac
     else
@@ -1043,7 +1051,7 @@ contains
                   n /= Model%nthl  .and. n /= Model%nthnc .and. n /= Model%ntgv    .and. &
                   n /= Model%nthv  .and. n /= Model%ntccn .and. n /= Model%ntccna  .and. &
                   n /= Model%ntrz  .and. n /= Model%ntgz  .and. n /= Model%nthz    .and. &
-                  n /= Model%ntsigma)
+                  n /= Model%ntsigma .and.  n /= Model%ntomega)
         Interstitial%otsptflag(n) = ltest
         if ( ltest ) then
           tracers = tracers + 1
@@ -1620,8 +1628,8 @@ contains
     else
       Interstitial%ngas  = 0
     end if
-    allocate (Interstitial%rilist(0:Interstitial%ngas))
-    allocate (Interstitial%cpilist(0:Interstitial%ngas))
+    allocate(Interstitial%rilist(0:Interstitial%ngas))
+    allocate(Interstitial%cpilist(0:Interstitial%ngas))
     if (present(rilist)) then
       Interstitial%rilist  = rilist(0:Interstitial%ngas)
       Interstitial%cpilist = cpilist(0:Interstitial%ngas)

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1203,6 +1203,7 @@ module GFS_typedefs
     integer              :: imfshalcnv_c3       = 5 !< flag for the Community Convective Cloud (C3) scheme
     logical              :: hwrf_samfdeep           !< flag for HWRF SAMF deepcnv scheme (HWRF)
     logical              :: progsigma               !< flag for prognostic area fraction in samf ddepcnv scheme (GFS)
+    logical              :: progomega               !< flag for prognostic vertical velocity in samf ddepcnv scheme (GFS)
     integer              :: imfdeepcnv      !< flag for mass-flux deep convection scheme
                                             !<     1: July 2010 version of SAS conv scheme
                                             !<           current operational version as of 2016
@@ -1502,6 +1503,7 @@ module GFS_typedefs
     integer              :: nthz            !< tracer index for hail reflectivity
     integer              :: ntke            !< tracer index for kinetic energy
     integer              :: ntsigma         !< tracer index for updraft area fraction
+    integer              :: ntomega         !< tracer index for updraft velocity
     integer              :: nto             !< tracer index for oxygen ion
     integer              :: nto2            !< tracer index for oxygen
     integer              :: ntwa            !< tracer index for water friendly aerosol
@@ -3216,7 +3218,7 @@ module GFS_typedefs
        allocate (Coupling%dqdt_qmicro (IM,Model%levs))
        Coupling%dqdt_qmicro = clear_val
     endif
-
+    
     !--- stochastic physics option
     if (Model%do_sppt .or. Model%ca_global) then
       allocate (Coupling%sppt_wts  (IM,Model%levs))
@@ -3757,7 +3759,8 @@ module GFS_typedefs
 
     logical              :: hwrf_samfdeep     = .false.               !< flag for HWRF SAMF deepcnv scheme
     logical              :: hwrf_samfshal     = .false.               !< flag for HWRF SAMF shalcnv scheme
-    logical              :: progsigma         = .false.               !< flag for prognostic updraft area fraction closure in saSAS or Unified conv.
+    logical              :: progsigma         = .false.               !< flag for prognostic updraft area fraction closure in saSAS or C3
+    logical              :: progomega         = .false.               !< flag for prognostic updraft velocity in saSAS or C3
     integer              :: conv_cf_opt       =  0                    !< option for convection scheme cloud fraction computation
     logical              :: do_mynnedmf       = .false.               !< flag for MYNN-EDMF
     logical              :: do_mynnsfclay     = .false.               !< flag for MYNN Surface Layer Scheme
@@ -4139,8 +4142,9 @@ module GFS_typedefs
                                do_ugwp_v1, do_ugwp_v1_orog_only,  do_ugwp_v1_w_gsldrag,     &
                                ugwp_seq_update, var_ric, coef_ric_l, coef_ric_s, hurr_pbl,  &
                                do_myjsfc, do_myjpbl,                                        &
-                               hwrf_samfdeep, hwrf_samfshal,progsigma,betascu,betamcu,      &
-                               betadcu,h2o_phys, pdfcld, shcnvcw, redrag, hybedmf, satmedmf,&
+                               hwrf_samfdeep, hwrf_samfshal,progsigma,progomega,betascu,    &
+                               betamcu, betadcu, h2o_phys, pdfcld, shcnvcw,                 & 
+                               redrag, hybedmf, satmedmf,                                   &
                                shinhong, do_ysu, dspheat, lheatstrg, lseaspray, cnvcld,     &
                                xr_cnvcld, random_clds, shal_cnv, imfshalcnv, imfdeepcnv,    &
                                isatmedmf, conv_cf_opt, do_deep, jcap,                       &
@@ -4961,7 +4965,7 @@ module GFS_typedefs
     Model%hwrf_samfdeep = hwrf_samfdeep
     Model%hwrf_samfshal = hwrf_samfshal
 
-    !--prognostic closure - moisture coupling                                                                                 
+    !--prognostic closure - check                                                                                 
     if ((progsigma .and. imfdeepcnv/=2) .and. (progsigma .and. imfdeepcnv/=5)) then
        write(*,*) 'Logic error: progsigma requires imfdeepcnv=2 or 5'
        stop
@@ -4971,6 +4975,13 @@ module GFS_typedefs
     Model%betamcu = betamcu
     Model%betadcu = betadcu
 
+    !--prognostic closure - check
+    if (progomega .and. imfdeepcnv/=2) then
+       write(*,*) 'Logic error: progomega requires imfdeepcnv=2'
+       stop
+    end if
+    Model%progomega = progomega
+    
     if (oz_phys .and. oz_phys_2015) then
        write(*,*) 'Logic error: can only use one ozone physics option (oz_phys or oz_phys_2015), not both. Exiting.'
        stop
@@ -5258,6 +5269,7 @@ module GFS_typedefs
     Model%nthz             = get_tracer_index(Model%tracer_names, 'hail_ref',   Model%me, Model%master, Model%debug)
     Model%ntke             = get_tracer_index(Model%tracer_names, 'sgs_tke',    Model%me, Model%master, Model%debug)
     Model%ntsigma          = get_tracer_index(Model%tracer_names, 'sigmab',     Model%me, Model%master, Model%debug)
+    Model%ntomega          = get_tracer_index(Model%tracer_names, 'omegab',     Model%me, Model%master, Model%debug)
     Model%nqrimef          = get_tracer_index(Model%tracer_names, 'q_rimef',    Model%me, Model%master, Model%debug)
     Model%ntwa             = get_tracer_index(Model%tracer_names, 'liq_aero',   Model%me, Model%master, Model%debug)
     Model%ntia             = get_tracer_index(Model%tracer_names, 'ice_aero',   Model%me, Model%master, Model%debug)
@@ -7057,6 +7069,7 @@ module GFS_typedefs
       print *, ' nthz              : ', Model%nthz
       print *, ' ntke              : ', Model%ntke
       print *, ' ntsigma           : ', Model%ntsigma
+      print *, ' ntomega           : ', Model%ntomega
       print *, ' nto               : ', Model%nto
       print *, ' nto2              : ', Model%nto2
       print *, ' ntwa              : ', Model%ntwa

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -349,6 +349,14 @@
   type = real
   kind = kind_phys
   active = (index_of_updraft_area_fraction_in_tracer_concentration_array > 0 )
+[qgrs(:,:,index_of_updraft_velocity_in_tracer_concentration_array)]
+  standard_name = prognostic_updraft_velocity_in_convection
+  long_name = convective updraft velocity
+  units = frac
+  dimensions = (horizontal_dimension,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (index_of_updraft_velocity_in_tracer_concentration_array > 0 )
 [qgrs(:,:,index_for_smoke_in_tracer_concentration_array)]
   standard_name = smoke_tracer_concentration
   long_name = concentration of smoke
@@ -631,7 +639,14 @@
   type = real
   kind = kind_phys
   active = ( index_of_updraft_area_fraction_in_tracer_concentration_array > 0 )
-
+[gq0(:,:,index_of_updraft_velocity_in_tracer_concentration_array)]
+  standard_name = updraft_velocity_updated_by_physics
+  long_name = convective updraft area fraction updated by physics
+  units = frac
+  dimensions = (horizontal_dimension,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = ( index_of_updraft_velocity_in_tracer_concentration_array > 0 )
 ########################################################################
 [ccpp-table-properties]
   name = GFS_sfcprop_type
@@ -5653,6 +5668,12 @@
   units = flag
   dimensions = ()
   type = logical
+[progomega]
+  standard_name = do_prognostic_updraft_velocity
+  long_name = do_prognostic_updraft_velocity
+  units = flag
+  dimensions = ()
+  type = logical
 [betascu]
   standard_name = tuning_param_for_shallow_cu
   long_name = tuning param for shallow cu in case prognostic closure is used
@@ -6612,6 +6633,12 @@
 [ntsigma]
   standard_name = index_of_updraft_area_fraction_in_tracer_concentration_array
   long_name = tracer index of updraft_area_fraction
+  units = index
+  dimensions = ()
+  type = integer
+[ntomega]
+  standard_name = index_of_updraft_velocity_in_tracer_concentration_array
+  long_name = tracer index of updraft_velocity
   units = index
   dimensions = ()
   type = integer


### PR DESCRIPTION
## Description

This development incorporates a new prognostic updraft velocity equation into the saSAS deep and shallow convection schemes. It is introduced as a module and will be easily added to the C3 scheme as well, once the modularized C3 code is in place. 

The equation describes the time-evolution of convective updraft velocity, with buoyancy as a source term, and quadratic damping is due to aerodynamic drag and mixing/diffusion and linear damping from wind shear. 

The equation is discretized using an implicit approach, and solved as a quadratic equation. For implementation details - please see: https://docs.google.com/document/d/13VH7DV4erJcuuF_-dUGpplk9uYHF6dalfx8l1fAIxe8/edit?tab=t.0

The prognostic updraft velocity is used in the prognostic closure if progsigma = true and progomega = true, it is also replacing the diagnostic updraft velocity in the adjustment time-scale computation if progomega = true (regardless of progsigma). I here implement the scheme using the default setting of progomega = false for further testing and evaluation, and thus no regression tests should fail and no new baselines are required. 


- fixes https://github.com/ufs-community/ufs-weather-model/issues/2535


Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on 
https://github.com/ufs-community/ccpp-physics/pull/246

# Requirements before merging
- [x] All new code in this PR is tested by at least one unit test
- [x] All new code in this PR includes Doxygen documentation
- [x] All new code in this PR does not add new compilation warnings (check CI output)
