### PR TITLE
Change BUILD_TESTING to BUILD_CI_TESTING in CMake, to allow ufs-weather-model to use BUILD_TESTING

### DIFF
--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -120,7 +120,7 @@ jobs:
         export CC=mpicc
         export CXX=mpicxx
         export FC=mpif90
-        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_TESTING=ON ${{ matrix.cmake_opts }} ${{ env.gcov_cmake }}
+        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_CI_TESTING=ON ${{ matrix.cmake_opts }} ${{ env.gcov_cmake }}
         make -j2
 
     - name: run-tests

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -119,7 +119,7 @@ jobs:
         export CC=mpicc
         export CXX=mpicxx
         export FC=mpif90
-        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_TESTING=ON ${{ matrix.cmake_opts }} -DENABLE_FV3ATM_DOCS=ON ${{ env.gcov_cmake }}
+        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_CI_TESTING=ON ${{ matrix.cmake_opts }} -DENABLE_FV3ATM_DOCS=ON ${{ env.gcov_cmake }}
         make doxygen_doc
 
     - name: upload-docs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(ENABLE_FV3ATM_DOCS)
 endif()
 
 # Enable CI build & unit testing:
-if(BUILD_TESTING)
+if(BUILD_CI_TESTING)
   project(fv3atm VERSION 1.0 LANGUAGES C CXX Fortran)
   include(ci/CMakeLists.txt)
 endif()
@@ -165,7 +165,7 @@ if(OPENMP)
   target_link_libraries(fv3atm PUBLIC OpenMP::OpenMP_Fortran)
 endif()
 
-if(BUILD_TESTING)
+if(BUILD_CI_TESTING)
   include(CTest)
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
## Description

BUILD_TESTING was used by @AlexanderRichert-NOAA to get the fv3atm special build working. It's necessary because fv3atm contains code that links to subcomponent code, and that doesn't build on its own.

But BUILD_TESTING is a standard CMake option that has other uses. So instead, we should use BUILD_CI_TESTING for our own home-rolled hackery to build fv3atm in the CI system.

### Issue(s) addressed

Fixes #821


## Testing

In CI

## Dependencies

None.

