### PR TITLE
removed mention of doxygen, warnings, and unit tests from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,7 +36,3 @@ If so add the "waiting for other repos" label and list the upstream PRs
 - waiting on noaa-emc/nems/pull/<pr_number>
 - waiting on noaa-emc/fv3atm/pull/<pr_number>
 
-# Requirements before merging
-- [ ] All new code in this PR is tested by at least one unit test
-- [ ] All new code in this PR includes Doxygen documentation
-- [ ] All new code in this PR does not add new compilation warnings (check CI output)


### PR DESCRIPTION
## Description

Removed mention of doxygen, warnings, and unit tests from PR template. It's unrealistic to expect these until the project supports them better. Without proper support from the repo and the process, these are unrealistic goals.


### Issue(s) addressed

Fixes #913


## Testing

N/A


## Dependencies

None.

