### PR TITLE
Merge NCAR:main to ufs-community:ufs/dev (ccpp/physics) + Update GF/C3 for SRW3.0 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = ufs/dev
+  url = https://github.com/grantfirl/ccpp-physics
+  branch = NCAR_main_merge_20250206
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = ufs/dev
-  url = https://github.com/grantfirl/ccpp-physics
-  branch = NCAR_main_merge_20250206
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/haiqinli/ccpp-physics
+  branch = ufs/dev-SRW3.0
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This PR updates the ufs-community:ufs/dev branch of ccpp-physics from the NCAR:main. See https://github.com/ufs-community/ccpp-physics/pull/251 for a more complete description of the ccpp-physics changes.

Combined with #919 from @haiqinli. His description from #919:

Update the GF/C3 for the SRW 3.0.0 release. It includes some of the GF/C3 updates implemented for RRFSv1 and still was successful in reproducing predicted severe storms. It also includes the simplified cold pool parameterization for C3.

The results of GF/C3 related RT cases will be changed.


### Issue(s) addressed

None

## Testing

UFS RTs on Hera


## Dependencies

https://github.com/ufs-community/ccpp-physics/pull/251

