### PR TITLE
Convert GFS DDTs from blocked data structures to contiguous arrays: Part Deux + CCPP updates in fv3atm/ccpp-physics: split physics in two groups, reset GFS_interstitial DDT in CCPP_driver.F90 #936

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = ufs/dev
+  url = https://github.com/climbfuji/ccpp-physics
+  branch = feature/remove_gfs_int_radphys_reset
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = ufs/dev
-  url = https://github.com/climbfuji/ccpp-physics
-  branch = feature/remove_gfs_int_radphys_reset
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -1153,7 +1153,7 @@ subroutine atmos_model_restart(Atmos, timestamp)
 
     if (quilting_restart) then
        call fv_sfc_restart_output(GFS_sfcprop, Atm_block, GFS_control)
-       call fv_phy_restart_output(GFS_restart_var, Atm_block)
+       call fv_phy_restart_output(GFS_restart_var, Atm_block, GFS_Control)
        call fv_dyn_restart_output(Atm(mygrid), timestamp)
     else
        call atmosphere_restart(timestamp)

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -1023,7 +1023,7 @@ subroutine update_atmos_model_state (Atmos, rc)
       call atmosphere_nggps_diag(Atmos%Time)
       call fv3atm_diag_output(Atmos%Time, GFS_Diag, Atm_block, GFS_control%nx, GFS_control%ny, &
                             GFS_control%levs, 1, 1, 1.0_GFS_kind_phys, time_int, time_intfull, &
-                            GFS_control%fhswr, GFS_control%fhlwr)
+                            GFS_control%fhswr, GFS_control%fhlwr, GFS_control)
     endif
 
     !---  find current fhzero

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -205,7 +205,7 @@ type(DYCORE_data_type),    allocatable :: DYCORE_Data(:)  ! number of blocks
 !  GFS containers
 !----------------
 type(GFS_externaldiag_type), target :: GFS_Diag(DIAG_SIZE)
-type(GFS_restart_type)              :: GFS_restart_var
+type(GFS_restart_type)     , allocatable, target :: GFS_restart_var(:)
 
 !--------------
 ! IAU container

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -109,8 +109,6 @@ SCHEME_FILES = [
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_overlap.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_post.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_stochastics.F90',
-    'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_rad_reset.F90',
-    'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_phys_reset.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_1.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_2.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_stateout_reset.F90',

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -132,18 +132,18 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_init for "phys-ps"---required for Land IAU
-      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys-ps", ierr=ierr)
+      ! call timestep_init for "phys_ps"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys_ps", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys-ps"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys_ps"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
 
-      ! call timestep_init for "phys-ts"---required for Land IAU
-      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys-ts", ierr=ierr)
+      ! call timestep_init for "phys_ts"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys_ts", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys-ts"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys_ts"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
@@ -204,17 +204,17 @@ module CCPP_driver
         !--- Call CCPP radiation/physics/stochastics group
         if (trim(step)=="physics") then
           ! Process-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys-ps", ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys_ps", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys-ps", &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys_ps", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2
           endif
           ! Time-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys-ts", ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys_ts", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys-ts", &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys_ts", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2
@@ -249,18 +249,18 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_finalize for "phys-ps"---required for Land IAU
-      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys-ps", ierr=ierr)
+      ! call timestep_finalize for "phys_ps"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys_ps", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys-ps"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys_ps"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
 
-      ! call timestep_finalize for "phys-ts"---required for Land IAU
-      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys-ts", ierr=ierr)
+      ! call timestep_finalize for "phys_ts"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys_ts", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys-ts"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys_ts"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -204,17 +204,17 @@ module CCPP_driver
         !--- Call CCPP radiation/physics/stochastics group
         if (trim(step)=="physics") then
           ! Process-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_process_split"), ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_process_split", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_process_split"), &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_process_split", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2
           endif
           ! Time-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_time_split"), ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_time_split", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_time_split"), &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_time_split", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -186,7 +186,7 @@ module CCPP_driver
 !$OMP          default (none)                              &
 !$OMP          shared (nblks, nthrdsX, non_uniform_blocks, &
 !$OMP                  cdata_block, ccpp_suite, step,      &
-!$OMP                  GFS_Interstitial)                   &
+!$OMP                  GFS_Control, GFS_Interstitial)      &
 !$OMP          private (nb, nt, ntX, ierr2)                &
 !$OMP          reduction (+:ierr)
 #ifdef _OPENMP

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -13,7 +13,8 @@ module CCPP_driver
                                 cdata_block,                         &
                                 ccpp_suite,                          &
                                 GFS_control,                         &
-                                GFS_Intdiag
+                                GFS_Intdiag,                         &
+                                GFS_Interstitial
 
   implicit none
 
@@ -184,8 +185,9 @@ module CCPP_driver
 !$OMP parallel num_threads (nthrds)                        &
 !$OMP          default (none)                              &
 !$OMP          shared (nblks, nthrdsX, non_uniform_blocks, &
-!$OMP                  cdata_block,ccpp_suite, step)       &
-!$OMP          private (nb,nt,ntX,ierr2)                   &
+!$OMP                  cdata_block, ccpp_suite, step,      &
+!$OMP                  GFS_Interstitial)                   &
+!$OMP          private (nb, nt, ntX, ierr2)                &
 !$OMP          reduction (+:ierr)
 #ifdef _OPENMP
       nt = omp_get_thread_num()+1
@@ -203,6 +205,8 @@ module CCPP_driver
         end if
         !--- Call CCPP radiation/physics/stochastics group
         if (trim(step)=="physics") then
+          ! Reset GFS_Interstitial DDT physics fields for this thread
+          call GFS_Interstitial(ntX)%phys_reset(GFS_control)
           ! Process-split physics
           call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys_ps", ierr=ierr2)
           if (ierr2/=0) then
@@ -220,6 +224,11 @@ module CCPP_driver
             ierr = ierr + ierr2
           endif
         else
+          if (trim(step)=="radiation") then
+            ! Reset GFS_Interstitial DDT radiation fields for this thread
+            call GFS_Interstitial(ntX)%rad_reset(GFS_control)
+          end if
+          ! Radiation
           call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name=trim(step), ierr=ierr2)
           if (ierr2/=0) then
             write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", trim(step), &

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -132,18 +132,18 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_init for "physics_process_split"---required for Land IAU
-      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="physics_process_split", ierr=ierr)
+      ! call timestep_init for "phys-ps"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys-ps", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group physics_process_split"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys-ps"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
 
-      ! call timestep_init for "physics_time_split"---required for Land IAU
-      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="physics_time_split", ierr=ierr)
+      ! call timestep_init for "phys-ts"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys-ts", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group physics_time_split"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys-ts"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
@@ -204,17 +204,17 @@ module CCPP_driver
         !--- Call CCPP radiation/physics/stochastics group
         if (trim(step)=="physics") then
           ! Process-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_process_split", ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys-ps", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_process_split", &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys-ps", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2
           endif
           ! Time-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_time_split", ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys-ts", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_time_split", &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys-ts", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2
@@ -249,18 +249,18 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_finalize for "physics_process_split"---required for Land IAU
-      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="physics_process_split", ierr=ierr)
+      ! call timestep_finalize for "phys-ps"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys-ps", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group physics_process_split"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys-ps"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
 
-      ! call timestep_finalize for "physics_time_split"---required for Land IAU
-      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="physics_time_split", ierr=ierr)
+      ! call timestep_finalize for "phys-ts"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys-ts", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group physics_time_split"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys-ts"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -132,14 +132,22 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_init for "physics"---required for Land IAU
-      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="physics", ierr=ierr)
+      ! call timestep_init for "physics_process_split"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="physics_process_split", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group physics"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group physics_process_split"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
-      end if      
-            
+      end if
+
+      ! call timestep_init for "physics_time_split"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="physics_time_split", ierr=ierr)
+      if (ierr/=0) then
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group physics_time_split"
+        write(0,'(a)') trim(cdata_domain%errmsg)
+        return
+      end if
+
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       ! DH* 20210104 - this block of code will be removed once the CCPP framework    !
       ! fully supports handling diagnostics through its metadata, work in progress   !
@@ -194,12 +202,31 @@ module CCPP_driver
             ntX = nt
         end if
         !--- Call CCPP radiation/physics/stochastics group
-        call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name=trim(step), ierr=ierr2)
-        if (ierr2/=0) then
-           write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", trim(step), &
-                                     ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
-           write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
-           ierr = ierr + ierr2
+        if (trim(step)=="physics") then
+          ! Process-split physics
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_process_split"), ierr=ierr2)
+          if (ierr2/=0) then
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_process_split"), &
+                                      ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
+            write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
+            ierr = ierr + ierr2
+          endif
+          ! Time-split physics
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_time_split"), ierr=ierr2)
+          if (ierr2/=0) then
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_time_split"), &
+                                      ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
+            write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
+            ierr = ierr + ierr2
+          endif
+        else
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name=trim(step), ierr=ierr2)
+          if (ierr2/=0) then
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", trim(step), &
+                                      ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
+            write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
+            ierr = ierr + ierr2
+          endif
         end if
       end do
 !$OMP end do
@@ -222,13 +249,21 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_finalize for "physics"---required for Land IAU
-      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="physics", ierr=ierr)
+      ! call timestep_finalize for "physics_process_split"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="physics_process_split", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group physics"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group physics_process_split"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
-      end if      
+      end if
+
+      ! call timestep_finalize for "physics_time_split"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="physics_time_split", ierr=ierr)
+      if (ierr/=0) then
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group physics_time_split"
+        write(0,'(a)') trim(cdata_domain%errmsg)
+        return
+      end if
 
     ! Physics finalize
     else if (trim(step)=="physics_finalize") then

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -39,7 +39,7 @@ module GFS_diagnostics
     character(len=64)    :: mask
     character(len=64)    :: intpl_method
     real(kind=kind_phys) :: cnvfac
-    type(data_subtype), dimension(1) :: data
+    type(data_subtype)   :: data
    end type GFS_externaldiag_type
 
   !--- public data type ---
@@ -83,7 +83,7 @@ module GFS_diagnostics
           ExtDiag(idx)%unit = trim(Model%dtend_var_labels(itrac)%unit)
        endif
        nlev = size(IntDiag%dtend,2)
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dtend(:,:,idtend)
+       ExtDiag(idx)%data%var3 => IntDiag%dtend(:,:,idtend)
     endif
   end subroutine add_dtend
 
@@ -165,7 +165,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'frac'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%cldfra2d(:)
+    ExtDiag(idx)%data%var2 => IntDiag%cldfra2d(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -174,7 +174,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'frac'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%total_albedo(:)
+    ExtDiag(idx)%data%var2 => IntDiag%total_albedo(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -183,7 +183,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%lwp_ex(:)
+    ExtDiag(idx)%data%var2 => IntDiag%lwp_ex(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -192,7 +192,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%iwp_ex(:)
+    ExtDiag(idx)%data%var2 => IntDiag%iwp_ex(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -201,7 +201,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%lwp_fc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%lwp_fc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -210,7 +210,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%iwp_fc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%iwp_fc(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -220,8 +220,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%mask = 'positive_flux'
-    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,3)
-    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,4)
+    ExtDiag(idx)%data%var2  => IntDiag%fluxr(:,3)
+    ExtDiag(idx)%data%var21 => IntDiag%fluxr(:,4)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -232,7 +232,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dlwsfc(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -241,7 +241,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dlwsfci(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -252,7 +252,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%ulwsfc(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -262,7 +262,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,23)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,23)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -272,7 +272,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,2)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,2)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -282,7 +282,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,1)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,1)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -291,7 +291,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%ulwsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -303,7 +303,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,4)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,4)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -312,7 +312,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dswsfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dswsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -324,7 +324,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,3)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,3)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -333,7 +333,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%uswsfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%uswsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -344,7 +344,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,21)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,21)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -355,7 +355,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,22)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,22)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -366,7 +366,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,24)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,24)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -377,7 +377,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,25)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,25)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -388,7 +388,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,26)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,26)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -399,7 +399,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,27)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,27)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -410,7 +410,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,28)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,28)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -421,7 +421,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,29)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,29)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -432,7 +432,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,30)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,30)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -443,7 +443,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,31)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,31)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -454,7 +454,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,32)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,32)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -463,7 +463,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,32)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,32)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -474,7 +474,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,33)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,33)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -486,7 +486,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,23)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,23)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -498,7 +498,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,2)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,2)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -510,7 +510,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,1)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,1)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -521,7 +521,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,17)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,17)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -532,7 +532,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,18)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,18)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -541,7 +541,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_100    
-    ExtDiag(idx)%data(1)%var2 => Cldprop%cv(:)
+    ExtDiag(idx)%data%var2 => Cldprop%cv(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -550,8 +550,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%mask = 'cldmask'    
-    ExtDiag(idx)%data(1)%var2  => Cldprop%cvt(:)
-    ExtDiag(idx)%data(1)%var21 => Cldprop%cv(:)
+    ExtDiag(idx)%data%var2  => Cldprop%cvt(:)
+    ExtDiag(idx)%data%var21 => Cldprop%cv(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -560,8 +560,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%mask = 'cldmask'    
-    ExtDiag(idx)%data(1)%var2  => Cldprop%cvb(:)
-    ExtDiag(idx)%data(1)%var21 => Cldprop%cv(:)
+    ExtDiag(idx)%data%var2  => Cldprop%cvb(:)
+    ExtDiag(idx)%data%var21 => Cldprop%cv(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -572,7 +572,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,5)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,5)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -583,8 +583,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"
-    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,8)
-    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
+    ExtDiag(idx)%data%var2  => IntDiag%fluxr(:,8)
+    ExtDiag(idx)%data%var21 => IntDiag%fluxr(:,5)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -595,8 +595,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"    
-    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,11)
-    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
+    ExtDiag(idx)%data%var2  => IntDiag%fluxr(:,11)
+    ExtDiag(idx)%data%var21 => IntDiag%fluxr(:,5)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -607,8 +607,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"    
-    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,14)
-    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
+    ExtDiag(idx)%data%var2  => IntDiag%fluxr(:,14)
+    ExtDiag(idx)%data%var21 => IntDiag%fluxr(:,5)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -619,7 +619,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,6)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,6)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -630,8 +630,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"    
-    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,9)
-    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
+    ExtDiag(idx)%data%var2  => IntDiag%fluxr(:,9)
+    ExtDiag(idx)%data%var21 => IntDiag%fluxr(:,6)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -642,8 +642,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"    
-    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,12)
-    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
+    ExtDiag(idx)%data%var2  => IntDiag%fluxr(:,12)
+    ExtDiag(idx)%data%var21 => IntDiag%fluxr(:,6)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -654,8 +654,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"    
-    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,15)
-    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
+    ExtDiag(idx)%data%var2  => IntDiag%fluxr(:,15)
+    ExtDiag(idx)%data%var21 => IntDiag%fluxr(:,6)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -666,7 +666,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,7)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,7)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -677,8 +677,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"    
-    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,10)
-    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
+    ExtDiag(idx)%data%var2  => IntDiag%fluxr(:,10)
+    ExtDiag(idx)%data%var21 => IntDiag%fluxr(:,7)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -689,8 +689,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"    
-    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,13)
-    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
+    ExtDiag(idx)%data%var2  => IntDiag%fluxr(:,13)
+    ExtDiag(idx)%data%var21 => IntDiag%fluxr(:,7)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -701,8 +701,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"    
-    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,16)
-    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
+    ExtDiag(idx)%data%var2  => IntDiag%fluxr(:,16)
+    ExtDiag(idx)%data%var21 => IntDiag%fluxr(:,7)
 
 !--- aerosol diagnostics ---
     idx = idx + 1
@@ -712,7 +712,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,34)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,34)
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -721,7 +721,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,35)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,35)
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -730,7 +730,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,36)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,36)
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -739,7 +739,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,37)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,37)
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -748,7 +748,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,38)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,38)
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -757,7 +757,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,39)
+    ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,39)
 !--- air quality diagnostics ---
   if (Model%cplaqm) then
     if (associated(IntDiag%aod)) then
@@ -767,7 +767,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total aerosol optical depth at 550 nm'
       ExtDiag(idx)%unit = 'numerical'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var2 => IntDiag%aod(:)
+      ExtDiag(idx)%data%var2 => IntDiag%aod(:)
     endif
   endif
 
@@ -782,7 +782,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fluxr diagnostic '//trim(xtra)//' - GFS radiation'
       ExtDiag(idx)%unit = 'XXX'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,num)
+      ExtDiag(idx)%data%var2 => IntDiag%fluxr(:,num)
     enddo
 
 !--- the next two appear to be appear to be coupling fields in gloopr
@@ -794,7 +794,7 @@ module GFS_diagnostics
 !rab      ExtDiag(idx)%name = 'dswcmp_'//trim(xtra)
 !rab      ExtDiag(idx)%desc = 'dswcmp dagnostic '//trim(xtra)//' - GFS radiation'
 !rab      ExtDiag(idx)%unit = 'XXX'
-!rab      ExtDiag(idx)%data(1)%var2 => IntDiag%dswcmp(:,num)
+!rab      ExtDiag(idx)%data%var2 => IntDiag%dswcmp(:,num)
 !rab    enddo
 !rab
 !rab    do num = 1,4
@@ -805,7 +805,7 @@ module GFS_diagnostics
 !rab      ExtDiag(idx)%desc = 'uswcmp dagnostic '//trim(xtra)//' - GFS radiation'
 !rab      ExtDiag(idx)%unit = 'XXX'
 !rab      ExtDiag(idx)%mod_name = 'gfs_phys'
-!rab      ExtDiag(idx)%data(1)%var2 => IntDiag%uswcmp(:,num)
+!rab      ExtDiag(idx)%data%var2 => IntDiag%uswcmp(:,num)
 !rab    enddo
 
 ! DH gfortran cannot point to members of arrays of derived types such
@@ -820,7 +820,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%upfxc
+    ExtDiag(idx)%data%var2 => IntDiag%topfsw(:)%upfxc
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -829,7 +829,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%dnfxc
+    ExtDiag(idx)%data%var2 => IntDiag%topfsw(:)%dnfxc
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -838,7 +838,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%upfx0
+    ExtDiag(idx)%data%var2 => IntDiag%topfsw(:)%upfx0
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -847,7 +847,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%topflw(:)%upfxc
+    ExtDiag(idx)%data%var2 => IntDiag%topflw(:)%upfxc
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -856,7 +856,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%topflw(:)%upfx0
+    ExtDiag(idx)%data%var2 => IntDiag%topflw(:)%upfx0
 #endif
 
 !--- physics accumulated diagnostics ---
@@ -866,7 +866,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'Accumulated surface storm water runoff'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%srunoff(:)
+    ExtDiag(idx)%data%var2 => IntDiag%srunoff(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -875,7 +875,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%evbsa(:)
+    ExtDiag(idx)%data%var2 => IntDiag%evbsa(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -884,7 +884,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%evcwa(:)
+    ExtDiag(idx)%data%var2 => IntDiag%evcwa(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -893,7 +893,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%snohfa(:)
+    ExtDiag(idx)%data%var2 => IntDiag%snohfa(:)
 
     if (Model%lsm == Model%lsm_noahmp) then
      idx = idx + 1
@@ -903,7 +903,7 @@ module GFS_diagnostics
      ExtDiag(idx)%unit = 'W/m**2'
      ExtDiag(idx)%mod_name = 'gfs_phys'
      ExtDiag(idx)%time_avg = .TRUE.     
-     ExtDiag(idx)%data(1)%var2 => IntDiag%paha(:)
+     ExtDiag(idx)%data%var2 => IntDiag%paha(:)
     endif
 
     idx = idx + 1
@@ -913,7 +913,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%transa(:)
+    ExtDiag(idx)%data%var2 => IntDiag%transa(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -922,7 +922,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.    
-    ExtDiag(idx)%data(1)%var2 => IntDiag%sbsnoa(:)
+    ExtDiag(idx)%data%var2 => IntDiag%sbsnoa(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -932,7 +932,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%cnvfac = cn_100
-    ExtDiag(idx)%data(1)%var2 => IntDiag%snowca(:)
+    ExtDiag(idx)%data%var2 => IntDiag%snowca(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -940,7 +940,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'snow cover '
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%sncovr(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%sncovr(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -949,8 +949,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%mask = "land_only"
-    ExtDiag(idx)%data(1)%var2  => IntDiag%soilm(:)
-       ExtDiag(idx)%data(1)%var21 => Sfcprop%slmsk(:)
+    ExtDiag(idx)%data%var2  => IntDiag%soilm(:)
+       ExtDiag(idx)%data%var21 => Sfcprop%slmsk(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -959,7 +959,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tmpmin(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tmpmin(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -968,7 +968,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tmpmax(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tmpmax(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -979,7 +979,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dusfc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dusfc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -990,7 +990,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dvsfc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dvsfc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1001,7 +1001,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dtsfc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dtsfc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1012,7 +1012,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dqsfc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dqsfc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1024,7 +1024,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%totprcp(:)
+    ExtDiag(idx)%data%var2 => IntDiag%totprcp(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1035,7 +1035,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%totprcpb(:)
+    ExtDiag(idx)%data%var2 => IntDiag%totprcpb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1046,8 +1046,8 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     !    ExtDiag(idx)%mask = "land_ice_only"
-    ExtDiag(idx)%data(1)%var2  => IntDiag%gflux(:)
-    !ExtDiag(idx)%data(1)%var21 => Sfcprop%slmsk(:)
+    ExtDiag(idx)%data%var2  => IntDiag%gflux(:)
+    !ExtDiag(idx)%data%var21 => Sfcprop%slmsk(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1056,7 +1056,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dlwsfc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1065,7 +1065,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%ulwsfc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1074,7 +1074,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 's'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%suntim(:)
+    ExtDiag(idx)%data%var2 => IntDiag%suntim(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1082,7 +1082,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total water runoff'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%runoff(:)
+    ExtDiag(idx)%data%var2 => IntDiag%runoff(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1090,7 +1090,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total evaporation of intercepted water'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tecan(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tecan(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1098,7 +1098,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total plant transpiration'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tetran(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tetran(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1106,7 +1106,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total soil surface evaporation'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tedir(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tedir(:)
 
     if (Model%lsm == Model%lsm_noahmp) then
      idx = idx + 1
@@ -1115,7 +1115,7 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = 'total water storage in aquifer'
      ExtDiag(idx)%unit = 'kg/m**2'
      ExtDiag(idx)%mod_name = 'gfs_phys'
-     ExtDiag(idx)%data(1)%var2 => IntDiag%twa(:)
+     ExtDiag(idx)%data%var2 => IntDiag%twa(:)
     endif
 
     idx = idx + 1
@@ -1125,7 +1125,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'mm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%ep(:)
+    ExtDiag(idx)%data%var2 => IntDiag%ep(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1135,7 +1135,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%cldwrk(:)
+    ExtDiag(idx)%data%var2 => IntDiag%cldwrk(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1145,7 +1145,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dugwd(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dugwd(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1155,7 +1155,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dvgwd(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dvgwd(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1164,7 +1164,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kPa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%psmean(:)
+    ExtDiag(idx)%data%var2 => IntDiag%psmean(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1176,7 +1176,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcp(:)
+    ExtDiag(idx)%data%var2 => IntDiag%cnvprcp(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1187,7 +1187,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcpb(:)
+    ExtDiag(idx)%data%var2 => IntDiag%cnvprcpb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1195,7 +1195,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface convective precipitation rate'
     ExtDiag(idx)%unit = 'kg/m**2/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcp(:)
+    ExtDiag(idx)%data%var2 => IntDiag%cnvprcp(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1204,7 +1204,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%spfhmin(:)
+    ExtDiag(idx)%data%var2 => IntDiag%spfhmin(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1213,7 +1213,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%spfhmax(:)
+    ExtDiag(idx)%data%var2 => IntDiag%spfhmax(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1222,7 +1222,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%u10mmax(:)
+    ExtDiag(idx)%data%var2 => IntDiag%u10mmax(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1231,7 +1231,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%v10mmax(:)
+    ExtDiag(idx)%data%var2 => IntDiag%v10mmax(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1240,7 +1240,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%wind10mmax(:)
+    ExtDiag(idx)%data%var2 => IntDiag%wind10mmax(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1249,7 +1249,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%u10max(:)
+    ExtDiag(idx)%data%var2 => IntDiag%u10max(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1258,7 +1258,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%v10max(:)
+    ExtDiag(idx)%data%var2 => IntDiag%v10max(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1267,7 +1267,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%spd10max(:)
+    ExtDiag(idx)%data%var2 => IntDiag%spd10max(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1276,7 +1276,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%t02max(:)
+    ExtDiag(idx)%data%var2 => IntDiag%t02max(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1285,7 +1285,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%t02min(:)
+    ExtDiag(idx)%data%var2 => IntDiag%t02min(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1294,7 +1294,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%rh02max(:)
+    ExtDiag(idx)%data%var2 => IntDiag%rh02max(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1303,7 +1303,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%rh02min(:)
+    ExtDiag(idx)%data%var2 => IntDiag%rh02min(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1311,7 +1311,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'max hourly precipitation rate'
     ExtDiag(idx)%unit = 'mm h-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%pratemax(:)
+    ExtDiag(idx)%data%var2 => IntDiag%pratemax(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1320,7 +1320,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    ExtDiag(idx)%data(1)%var2 => IntDiag%frzr(:)
+    ExtDiag(idx)%data%var2 => IntDiag%frzr(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1329,7 +1329,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    ExtDiag(idx)%data(1)%var2 => IntDiag%frzrb(:)
+    ExtDiag(idx)%data%var2 => IntDiag%frzrb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1338,7 +1338,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    ExtDiag(idx)%data(1)%var2 => IntDiag%frozr(:)
+    ExtDiag(idx)%data%var2 => IntDiag%frozr(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1347,7 +1347,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    ExtDiag(idx)%data(1)%var2 => IntDiag%frozrb(:)
+    ExtDiag(idx)%data%var2 => IntDiag%frozrb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1356,7 +1356,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tsnowp(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tsnowp(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1365,7 +1365,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tsnowpb(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tsnowpb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1373,7 +1373,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'precipitation ice density'
     ExtDiag(idx)%unit = 'kg m^-3'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%rhonewsn1(:)
+    ExtDiag(idx)%data%var2 => IntDiag%rhonewsn1(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1381,7 +1381,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total rain at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%rain(:)
+    ExtDiag(idx)%data%var2 => IntDiag%rain(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1389,7 +1389,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'convective rain at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%rainc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%rainc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1397,7 +1397,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'ice fall at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%ice(:)
+    ExtDiag(idx)%data%var2 => IntDiag%ice(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1405,7 +1405,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'snow fall at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%snow(:)
+    ExtDiag(idx)%data%var2 => IntDiag%snow(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1413,7 +1413,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'graupel fall at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%graupel(:)
+    ExtDiag(idx)%data%var2 => IntDiag%graupel(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1424,7 +1424,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%totice(:)
+    ExtDiag(idx)%data%var2 => IntDiag%totice(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1434,7 +1434,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%toticeb(:)
+    ExtDiag(idx)%data%var2 => IntDiag%toticeb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1445,7 +1445,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%totsnw(:)
+    ExtDiag(idx)%data%var2 => IntDiag%totsnw(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1455,7 +1455,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%totsnwb(:)
+    ExtDiag(idx)%data%var2 => IntDiag%totsnwb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1466,7 +1466,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%totgrp(:)
+    ExtDiag(idx)%data%var2 => IntDiag%totgrp(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1476,7 +1476,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%totgrpb(:)
+    ExtDiag(idx)%data%var2 => IntDiag%totgrpb(:)
 
     if(associated(Coupling%sfcdlw)) then
        idx = idx + 1
@@ -1485,7 +1485,7 @@ module GFS_diagnostics
        ExtDiag(idx)%desc = 'sfcdlw'
        ExtDiag(idx)%unit = 'W m-2'
        ExtDiag(idx)%mod_name = 'gfs_phys'
-       ExtDiag(idx)%data(1)%var2 => Coupling%sfcdlw(:)
+       ExtDiag(idx)%data%var2 => Coupling%sfcdlw(:)
     endif
 
     if(associated(Coupling%htrlw)) then
@@ -1495,7 +1495,7 @@ module GFS_diagnostics
        ExtDiag(idx)%desc = 'htrlw'
        ExtDiag(idx)%unit = 'W m-2'
        ExtDiag(idx)%mod_name = 'gfs_phys'
-       ExtDiag(idx)%data(1)%var3 => Coupling%htrlw(:,:)
+       ExtDiag(idx)%data%var3 => Coupling%htrlw(:,:)
     endif
 
     if(associated(Radtend%lwhc)) then
@@ -1505,7 +1505,7 @@ module GFS_diagnostics
        ExtDiag(idx)%desc = 'lwhc'
        ExtDiag(idx)%unit = 'K s-1'
        ExtDiag(idx)%mod_name = 'gfs_phys'
-       ExtDiag(idx)%data(1)%var3 => Radtend%lwhc(:,:)
+       ExtDiag(idx)%data%var3 => Radtend%lwhc(:,:)
     endif
 
 !--- physics instantaneous diagnostics ---
@@ -1516,7 +1516,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%u10m(:)
+    ExtDiag(idx)%data%var2 => IntDiag%u10m(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1525,7 +1525,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%v10m(:)
+    ExtDiag(idx)%data%var2 => IntDiag%v10m(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1534,7 +1534,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dpt2m(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dpt2m(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1542,7 +1542,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'layer 1 height'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%zlvl(:)
+    ExtDiag(idx)%data%var2 => IntDiag%zlvl(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1552,7 +1552,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mask = 'pseudo_ps'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%psurf(:)
+    ExtDiag(idx)%data%var2 => IntDiag%psurf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1561,7 +1561,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => Tbd%hpbl(:)
+    ExtDiag(idx)%data%var2 => Tbd%hpbl(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1570,7 +1570,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%pwat(:)
+    ExtDiag(idx)%data%var2 => IntDiag%pwat(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1579,7 +1579,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%t1(:)
+    ExtDiag(idx)%data%var2 => IntDiag%t1(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1588,7 +1588,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%q1(:)
+    ExtDiag(idx)%data%var2 => IntDiag%q1(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1597,7 +1597,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%u1(:)
+    ExtDiag(idx)%data%var2 => IntDiag%u1(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1606,7 +1606,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%v1(:)
+    ExtDiag(idx)%data%var2 => IntDiag%v1(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1615,7 +1615,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m2/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%chh(:)
+    ExtDiag(idx)%data%var2 => IntDiag%chh(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1624,7 +1624,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%cmm(:)
+    ExtDiag(idx)%data%var2 => IntDiag%cmm(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1633,7 +1633,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dlwsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1642,7 +1642,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%ulwsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1651,7 +1651,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dswsfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dswsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1660,7 +1660,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%uswsfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%uswsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1668,7 +1668,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous u component of surface stress'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dusfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dusfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1676,7 +1676,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous v component of surface stress'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dvsfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dvsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1685,7 +1685,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dtsfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dtsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1694,7 +1694,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dqsfci(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dqsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1702,7 +1702,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous surface ground heat flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%gfluxi(:)
+    ExtDiag(idx)%data%var2 => IntDiag%gfluxi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1710,7 +1710,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'wiltimg point (volumetric)'
     ExtDiag(idx)%unit = 'Proportion'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%smcwlt2(:)
+    ExtDiag(idx)%data%var2 => IntDiag%smcwlt2(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1718,7 +1718,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'Field Capacity (volumetric)'
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%smcref2(:)
+    ExtDiag(idx)%data%var2 => IntDiag%smcref2(:)
 
     if (Model%lsm == Model%lsm_noahmp) then
      idx = idx + 1
@@ -1727,7 +1727,7 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = 'instantaneous precipitation advected heat flux'
      ExtDiag(idx)%unit = 'W/m**2'
      ExtDiag(idx)%mod_name = 'gfs_phys'
-     ExtDiag(idx)%data(1)%var2 => IntDiag%pahi(:)
+     ExtDiag(idx)%data%var2 => IntDiag%pahi(:)
     endif
 
     idx = idx + 1
@@ -1736,7 +1736,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous surface potential evaporation'
     ExtDiag(idx)%unit = 'mm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%epi(:)
+    ExtDiag(idx)%data%var2 => IntDiag%epi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1745,9 +1745,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     if (Model%lsm==Model%lsm_ruc) then
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%wetness(:)
+       ExtDiag(idx)%data%var2 => Sfcprop%wetness(:)
     else
-       ExtDiag(idx)%data(1)%var2 => IntDiag%wet1(:)
+       ExtDiag(idx)%data%var2 => IntDiag%wet1(:)
     endif
 
     idx = idx + 1
@@ -1757,7 +1757,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%sr(:)
+    ExtDiag(idx)%data%var2 => IntDiag%sr(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1768,7 +1768,7 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tdomr(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tdomr(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1779,7 +1779,7 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tdoms(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tdoms(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1790,7 +1790,7 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tdomzr(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tdomzr(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1801,7 +1801,7 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tdomip(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tdomip(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -1809,7 +1809,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'Radar reflectivity'
     ExtDiag(idx)%unit = 'dBz'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%refl_10cm(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%refl_10cm(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1817,7 +1817,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'Maximum hail diameter at lowest model level'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%max_hail_diam_sfc(:)
+    ExtDiag(idx)%data%var2 => IntDiag%max_hail_diam_sfc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -1825,7 +1825,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'Atmospheric heat diffusivity'
     ExtDiag(idx)%unit = 'm2s-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dkt(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dkt(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -1833,7 +1833,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'Atmospheric momentum diffusivity'
     ExtDiag(idx)%unit = 'm2s-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dku(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dku(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -1841,7 +1841,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'Instantaneous 3D Cloud Fraction'
     ExtDiag(idx)%unit = 'frac'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%cldfra(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%cldfra(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -1850,7 +1850,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     if( Model%ncnvw > 0 ) then       
-       ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%ncnvw)
+       ExtDiag(idx)%data%var3 => Tbd%phy_f3d(:,:,Model%ncnvw)
     endif
 
     if (Model%do_skeb) then
@@ -1860,7 +1860,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 =>Coupling%skebu_wts(:,:)
+      ExtDiag(idx)%data%var3 =>Coupling%skebu_wts(:,:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -1868,7 +1868,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Coupling%skebv_wts(:,:)
+      ExtDiag(idx)%data%var3 => Coupling%skebv_wts(:,:)
     endif
 
     idx = idx + 1
@@ -1877,7 +1877,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'level of dividing streamline'
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%zmtnblck(:)
+    ExtDiag(idx)%data%var2 => IntDiag%zmtnblck(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1885,7 +1885,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'max hourly 1-km agl reflectivity'
     ExtDiag(idx)%unit = 'dBZ'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%refdmax(:)
+    ExtDiag(idx)%data%var2 => IntDiag%refdmax(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1893,7 +1893,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'max hourly -10C reflectivity'
     ExtDiag(idx)%unit = 'dBZ'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%refdmax263k(:)
+    ExtDiag(idx)%data%var2 => IntDiag%refdmax263k(:)
 
     if (Model%do_sppt .or. Model%ca_global) then
       idx = idx + 1
@@ -1902,7 +1902,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Coupling%sppt_wts(:,:)
+      ExtDiag(idx)%data%var3 => Coupling%sppt_wts(:,:)
     endif
 
     if (Model%do_shum) then
@@ -1912,7 +1912,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Coupling%shum_wts(:,:)
+      ExtDiag(idx)%data%var3 => Coupling%shum_wts(:,:)
     endif
 
     if (Model%do_spp) then
@@ -1922,7 +1922,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp pbl perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_pbl(:,:)
+      ExtDiag(idx)%data%var3 => Coupling%spp_wts_pbl(:,:)
     endif
 
     if (Model%do_spp) then
@@ -1932,7 +1932,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp sfc perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_sfc(:,:)
+      ExtDiag(idx)%data%var3 => Coupling%spp_wts_sfc(:,:)
     endif
 
     if (Model%do_spp) then
@@ -1942,7 +1942,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp mp perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_mp(:,:)
+      ExtDiag(idx)%data%var3 => Coupling%spp_wts_mp(:,:)
     endif
 
     if (Model%do_spp) then
@@ -1952,7 +1952,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp gwd perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_gwd(:,:)
+      ExtDiag(idx)%data%var3 => Coupling%spp_wts_gwd(:,:)
     endif
 
     if (Model%do_spp) then
@@ -1962,7 +1962,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp rad perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_rad(:,:)
+      ExtDiag(idx)%data%var3 => Coupling%spp_wts_rad(:,:)
     endif
 
     if (Model%do_spp) then
@@ -1972,7 +1972,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp cu deep perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_cu_deep(:,:)
+      ExtDiag(idx)%data%var3 => Coupling%spp_wts_cu_deep(:,:)
     endif
 
     if (Model%lndp_type /= 0) then
@@ -1982,7 +1982,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation amplitude'
       ExtDiag(idx)%unit = 'none'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Coupling%sfc_wts(:,:)
+      ExtDiag(idx)%data%var3 => Coupling%sfc_wts(:,:)
     endif
 
     if (Model%do_ca) then
@@ -1992,7 +1992,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Cellular Automata'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var2 => Coupling%ca1(:)
+      ExtDiag(idx)%data%var2 => Coupling%ca1(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2000,7 +2000,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA deep conv'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var2 => Coupling%ca_deep(:)
+      ExtDiag(idx)%data%var2 => Coupling%ca_deep(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2008,7 +2008,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA turbulence'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var2 => Coupling%ca_turb(:)
+      ExtDiag(idx)%data%var2 => Coupling%ca_turb(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2016,7 +2016,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA shallow conv'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var2 => Coupling%ca_shal(:)
+      ExtDiag(idx)%data%var2 => Coupling%ca_shal(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2024,7 +2024,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA radiation'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var2 => Coupling%ca_rad(:)
+      ExtDiag(idx)%data%var2 => Coupling%ca_rad(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2032,7 +2032,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA microphys'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'      
-      ExtDiag(idx)%data(1)%var2 => Coupling%ca_micro(:)
+      ExtDiag(idx)%data%var2 => Coupling%ca_micro(:)
     endif
 
   if (Model%lkm/=0) then
@@ -2044,7 +2044,7 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'fraction'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%lakefrac(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%lakefrac(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2053,7 +2053,7 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%lakedepth(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%lakedepth(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2062,7 +2062,7 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%T_snow(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%T_snow(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2071,7 +2071,7 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%T_ice(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%T_ice(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2080,7 +2080,7 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'flag'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      ExtDiag(idx)%data(1)%int2 => Sfcprop%use_lake_model(:)
+      ExtDiag(idx)%data%int2 => Sfcprop%use_lake_model(:)
 
       if(Model%iopt_lake==Model%iopt_lake_clm) then
 
@@ -2093,7 +2093,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'lake point is considered salty by clm lake model'
         ExtDiag(idx)%unit = '1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        ExtDiag(idx)%data(1)%int2 => Sfcprop%lake_is_salty(:)
+        ExtDiag(idx)%data%int2 => Sfcprop%lake_is_salty(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2101,7 +2101,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'clm lake model considers the point to be so salty it cannot freeze'
         ExtDiag(idx)%unit = '1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        ExtDiag(idx)%data(1)%int2 => Sfcprop%lake_cannot_freeze(:)
+        ExtDiag(idx)%data%int2 => Sfcprop%lake_cannot_freeze(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2110,7 +2110,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_t2m(:)
+        ExtDiag(idx)%data%var2 => Sfcprop%lake_t2m(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2119,7 +2119,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg/kg'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_q2m(:)
+        ExtDiag(idx)%data%var2 => Sfcprop%lake_q2m(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2128,7 +2128,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'fraction'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_albedo(:)
+        ExtDiag(idx)%data%var2 => Sfcprop%lake_albedo(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2137,7 +2137,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'mm'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_h2osno2d(:)
+        ExtDiag(idx)%data%var2 => Sfcprop%lake_h2osno2d(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2146,7 +2146,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'm'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_sndpth2d(:)
+        ExtDiag(idx)%data%var2 => Sfcprop%lake_sndpth2d(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2155,7 +2155,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'count'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_snl2d(:)
+        ExtDiag(idx)%data%var2 => Sfcprop%lake_snl2d(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2164,7 +2164,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_tsfc(:)
+        ExtDiag(idx)%data%var2 => Sfcprop%lake_tsfc(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2173,7 +2173,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-3'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_savedtke12d(:)
+        ExtDiag(idx)%data%var2 => Sfcprop%lake_savedtke12d(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2182,7 +2182,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'unitless'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_ht(:)
+        ExtDiag(idx)%data%var2 => Sfcprop%lake_ht(:)
      endif
      !
   endif
@@ -2195,7 +2195,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'height of dividing streamline'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%zmtb(:)
+    ExtDiag(idx)%data%var2 => IntDiag%zmtb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2203,7 +2203,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'height of OGW-launch'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%zogw(:)
+    ExtDiag(idx)%data%var2 => IntDiag%zogw(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2211,7 +2211,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'height of LWB-level'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%zlwb(:)
+    ExtDiag(idx)%data%var2 => IntDiag%zlwb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2219,7 +2219,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' OGW vertical MF at launch level'
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tau_ogw(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tau_ogw(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2227,7 +2227,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' ORO-MTB integrated flux from surface'
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tau_mtb(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tau_mtb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2235,7 +2235,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' ORO-TOFD integrated flux from surface'
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tau_tofd(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tau_tofd(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2243,7 +2243,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' NGW momentum flux at launch level '
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%tau_ngw(:)
+    ExtDiag(idx)%data%var2 => IntDiag%tau_ngw(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2251,7 +2251,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'axz_oro averaged E-W OROGW-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_ogw(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%du3dt_ogw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2259,7 +2259,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'axz_oro averaged E-W GWALL-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_ngw(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%du3dt_ngw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2267,7 +2267,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'axz_oro averaged E-W MTB-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_mtb(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%du3dt_mtb(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2275,7 +2275,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'axz_oro averaged E-W TMS-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_tms(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%du3dt_tms(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2283,7 +2283,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from mesoscale OGWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_ogw(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dudt_ogw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2291,7 +2291,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from mesoscale OGWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_ogw(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dvdt_ogw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2299,7 +2299,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from blocking drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_obl(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dudt_obl(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2307,7 +2307,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from blocking drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_obl(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dvdt_obl(:,:)
 
     ! 2D variables
 
@@ -2317,7 +2317,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from meso scale ogw'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%du_ogwcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%du_ogwcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2325,7 +2325,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from meso scale ogw'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dv_ogwcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dv_ogwcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2333,7 +2333,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from blocking drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%du_oblcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%du_oblcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2341,7 +2341,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from blocking drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dv_oblcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dv_oblcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2350,7 +2350,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_ogw(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dws3dt_ogw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2359,7 +2359,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_obl(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dws3dt_obl(:,:)
 
     ! Variables for GSL drag suite
 
@@ -2369,7 +2369,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from small scale GWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_oss(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dudt_oss(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2377,7 +2377,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from small scale GWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_oss(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dvdt_oss(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2385,7 +2385,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from form drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_ofd(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dudt_ofd(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2393,7 +2393,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from form drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_ofd(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dvdt_ofd(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2402,7 +2402,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_oss(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dws3dt_oss(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2411,7 +2411,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_ofd(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%dws3dt_ofd(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2420,7 +2420,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ogw(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%ldu3dt_ogw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2429,7 +2429,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_obl(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%ldu3dt_obl(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2438,7 +2438,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ofd(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%ldu3dt_ofd(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2447,7 +2447,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_oss(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%ldu3dt_oss(:,:)
 
     ! 2D variables
 
@@ -2457,7 +2457,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from small scale gwd'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%du_osscol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%du_osscol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2465,7 +2465,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from small scale gwd'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dv_osscol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dv_osscol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2473,7 +2473,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from form drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%du_ofdcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%du_ofdcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2481,7 +2481,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from form drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dv_ofdcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dv_ofdcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2490,7 +2490,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%du3_ogwcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%du3_ogwcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2499,7 +2499,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_ogwcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dv3_ogwcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2508,7 +2508,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%du3_oblcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%du3_oblcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2517,7 +2517,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_oblcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dv3_oblcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2526,7 +2526,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%du3_osscol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%du3_osscol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2535,7 +2535,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_osscol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dv3_osscol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2544,7 +2544,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%du3_ofdcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%du3_ofdcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2553,7 +2553,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_ofdcol(:)
+    ExtDiag(idx)%data%var2 => IntDiag%dv3_ofdcol(:)
 
     ! UGWP non-stationary GWD outputs
 
@@ -2564,7 +2564,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ngw(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%ldu3dt_ngw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2573,7 +2573,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var3 => IntDiag%ldv3dt_ngw(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%ldv3dt_ngw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2582,7 +2582,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K s-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%data(1)%var3 => IntDiag%ldt3dt_ngw(:,:)
+    ExtDiag(idx)%data%var3 => IntDiag%ldt3dt_ngw(:,:)
 
   ENDIF  ! if (Model%ldiag_ugwp)
 
@@ -2609,7 +2609,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-1 s-3'
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%time_avg = .TRUE.
-        ExtDiag(idx)%data(1)%var3 => IntDiag%upd_mf(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%upd_mf(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -2618,7 +2618,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-1 s-3'
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%time_avg = .TRUE.
-        ExtDiag(idx)%data(1)%var3 => IntDiag%dwn_mf(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%dwn_mf(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -2627,7 +2627,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-1 s-3'
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%time_avg = .TRUE.
-        ExtDiag(idx)%data(1)%var3 => IntDiag%det_mf(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%det_mf(:,:)
 
       end if if_qdiag3d
 
@@ -2659,7 +2659,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean nir albedo with strong cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%alnsf(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%alnsf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2667,7 +2667,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean nir albedo with weak cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%alnwf(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%alnwf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2675,7 +2675,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean vis albedo with strong cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%alvsf(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%alvsf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2683,7 +2683,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean vis albedo with weak cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%alvwf(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%alvwf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2691,7 +2691,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'canopy water (cnwat in gfs data)'
     ExtDiag(idx)%unit = 'mm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%canopy(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%canopy(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2699,7 +2699,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = '10-meter wind speed divided by lowest model wind speed'
     ExtDiag(idx)%unit = 'N/A'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%f10m(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%f10m(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2707,7 +2707,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fractional coverage with strong cosz dependency'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%facsf(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%facsf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2715,7 +2715,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fractional coverage with weak cosz dependency'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 =>Sfcprop%facwf(:)
+    ExtDiag(idx)%data%var2 =>Sfcprop%facwf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2723,7 +2723,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fh parameter from PBL scheme'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%ffhh(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%ffhh(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2731,7 +2731,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fm parameter from PBL scheme'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%ffmm(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%ffmm(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2739,7 +2739,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'uustar surface frictional wind'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%uustar(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%uustar(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2747,7 +2747,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface slope type'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%int2 => Sfcprop%slope(:)
+    ExtDiag(idx)%data%int2 => Sfcprop%slope(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2755,7 +2755,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface ice concentration (ice=1; no ice=0)'
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%fice(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%fice(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2763,7 +2763,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sea ice thickness (icetk in gfs_data)'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%hice(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%hice(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2771,7 +2771,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'maximum snow albedo in fraction'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%snoalb(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%snoalb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2779,7 +2779,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'maximum fractional coverage of green vegetation'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%shdmax(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%shdmax(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2787,7 +2787,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'minimum fractional coverage of green vegetation'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%shdmin(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%shdmin(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2796,7 +2796,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one/cn_th
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%snowd(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%snowd(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2804,7 +2804,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous sublimation (evaporation from snow)'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%sbsno(:)
+    ExtDiag(idx)%data%var2 => IntDiag%sbsno(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2812,7 +2812,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous direct evaporation over land'
     ExtDiag(idx)%unit = 'W m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%evbs(:)
+    ExtDiag(idx)%data%var2 => IntDiag%evbs(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2820,7 +2820,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous canopy evaporation'
     ExtDiag(idx)%unit = 'W m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%evcw(:)
+    ExtDiag(idx)%data%var2 => IntDiag%evcw(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2828,7 +2828,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous transpiration'
     ExtDiag(idx)%unit = 'W m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => IntDiag%trans(:)
+    ExtDiag(idx)%data%var2 => IntDiag%trans(:)
 
     if (Model%lsm == Model%lsm_ruc) then
 
@@ -2838,7 +2838,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface albedo over land'
       ExtDiag(idx)%unit = 'fraction'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%sfalb_lnd(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%sfalb_lnd(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2846,7 +2846,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'density of frozen precipitation'
       ExtDiag(idx)%unit = 'kg m-3'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%rhofr(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%rhofr(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2854,7 +2854,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated frozen precipitation over land'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%snowfallac_land(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%snowfallac_land(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2862,7 +2862,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated SWE of frozen precipitation over land'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%acsnow_land(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%acsnow_land(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2870,7 +2870,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'accumulated snow melt over land'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var2 => IntDiag%snowmt_land(:)
+      ExtDiag(idx)%data%var2 => IntDiag%snowmt_land(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2878,7 +2878,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated frozen precipitation over ice'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%snowfallac_ice(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%snowfallac_ice(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2886,7 +2886,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated SWE of frozen precipitation over ice'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%acsnow_ice(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%acsnow_ice(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2894,7 +2894,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'accumulated snow melt over ice'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var2 => IntDiag%snowmt_ice(:)
+      ExtDiag(idx)%data%var2 => IntDiag%snowmt_ice(:)
     endif ! RUC lsm
 
     idx = idx + 1
@@ -2904,7 +2904,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%srflag(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%srflag(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2912,7 +2912,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'soil type in integer 1-9'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%int2 => Sfcprop%stype(:)
+    ExtDiag(idx)%data%int2 => Sfcprop%stype(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2920,7 +2920,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'soil color in integer 1-20'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%int2 => Sfcprop%scolor(:)
+    ExtDiag(idx)%data%int2 => Sfcprop%scolor(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2928,7 +2928,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'land fraction'
     ExtDiag(idx)%unit = 'fraction [0:1]'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%landfrac(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%landfrac(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2937,7 +2937,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%q2m(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%q2m(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2946,7 +2946,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%t2m(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%t2m(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2954,7 +2954,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface temperature'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%tsfc(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%tsfc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2962,7 +2962,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface zonal current'
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%usfco(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%usfco(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2970,7 +2970,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface meridional current'
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%vsfco(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%vsfco(:)
 
     if (Model%frac_grid) then
       do num = 1,Model%kice
@@ -2981,7 +2981,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'internal ice temperature layer ' // trim(xtra)
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        ExtDiag(idx)%data(1)%var2 => Sfcprop%tiice(:,num)
+        ExtDiag(idx)%data%var2 => Sfcprop%tiice(:,num)
       enddo
     end if
 
@@ -2991,7 +2991,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'deep soil temperature'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%tg3(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%tg3(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2999,7 +2999,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface temperature over ice fraction'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%tisfc(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%tisfc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3007,7 +3007,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total time-step precipitation'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => Sfcprop%tprcp(:)
+    ExtDiag(idx)%data%var2 => Sfcprop%tprcp(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3015,7 +3015,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'vegetation type in integer'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%int2 => sfcprop%vtype(:)
+    ExtDiag(idx)%data%int2 => sfcprop%vtype(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3023,7 +3023,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface snow water equivalent'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%weasd(:)
+    ExtDiag(idx)%data%var2 => sfcprop%weasd(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3031,7 +3031,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface snow water equivalent over ice'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%weasdi(:)
+    ExtDiag(idx)%data%var2 => sfcprop%weasdi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3039,7 +3039,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'snow depth over ice'
     ExtDiag(idx)%unit = 'mm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%snodi(:)
+    ExtDiag(idx)%data%var2 => sfcprop%snodi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3048,7 +3048,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'gpm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one
-    ExtDiag(idx)%data(1)%var2 => sfcprop%oro(:)
+    ExtDiag(idx)%data%var2 => sfcprop%oro(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3056,7 +3056,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sea-land-ice mask (0-sea, 1-land, 2-ice)'
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%slmsk(:)
+    ExtDiag(idx)%data%var2 => sfcprop%slmsk(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3065,7 +3065,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one/cn_100
-    ExtDiag(idx)%data(1)%var2 => sfcprop%zorl(:)
+    ExtDiag(idx)%data%var2 => sfcprop%zorl(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3074,7 +3074,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_100
-    ExtDiag(idx)%data(1)%var2 => sfcprop%vfrac(:)
+    ExtDiag(idx)%data%var2 => sfcprop%vfrac(:)
 
     if (Model%lsm==Model%lsm_ruc) then
       idx = idx + 1
@@ -3084,7 +3084,7 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'fraction'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%cnvfac = cn_100
-      ExtDiag(idx)%data(1)%var2 => sfcprop%wetness(:)
+      ExtDiag(idx)%data%var2 => sfcprop%wetness(:)
     end if
 
     idx = idx + 1
@@ -3093,7 +3093,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sfc nir beam sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => Coupling%nirbmdi(:)
+    ExtDiag(idx)%data%var2 => Coupling%nirbmdi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3101,7 +3101,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sfc nir diff sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => Coupling%nirdfdi(:)
+    ExtDiag(idx)%data%var2 => Coupling%nirdfdi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3109,7 +3109,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sfc uv+vis beam sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => Coupling%visbmdi(:)
+    ExtDiag(idx)%data%var2 => Coupling%visbmdi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3117,7 +3117,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' sfc uv+vis diff sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%data(1)%var2 => Coupling%visdfdi(:)
+    ExtDiag(idx)%data%var2 => Coupling%visdfdi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3125,7 +3125,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'leaf area index'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%xlaixy(:)
+    ExtDiag(idx)%data%var2 => sfcprop%xlaixy(:)
 
     do num = 1,Model%nvegcat
       write (xtra,'(i2)') num
@@ -3135,7 +3135,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fraction of vegetation category'//trim(xtra)
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => sfcprop%vegtype_frac(:,num)
+      ExtDiag(idx)%data%var2 => sfcprop%vegtype_frac(:,num)
     enddo
 
     do num = 1,Model%nsoilcat
@@ -3146,7 +3146,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fraction of soil category'//trim(xtra)
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => sfcprop%soiltype_frac(:,num)
+      ExtDiag(idx)%data%var2 => sfcprop%soiltype_frac(:,num)
     enddo
 
   if (Model%lsm == Model%lsm_ruc) then
@@ -3158,7 +3158,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'liquid soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
       ExtDiag(idx)%unit = 'm**3/m**3'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => sfcprop%sh2o(:,num)
+      ExtDiag(idx)%data%var2 => sfcprop%sh2o(:,num)
     enddo
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -3166,7 +3166,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'liquid soil moisture'
     ExtDiag(idx)%unit = 'm**3/m**3'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var3 => sfcprop%sh2o(:,:)
+    ExtDiag(idx)%data%var3 => sfcprop%sh2o(:,:)
   else
     do num = 1,Model%lsoil_lsm
       write (xtra,'(i1)') num
@@ -3184,7 +3184,7 @@ module GFS_diagnostics
 #endif
 ! *DH
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => sfcprop%slc(:,num)
+      ExtDiag(idx)%data%var2 => sfcprop%slc(:,num)
     enddo
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -3192,7 +3192,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'liquid soil moisture'
     ExtDiag(idx)%unit = 'm**3/m**3'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var3 => sfcprop%slc(:,:)
+    ExtDiag(idx)%data%var3 => sfcprop%slc(:,:)
   endif
 
   if (Model%lsm == Model%lsm_ruc) then
@@ -3204,7 +3204,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'volumetric soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
         ExtDiag(idx)%unit = 'fraction'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        ExtDiag(idx)%data(1)%var2 => sfcprop%smois(:,num)
+        ExtDiag(idx)%data%var2 => sfcprop%smois(:,num)
      enddo
      idx = idx + 1
      ExtDiag(idx)%axes = 3
@@ -3212,7 +3212,7 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = 'volumetric soil moisture'
      ExtDiag(idx)%unit = 'fraction'
      ExtDiag(idx)%mod_name = 'gfs_sfc'
-     ExtDiag(idx)%data(1)%var3 => sfcprop%smois(:,:)
+     ExtDiag(idx)%data%var3 => sfcprop%smois(:,:)
   else
      do num = 1,Model%lsoil_lsm
         write (xtra,'(i1)') num
@@ -3222,7 +3222,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'volumetric soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
         ExtDiag(idx)%unit = 'fraction'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        ExtDiag(idx)%data(1)%var2 => sfcprop%smc(:,num)
+        ExtDiag(idx)%data%var2 => sfcprop%smc(:,num)
      enddo
      idx = idx + 1
      ExtDiag(idx)%axes = 3
@@ -3230,7 +3230,7 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = 'volumetric soil moisture'
      ExtDiag(idx)%unit = 'fraction'
      ExtDiag(idx)%mod_name = 'gfs_sfc'
-     ExtDiag(idx)%data(1)%var3 => sfcprop%smc(:,:)
+     ExtDiag(idx)%data%var3 => sfcprop%smc(:,:)
   endif
 
   if (Model%lsm == Model%lsm_ruc) then
@@ -3242,7 +3242,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'soil temperature ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        ExtDiag(idx)%data(1)%var2 => sfcprop%tslb(:,num)
+        ExtDiag(idx)%data%var2 => sfcprop%tslb(:,num)
       enddo
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -3250,7 +3250,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'soil temperature'
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var3 => sfcprop%tslb(:,:)
+      ExtDiag(idx)%data%var3 => sfcprop%tslb(:,:)
    else
       do num = 1,Model%lsoil_lsm
          write (xtra,'(i1)') num
@@ -3260,7 +3260,7 @@ module GFS_diagnostics
          ExtDiag(idx)%desc = 'soil temperature ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
          ExtDiag(idx)%unit = 'K'
          ExtDiag(idx)%mod_name = 'gfs_sfc'
-         ExtDiag(idx)%data(1)%var2 => sfcprop%stc(:,num)
+         ExtDiag(idx)%data%var2 => sfcprop%stc(:,num)
       enddo
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -3268,7 +3268,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'soil temperature'
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var3 => sfcprop%stc(:,:)
+      ExtDiag(idx)%data%var3 => sfcprop%stc(:,:)
    endif
 
 !--------------------------nsst variables
@@ -3281,7 +3281,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst reference or foundation temperature'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%tref(:)
+    ExtDiag(idx)%data%var2 => sfcprop%tref(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3289,7 +3289,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst sub-layer cooling thickness'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%z_c(:)
+    ExtDiag(idx)%data%var2 => sfcprop%z_c(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3297,7 +3297,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient1 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%c_0(:)
+    ExtDiag(idx)%data%var2 => sfcprop%c_0(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3305,7 +3305,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient2 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%c_d(:)
+    ExtDiag(idx)%data%var2 => sfcprop%c_d(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3313,7 +3313,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient3 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%w_0(:)
+    ExtDiag(idx)%data%var2 => sfcprop%w_0(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3321,7 +3321,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient4 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%w_d(:)
+    ExtDiag(idx)%data%var2 => sfcprop%w_d(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3329,7 +3329,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst heat content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'k*m'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%xt(:)
+    ExtDiag(idx)%data%var2 => sfcprop%xt(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3337,7 +3337,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst salinity content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%xs(:)
+    ExtDiag(idx)%data%var2 => sfcprop%xs(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3345,7 +3345,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst u-current content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'm2/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%xu(:)
+    ExtDiag(idx)%data%var2 => sfcprop%xu(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3353,7 +3353,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst v-current content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'm2/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%xv(:)
+    ExtDiag(idx)%data%var2 => sfcprop%xv(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3361,7 +3361,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst diurnal thermocline layer thickness'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%xz(:)
+    ExtDiag(idx)%data%var2 => sfcprop%xz(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3369,7 +3369,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst mixed layer thickness'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%zm(:)
+    ExtDiag(idx)%data%var2 => sfcprop%zm(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3377,7 +3377,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst d(xt)/d(ts)'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%xtts(:)
+    ExtDiag(idx)%data%var2 => sfcprop%xtts(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3385,7 +3385,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst d(xt)/d(ts)'
     ExtDiag(idx)%unit = 'm/k'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%xzts(:)
+    ExtDiag(idx)%data%var2 => sfcprop%xzts(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3393,7 +3393,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst thickness of free convection layer'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%d_conv(:)
+    ExtDiag(idx)%data%var2 => sfcprop%d_conv(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3401,7 +3401,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst index to start dtlm run or not'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%ifd(:)
+    ExtDiag(idx)%data%var2 => sfcprop%ifd(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3409,7 +3409,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst sub-layer cooling amount'
     ExtDiag(idx)%unit = 'k'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%dt_cool(:)
+    ExtDiag(idx)%data%var2 => sfcprop%dt_cool(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3417,7 +3417,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst sensible heat flux due to rainfall'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    ExtDiag(idx)%data(1)%var2 => sfcprop%qrain(:)
+    ExtDiag(idx)%data%var2 => sfcprop%qrain(:)
 !--------------------------nsst variables
   endif
 
@@ -3430,7 +3430,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of water-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntwa)
+        ExtDiag(idx)%data%var3 => Statein%qgrs(:,:,Model%ntwa)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -3438,7 +3438,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'water-friendly surface aerosol source'
         ExtDiag(idx)%unit = 'kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        ExtDiag(idx)%data(1)%var2 => Coupling%nwfa2d(:)
+        ExtDiag(idx)%data%var2 => Coupling%nwfa2d(:)
       elseif (Model%mraerosol) then
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -3446,7 +3446,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of water-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => Stateout%gq0(:,:,Model%ntwa)
+        ExtDiag(idx)%data%var3 => Stateout%gq0(:,:,Model%ntwa)
       endif
     endif
 
@@ -3458,7 +3458,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of ice-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntia)
+        ExtDiag(idx)%data%var3 => Statein%qgrs(:,:,Model%ntia)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -3466,7 +3466,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'ice-friendly surface aerosol source'
         ExtDiag(idx)%unit = 'kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        ExtDiag(idx)%data(1)%var2 => Coupling%nifa2d(:)
+        ExtDiag(idx)%data%var2 => Coupling%nifa2d(:)
       else if (Model%mraerosol) then
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -3474,7 +3474,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of ice-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 =>Stateout%gq0(:,:,Model%ntia)
+        ExtDiag(idx)%data%var3 =>Stateout%gq0(:,:,Model%ntia)
       end if
     endif
 
@@ -3497,7 +3497,7 @@ module GFS_diagnostics
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%intpl_method = 'bilinear'
         ExtDiag(idx)%time_avg = .false.
-        ExtDiag(idx)%data(1)%var3 =>IntDiag%thompson_ext_diag3d(:,:,num)
+        ExtDiag(idx)%data%var3 =>IntDiag%thompson_ext_diag3d(:,:,num)
       enddo
     end if thompson_extended_diagnostics
 
@@ -3508,7 +3508,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'smoke concentration'
       ExtDiag(idx)%unit = 'kg kg-1'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntfsmoke)
+      ExtDiag(idx)%data%var3 => Statein%qgrs(:,:,Model%ntfsmoke)
     endif
 
     if (Model%rrfs_sd .and. Model%ntsmoke>0) then
@@ -3519,7 +3519,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface fire heat flux'
       ExtDiag(idx)%unit = 'W m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%fire_heat_flux(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%fire_heat_flux(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3527,7 +3527,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'ration of the burnt area to the grid cell area'
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%frac_grid_burned(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%frac_grid_burned(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3535,7 +3535,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'emission of fine dust for smoke'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%emdust(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%emdust(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3543,7 +3543,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'emission of seas for smoke'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%emseas(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%emseas(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3551,7 +3551,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'emission of anoc for thompson mp'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%emanoc(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%emanoc(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3559,7 +3559,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'coeff bb for smoke'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%coef_bb_dc(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%coef_bb_dc(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3567,7 +3567,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'minimum smoke plume height'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%min_fplume(:)
+      ExtDiag(idx)%data%var2 => Coupling%min_fplume(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3575,7 +3575,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'maximum smoke plume height'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%max_fplume(:)
+      ExtDiag(idx)%data%var2 => Coupling%max_fplume(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3583,7 +3583,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'hourly fire weather potential'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%rrfs_hwp(:)
+      ExtDiag(idx)%data%var2 => Coupling%rrfs_hwp(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3591,7 +3591,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'averaged fire weather potential'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%rrfs_hwp_ave(:)
+      ExtDiag(idx)%data%var2 => Coupling%rrfs_hwp_ave(:)
 
       extended_smoke_dust_diagnostics: if ( Model%extended_sd_diags ) then
 
@@ -3601,7 +3601,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'BL average wind speed'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%uspdavg(:)
+      ExtDiag(idx)%data%var2 => Coupling%uspdavg(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3609,7 +3609,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'BL depth modified parcel method'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%hpbl_thetav(:)
+      ExtDiag(idx)%data%var2 => Coupling%hpbl_thetav(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3617,7 +3617,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'dry deposition smoke'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,1)
+      ExtDiag(idx)%data%var2 => Coupling%drydep_flux(:,1)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3625,7 +3625,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'dry deposition dust'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,2)
+      ExtDiag(idx)%data%var2 => Coupling%drydep_flux(:,2)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3633,7 +3633,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'dry deposition coarsepm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,3)
+      ExtDiag(idx)%data%var2 => Coupling%drydep_flux(:,3)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3641,7 +3641,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'resolved wet deposition smoke'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpr_flux(:,1)
+      ExtDiag(idx)%data%var2 => Coupling%wetdpr_flux(:,1)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3649,7 +3649,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'resolved wet deposition dust'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpr_flux(:,2)
+      ExtDiag(idx)%data%var2 => Coupling%wetdpr_flux(:,2)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3657,7 +3657,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'resolved wet deposition coarsepm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpr_flux(:,3)
+      ExtDiag(idx)%data%var2 => Coupling%wetdpr_flux(:,3)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3665,7 +3665,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'convective wet deposition smoke'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,1)
+      ExtDiag(idx)%data%var2 => Coupling%wetdpc_flux(:,1)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3673,7 +3673,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'convective wet deposition dust'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,2)
+      ExtDiag(idx)%data%var2 => Coupling%wetdpc_flux(:,2)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3681,7 +3681,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'convective wet deposition coarsepm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,3)
+      ExtDiag(idx)%data%var2 => Coupling%wetdpc_flux(:,3)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3689,7 +3689,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'hour of peak smoke emissions'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%peak_hr(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%peak_hr(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3697,7 +3697,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fire type'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%int2 => Sfcprop%fire_type(:)
+      ExtDiag(idx)%data%int2 => Sfcprop%fire_type(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3705,7 +3705,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'lu nofire pixes'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%lu_nofire(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%lu_nofire(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3713,7 +3713,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'lu qfire pixes'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%lu_qfire(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%lu_qfire(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3721,7 +3721,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'coefficient to scale the fire activity depending on the fire duration'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%fhist(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%fhist(:)
 
       if (Model%ebb_dcycle == 2 ) then
          idx = idx + 1
@@ -3730,7 +3730,7 @@ module GFS_diagnostics
          ExtDiag(idx)%desc = 'Hours since fire was last detected'
          ExtDiag(idx)%unit = 'hrs'
          ExtDiag(idx)%mod_name = 'gfs_sfc'
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,3)
+         ExtDiag(idx)%data%var2 => Sfcprop%smoke2d_RRFS(:,3)
       endif
 
       endif  extended_smoke_dust_diagnostics
@@ -3741,7 +3741,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'smoke emission'
       ExtDiag(idx)%unit = 'ug/m2/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Coupling%ebu_smoke(:,:)
+      ExtDiag(idx)%data%var3 => Coupling%ebu_smoke(:,:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3749,7 +3749,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'input smoke emission'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%ebb_smoke_in(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%ebb_smoke_in(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3757,7 +3757,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'output frp'
       ExtDiag(idx)%unit = 'mw'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%frp_output(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%frp_output(:)
 
       smoke_forecast_mode: if (Model%ebb_dcycle == 2 ) then
 
@@ -3767,7 +3767,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Total EBB Emissions'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,1)
+      ExtDiag(idx)%data%var2 => Sfcprop%smoke2d_RRFS(:,1)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3775,7 +3775,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Daily mean Fire Radiative Power'
       ExtDiag(idx)%unit = 'mw'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,2)
+      ExtDiag(idx)%data%var2 => Sfcprop%smoke2d_RRFS(:,2)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3783,7 +3783,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Daily mean Hourly Wildfire Potential'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,4)
+      ExtDiag(idx)%data%var2 => Sfcprop%smoke2d_RRFS(:,4)
 
       endif smoke_forecast_mode
 
@@ -3793,7 +3793,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = '3d total extinction at 550nm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Radtend%ext550(:,:)
+      ExtDiag(idx)%data%var3 => Radtend%ext550(:,:)
     endif
 
     do i=1,Model%num_dfi_radar
@@ -3808,7 +3808,7 @@ module GFS_diagnostics
        ExtDiag(idx)%unit = 'K s-1'
        ExtDiag(idx)%mod_name = 'gfs_phys'
        ExtDiag(idx)%time_avg = .FALSE.
-       ExtDiag(idx)%data(1)%var3 => Tbd%dfi_radar_tten(:,:,i)
+       ExtDiag(idx)%data%var3 => Tbd%dfi_radar_tten(:,:,i)
     enddo
 
     if(Model%lightning_threat) then
@@ -3820,7 +3820,7 @@ module GFS_diagnostics
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ! CCPP physics units are flashes per minute
       ExtDiag(idx)%cnvfac = 5.0_kind_phys
-      ExtDiag(idx)%data(1)%var2 => IntDiag%ltg1_max(:)
+      ExtDiag(idx)%data%var2 => IntDiag%ltg1_max(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3830,7 +3830,7 @@ module GFS_diagnostics
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ! CCPP physics units are flashes per minute
       ExtDiag(idx)%cnvfac = 5.0_kind_phys
-      ExtDiag(idx)%data(1)%var2 => IntDiag%ltg2_max(:)
+      ExtDiag(idx)%data%var2 => IntDiag%ltg2_max(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3840,7 +3840,7 @@ module GFS_diagnostics
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ! CCPP physics units are flashes per minute
       ExtDiag(idx)%cnvfac = 5.0_kind_phys
-      ExtDiag(idx)%data(1)%var2 => IntDiag%ltg3_max(:)
+      ExtDiag(idx)%data%var2 => IntDiag%ltg3_max(:)
     endif
 
     ! Cloud effective radii from Microphysics
@@ -3852,7 +3852,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'effective radius of cloud liquid water particle'
       ExtDiag(idx)%unit = 'um'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%nleffr)
+      ExtDiag(idx)%data%var3 => Tbd%phy_f3d(:,:,Model%nleffr)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -3860,7 +3860,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'effective radius of stratiform cloud ice particle in um'
       ExtDiag(idx)%unit = 'um'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%nieffr)
+      ExtDiag(idx)%data%var3 => Tbd%phy_f3d(:,:,Model%nieffr)
       
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -3868,7 +3868,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'effective radius of stratiform cloud snow particle in um'
       ExtDiag(idx)%unit = 'um'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%nseffr)
+      ExtDiag(idx)%data%var3 => Tbd%phy_f3d(:,:,Model%nseffr)
     endif
 
     !MYNN
@@ -3880,7 +3880,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'height of highest plume'
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => IntDiag%ztop_plume(:)
+      ExtDiag(idx)%data%var2 => IntDiag%ztop_plume(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3888,7 +3888,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'maximum mass-flux in column'
       ExtDiag(idx)%unit = 'm s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => IntDiag%maxmf(:)
+      ExtDiag(idx)%data%var2 => IntDiag%maxmf(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3896,7 +3896,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'maximum width of plumes in grid column'
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => IntDiag%maxwidth(:)
+      ExtDiag(idx)%data%var2 => IntDiag%maxwidth(:)
     endif
 
     if (Model%do_mynnsfclay) then
@@ -3906,7 +3906,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'monin obukhov surface stability parameter'
       ExtDiag(idx)%unit = 'n/a'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%zol(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%zol(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3914,7 +3914,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface exchange coefficient for heat'
       ExtDiag(idx)%unit = 'W m-2 K-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%flhc(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%flhc(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3922,7 +3922,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface exchange coefficient for moisture'
       ExtDiag(idx)%unit = 'kg m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      ExtDiag(idx)%data(1)%var2 => Sfcprop%flqc(:)
+      ExtDiag(idx)%data%var2 => Sfcprop%flqc(:)
     endif
 
     if (Model%do_mynnedmf) then
@@ -3932,7 +3932,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'subgrid cloud fraction'
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Tbd%CLDFRA_BL(:,:)
+      ExtDiag(idx)%data%var3 => Tbd%CLDFRA_BL(:,:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -3940,7 +3940,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'subgrid cloud mixing ratio'
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Tbd%QC_BL(:,:)
+      ExtDiag(idx)%data%var3 => Tbd%QC_BL(:,:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -3948,7 +3948,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'turbulent mixing length'
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Tbd%el_pbl(:,:)
+      ExtDiag(idx)%data%var3 => Tbd%el_pbl(:,:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -3956,7 +3956,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = '2 X TKE (from mynn)'
       ExtDiag(idx)%unit = 'm2 s-2'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data(1)%var3 => Tbd%QKE(:,:)
+      ExtDiag(idx)%data%var3 => Tbd%QKE(:,:)
 
       if (Model%bl_mynn_output > 0) then
 
@@ -3966,7 +3966,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'updraft area fraction (from mynn)'
         ExtDiag(idx)%unit = '-'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_a(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%edmf_a(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -3974,7 +3974,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'mean updraft vertical veloctity (mynn)'
         ExtDiag(idx)%unit = 'm s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_w(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%edmf_w(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -3982,7 +3982,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'updraft total water (from mynn)'
         ExtDiag(idx)%unit = 'kg kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_qt(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%edmf_qt(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -3990,7 +3990,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'mean liquid potential temperature (mynn)'
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_thl(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%edmf_thl(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -3998,7 +3998,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'updraft entrainment rate (from mynn)'
         ExtDiag(idx)%unit = 'm-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_ent(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%edmf_ent(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4006,7 +4006,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'mean updraft liquid water (mynn)'
         ExtDiag(idx)%unit = 'kg kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_qc(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%edmf_qc(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4014,7 +4014,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'subsidence temperature tendency (from mynn)'
         ExtDiag(idx)%unit = 'K s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => IntDiag%sub_thl(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%sub_thl(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4022,7 +4022,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'subsidence water vapor tendency (mynn)'
         ExtDiag(idx)%unit = 'kg kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => IntDiag%sub_sqv(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%sub_sqv(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4030,7 +4030,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'detrainment temperature tendency (from mynn)'
         ExtDiag(idx)%unit = 'K s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => IntDiag%det_thl(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%det_thl(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4038,7 +4038,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'detrainment water vapor tendency (mynn)'
         ExtDiag(idx)%unit = 'kg kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        ExtDiag(idx)%data(1)%var3 => IntDiag%det_sqv(:,:)
+        ExtDiag(idx)%data%var3 => IntDiag%det_sqv(:,:)
       endif
     endif
 
@@ -4098,7 +4098,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%time_avg = Model%aux2d_time_avg(num)
-    ExtDiag(idx)%data(1)%var2 => IntDiag%aux2d(:,num)
+    ExtDiag(idx)%data%var2 => IntDiag%aux2d(:,num)
   enddo
 
   ! Auxiliary 3d arrays to output (for debugging)
@@ -4112,7 +4112,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%time_avg = Model%aux3d_time_avg(num)
-    ExtDiag(idx)%data(1)%var3 => IntDiag%aux3d(:,:,num)
+    ExtDiag(idx)%data%var3 => IntDiag%aux3d(:,:,num)
   enddo
 
   end subroutine GFS_externaldiag_populate
@@ -4160,7 +4160,7 @@ module GFS_diagnostics
          ExtDiag(idx)%unit = trim(unit)
          ExtDiag(idx)%mod_name = 'gfs_sfc'
          ExtDiag(idx)%intpl_method = 'nearest_stod'
-         ExtDiag(idx)%data(1)%var2 => var3d(:,k)
+         ExtDiag(idx)%data%var2 => var3d(:,k)
       enddo var_z_loop
 
     end subroutine link_all_levels

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -3751,7 +3751,6 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = 'volumetric soil moisture'
      ExtDiag(idx)%unit = 'fraction'
      ExtDiag(idx)%mod_name = 'gfs_sfc'
-     allocate (ExtDiag(idx)%data(nblks))
      do nb = 1,nblks
         ExtDiag(idx)%data(1)%var3 => sfcprop%smc(:,:)
      enddo

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -63,7 +63,7 @@ module GFS_diagnostics
     real(kind=kind_phys), pointer :: dtend(:,:,:) ! Assumption: dtend is null iff all(dtidx <= 1)
     character(len=*), intent(in), optional :: desc, unit
 
-    integer :: idtend, nlev
+    integer :: idtend
 
     idtend = Model%dtidx(itrac,iprocess)
     if(idtend>=1) then
@@ -82,7 +82,6 @@ module GFS_diagnostics
        else
           ExtDiag(idx)%unit = trim(Model%dtend_var_labels(itrac)%unit)
        endif
-       nlev = size(IntDiag%dtend,2)
        ExtDiag(idx)%data%var3 => IntDiag%dtend(:,:,idtend)
     endif
   end subroutine add_dtend
@@ -136,7 +135,7 @@ module GFS_diagnostics
     type(GFS_init_type),          intent(in)    :: Init_parm
 
 !--- local variables
-    integer :: idt, idx, num, NFXR, idtend, ichem, itrac, iprocess, i, nlev
+    integer :: idt, idx, num, NFXR, idtend, ichem, itrac, iprocess, i
     character(len=2) :: xtra
     real(kind=kind_phys), parameter :: cn_one = 1._kind_phys
     real(kind=kind_phys), parameter :: cn_100 = 100._kind_phys
@@ -145,7 +144,6 @@ module GFS_diagnostics
     character(len=30) :: namestr, descstr
 
     NFXR = Model%NFXR
-    nlev = size(Statein%qgrs,2)
     
     ExtDiag(:)%id = -99
     ExtDiag(:)%axes = -99

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -39,7 +39,7 @@ module GFS_diagnostics
     character(len=64)    :: mask
     character(len=64)    :: intpl_method
     real(kind=kind_phys) :: cnvfac
-    type(data_subtype), dimension(:), allocatable :: data
+    type(data_subtype), dimension(1)   :: data
    end type GFS_externaldiag_type
 
   !--- public data type ---
@@ -63,7 +63,7 @@ module GFS_diagnostics
     real(kind=kind_phys), pointer :: dtend(:,:,:) ! Assumption: dtend is null iff all(dtidx <= 1)
     character(len=*), intent(in), optional :: desc, unit
 
-    integer :: idtend, nb
+    integer :: idtend, nb, nlev
 
     idtend = Model%dtidx(itrac,iprocess)
     if(idtend>=1) then
@@ -82,9 +82,9 @@ module GFS_diagnostics
        else
           ExtDiag(idx)%unit = trim(Model%dtend_var_labels(itrac)%unit)
        endif
-       allocate (ExtDiag(idx)%data(nblks))
+       nlev = size(IntDiag%dtend,2)
        do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%dtend(Model%chunk_begin(nb):Model%chunk_end(nb),:,idtend)
+          ExtDiag(idx)%data(1)%var3 => IntDiag%dtend(:,:,idtend)
        enddo
     endif
   end subroutine add_dtend
@@ -114,10 +114,10 @@ module GFS_diagnostics
 !     ExtDiag%mask                 [char*64 ]   description of mask-type                      !
 !     ExtDiag%intpl_method         [char*64 ]   method to use for interpolation               !
 !     ExtDiag%cnvfac               [real*8  ]   conversion factor to output specified units   !
-!     ExtDiag%data(nb)%int2(:)     [integer ]   pointer to 2D data [=> null() for a 3D field] !
-!     ExtDiag%data(nb)%var2(:)     [real*8  ]   pointer to 2D data [=> null() for a 3D field] !
-!     ExtDiag%data(nb)%var21(:)    [real*8  ]   pointer to 2D data for ratios                 !
-!     ExtDiag%data(nb)%var3(:,:)   [real*8  ]   pointer to 3D data [=> null() for a 2D field] !
+!     ExtDiag%data%int2(:)         [integer ]   pointer to 2D data [=> null() for a 3D field] !
+!     ExtDiag%data%var2(:)         [real*8  ]   pointer to 2D data [=> null() for a 3D field] !
+!     ExtDiag%data%var21(:)        [real*8  ]   pointer to 2D data for ratios                 !
+!     ExtDiag%data%var3(:,:)       [real*8  ]   pointer to 3D data [=> null() for a 2D field] !
 !---------------------------------------------------------------------------------------------!
 
     use parse_tracers,    only: get_tracer_index
@@ -138,7 +138,7 @@ module GFS_diagnostics
     type(GFS_init_type),          intent(in)    :: Init_parm
 
 !--- local variables
-    integer :: idt, idx, num, nb, nblks, NFXR, idtend, ichem, itrac, iprocess, i
+    integer :: idt, idx, num, nb, nblks, NFXR, idtend, ichem, itrac, iprocess, i, nlev
     character(len=2) :: xtra
     real(kind=kind_phys), parameter :: cn_one = 1._kind_phys
     real(kind=kind_phys), parameter :: cn_100 = 100._kind_phys
@@ -147,8 +147,9 @@ module GFS_diagnostics
     character(len=30) :: namestr, descstr
 
     NFXR = Model%NFXR
-    nblks = Model%nchunks
-
+    nblks = 1!Model%nchunks
+    nlev = size(Statein%qgrs,2)
+    
     ExtDiag(:)%id = -99
     ExtDiag(:)%axes = -99
     ExtDiag(:)%cnvfac = cn_one
@@ -167,9 +168,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'frac'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%cldfra2d(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%cldfra2d(:)
     enddo
 
     idx = idx + 1
@@ -179,9 +179,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'frac'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%total_albedo(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%total_albedo(:)
     enddo
 
     idx = idx + 1
@@ -191,9 +190,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%lwp_ex(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%lwp_ex(:)
     enddo
 
     idx = idx + 1
@@ -203,9 +201,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%iwp_ex(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%iwp_ex(:)
     enddo
 
     idx = idx + 1
@@ -215,9 +212,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%lwp_fc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%lwp_fc(:)
     enddo
 
     idx = idx + 1
@@ -227,11 +223,10 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%iwp_fc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%iwp_fc(:)
     enddo
-
+    
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ALBDO_ave'
@@ -240,10 +235,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%mask = 'positive_flux'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2  => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),3)
-      ExtDiag(idx)%data(nb)%var21 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),4)
+       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,3)
+       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,4)
     enddo
 
     idx = idx + 1
@@ -255,11 +249,10 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dlwsfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfc(:)
     enddo
-
+    
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'DLWRFI'
@@ -267,11 +260,10 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dlwsfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfci(:)
     enddo
-
+    
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ULWRF'
@@ -281,11 +273,10 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%ulwsfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfc(:)
     enddo
-
+    
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'DSWRFItoa'
@@ -294,9 +285,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),23)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,23)
     enddo
 
     idx = idx + 1
@@ -307,9 +297,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),2)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,2)
     enddo
 
     idx = idx + 1
@@ -320,9 +309,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),1)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,1)
     enddo
 
     idx = idx + 1
@@ -332,9 +320,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%ulwsfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfci(:)
     enddo
 
     idx = idx + 1
@@ -347,9 +334,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),4)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,4)
     enddo
 
     idx = idx + 1
@@ -359,9 +345,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dswsfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dswsfci(:)
     enddo
 
     idx = idx + 1
@@ -374,9 +359,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),3)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,3)
     enddo
 
     idx = idx + 1
@@ -386,9 +370,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%uswsfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%uswsfci(:)
     enddo
 
     idx = idx + 1
@@ -400,9 +383,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),21)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,21)
     enddo
 
     idx = idx + 1
@@ -414,9 +396,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),22)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,22)
     enddo
 
     idx = idx + 1
@@ -428,11 +409,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),24)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,24)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'vddsf_ave'
@@ -442,11 +421,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),25)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,25)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'nbdsf_ave'
@@ -456,11 +433,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),26)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,26)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'nddsf_ave'
@@ -470,11 +445,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),27)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,27)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csulf_avetoa'
@@ -484,11 +457,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),28)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,28)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csusf_avetoa'
@@ -498,11 +469,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),29)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,29)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csdlf_ave'
@@ -512,11 +481,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),30)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,30)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csusf_ave'
@@ -526,11 +493,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),31)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,31)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csdsf_ave'
@@ -540,11 +505,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),32)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,32)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csdsf'
@@ -552,11 +515,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),32)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,32)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csulf_ave'
@@ -566,12 +527,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),33)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,33)
     enddo
-
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'DSWRFtoa'
@@ -582,12 +540,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),23)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,23)
     enddo
-
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'USWRFtoa'
@@ -598,11 +553,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),2)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,2)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ULWRFtoa'
@@ -613,11 +566,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),1)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,1)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDC_aveclm'
@@ -627,11 +578,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),17)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,17)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDC_avebndcl'
@@ -641,11 +590,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),18)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,18)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDCcnvcl'
@@ -653,11 +600,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_100
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Cldprop%cv(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Cldprop%cv(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PREScnvclt'
@@ -665,12 +610,10 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%mask = 'cldmask'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Cldprop%cvt(Model%chunk_begin(nb):Model%chunk_end(nb))
-      ExtDiag(idx)%data(nb)%var21 => Cldprop%cv(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2  => Cldprop%cvt(:)
+       ExtDiag(idx)%data(1)%var21 => Cldprop%cv(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PREScnvclb'
@@ -678,14 +621,10 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%mask = 'cldmask'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Cldprop%cvb(Model%chunk_begin(nb):Model%chunk_end(nb))
-      ExtDiag(idx)%data(nb)%var21 => Cldprop%cv(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2  => Cldprop%cvb(:)
+       ExtDiag(idx)%data(1)%var21 => Cldprop%cv(:)
     enddo
-!    if(mpp_pe()==mpp_root_pe())print *,'in gfdl_diag_register,af PREScnvclb,idx=',idx
-
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDC_avehcl'
@@ -695,9 +634,8 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),5)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,5)
     enddo
 
     idx = idx + 1
@@ -709,12 +647,10 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),8)
-      ExtDiag(idx)%data(nb)%var21 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),5)
+       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,8)
+       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PRES_avehcb'
@@ -724,12 +660,10 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),11)
-      ExtDiag(idx)%data(nb)%var21 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),5)
+       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,11)
+       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TEMP_avehct'
@@ -739,12 +673,10 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),14)
-      ExtDiag(idx)%data(nb)%var21 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),5)
+       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,14)
+       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDC_avemcl'
@@ -754,11 +686,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),6)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,6)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PRES_avemct'
@@ -768,12 +698,10 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),9)
-      ExtDiag(idx)%data(nb)%var21 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),6)
+       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,9)
+       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PRES_avemcb'
@@ -783,12 +711,10 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),12)
-      ExtDiag(idx)%data(nb)%var21 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),6)
+       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,12)
+       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TEMP_avemct'
@@ -798,12 +724,10 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),15)
-      ExtDiag(idx)%data(nb)%var21 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),6)
+       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,15)
+       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDC_avelcl'
@@ -813,12 +737,10 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),7)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,7)
     enddo
-
-   idx = idx + 1
+    idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PRES_avelct'
     ExtDiag(idx)%desc = 'pressure low cloud top level'
@@ -827,12 +749,10 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),10)
-      ExtDiag(idx)%data(nb)%var21 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),7)
+       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,10)
+       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PRES_avelcb'
@@ -842,12 +762,10 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),13)
-      ExtDiag(idx)%data(nb)%var21 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),7)
+       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,13)
+       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TEMP_avelct'
@@ -857,10 +775,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),16)
-      ExtDiag(idx)%data(nb)%var21 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),7)
+       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,16)
+       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
     enddo
 !--- aerosol diagnostics ---
     idx = idx + 1
@@ -870,11 +787,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),34)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,34)
     enddo
-
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -883,11 +798,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),35)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,35)
     enddo
-
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -896,11 +809,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),36)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,36)
     enddo
-
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -909,11 +820,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),37)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,37)
     enddo
-
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -922,11 +831,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),38)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,38)
     enddo
-
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -935,11 +842,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),39)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,39)
     enddo
-
 !--- air quality diagnostics ---
   if (Model%cplaqm) then
     if (associated(IntDiag%aod)) then
@@ -949,9 +854,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total aerosol optical depth at 550 nm'
       ExtDiag(idx)%unit = 'numerical'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => IntDiag%aod(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => IntDiag%aod(:)
       enddo
     endif
   endif
@@ -967,9 +871,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fluxr diagnostic '//trim(xtra)//' - GFS radiation'
       ExtDiag(idx)%unit = 'XXX'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => IntDiag%fluxr(Model%chunk_begin(nb):Model%chunk_end(nb),num)
+         ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,num)
       enddo
     enddo
 
@@ -982,10 +885,7 @@ module GFS_diagnostics
 !rab      ExtDiag(idx)%name = 'dswcmp_'//trim(xtra)
 !rab      ExtDiag(idx)%desc = 'dswcmp dagnostic '//trim(xtra)//' - GFS radiation'
 !rab      ExtDiag(idx)%unit = 'XXX'
-!rab      ExtDiag(idx)%mod_name = 'gfs_phys'
-!rab      do nb = 1,nblks
-!rab        ExtDiag(idx)%data(nb)%var2 => IntDiag%dswcmp(Model%chunk_begin(nb):Model%chunk_end(nb),num)
-!rab      enddo
+!rab      ExtDiag(idx)%data(1)%var2 => IntDiag%dswcmp(:,num)
 !rab    enddo
 !rab
 !rab    do num = 1,4
@@ -996,9 +896,7 @@ module GFS_diagnostics
 !rab      ExtDiag(idx)%desc = 'uswcmp dagnostic '//trim(xtra)//' - GFS radiation'
 !rab      ExtDiag(idx)%unit = 'XXX'
 !rab      ExtDiag(idx)%mod_name = 'gfs_phys'
-!rab      do nb = 1,nblks
-!rab        ExtDiag(idx)%data(nb)%var2 => IntDiag%uswcmp(Model%chunk_begin(nb):Model%chunk_end(nb),num)
-!rab      enddo
+!rab      ExtDiag(idx)%data(1)%var2 => IntDiag%uswcmp(:,num)
 !rab    enddo
 
 ! DH gfortran cannot point to members of arrays of derived types such
@@ -1013,9 +911,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%topfsw(Model%chunk_begin(nb):Model%chunk_end(nb))%upfxc
+       ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%upfxc
     enddo
 
     idx = idx + 1
@@ -1025,9 +922,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%topfsw(Model%chunk_begin(nb):Model%chunk_end(nb))%dnfxc
+       ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%dnfxc
     enddo
 
     idx = idx + 1
@@ -1037,9 +933,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%topfsw(Model%chunk_begin(nb):Model%chunk_end(nb))%upfx0
+       ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%upfx0
     enddo
 
     idx = idx + 1
@@ -1049,9 +944,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%topflw(Model%chunk_begin(nb):Model%chunk_end(nb))%upfxc
+       ExtDiag(idx)%data(1)%var2 => IntDiag%topflw(:)%upfxc
     enddo
 
     idx = idx + 1
@@ -1061,9 +955,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%topflw(Model%chunk_begin(nb):Model%chunk_end(nb))%upfx0
+       ExtDiag(idx)%data(1)%var2 => IntDiag%topflw(:)%upfx0
     enddo
 #endif
 
@@ -1074,11 +967,9 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'Accumulated surface storm water runoff'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%srunoff(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%srunoff(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'evbs_ave'
@@ -1086,11 +977,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%evbsa(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%evbsa(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'evcw_ave'
@@ -1098,11 +987,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%evcwa(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%evcwa(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'snohf'
@@ -1110,11 +997,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%snohfa(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%snohfa(:)
     enddo
-
     if (Model%lsm == Model%lsm_noahmp) then
      idx = idx + 1
      ExtDiag(idx)%axes = 2
@@ -1123,9 +1008,8 @@ module GFS_diagnostics
      ExtDiag(idx)%unit = 'W/m**2'
      ExtDiag(idx)%mod_name = 'gfs_phys'
      ExtDiag(idx)%time_avg = .TRUE.
-     allocate (ExtDiag(idx)%data(nblks))
      do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var2 => IntDiag%paha(Model%chunk_begin(nb):Model%chunk_end(nb))
+        ExtDiag(idx)%data(1)%var2 => IntDiag%paha(:)
      enddo
     endif
 
@@ -1136,11 +1020,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%transa(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%transa(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'sbsno_ave'
@@ -1148,11 +1030,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%sbsnoa(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%sbsnoa(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'snowc_ave'
@@ -1161,22 +1041,18 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%cnvfac = cn_100
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%snowca(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%snowca(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'snowc'
     ExtDiag(idx)%desc = 'snow cover '
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%sncovr(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%sncovr(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'soilm'
@@ -1184,12 +1060,10 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%mask = "land_only"
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2  => IntDiag%soilm(Model%chunk_begin(nb):Model%chunk_end(nb))
-      ExtDiag(idx)%data(nb)%var21 => Sfcprop%slmsk(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2  => IntDiag%soilm(:)
+       ExtDiag(idx)%data(1)%var21 => Sfcprop%slmsk(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'tmpmin2m'
@@ -1197,11 +1071,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tmpmin(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tmpmin(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'tmpmax2m'
@@ -1209,11 +1081,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tmpmax(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tmpmax(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dusfc'
@@ -1223,11 +1093,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dusfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dusfc(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dvsfc'
@@ -1237,11 +1105,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dvsfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dvsfc(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'shtfl_ave'
@@ -1251,11 +1117,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dtsfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dtsfc(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'lhtfl_ave'
@@ -1265,11 +1129,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dqsfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dqsfc(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totprcp_ave'
@@ -1280,11 +1142,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%totprcp(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%totprcp(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totprcpb_ave'
@@ -1294,11 +1154,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%totprcpb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%totprcpb(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'gflux_ave'
@@ -1307,13 +1165,11 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-!    ExtDiag(idx)%mask = "land_ice_only"
-    allocate (ExtDiag(idx)%data(nblks))
+    !    ExtDiag(idx)%mask = "land_ice_only"
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2  => IntDiag%gflux(Model%chunk_begin(nb):Model%chunk_end(nb))
-!      ExtDiag(idx)%data(nb)%var21 => Sfcprop%slmsk(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2  => IntDiag%gflux(:)
+       !ExtDiag(idx)%data(1)%var21 => Sfcprop%slmsk(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dlwsfc'
@@ -1321,11 +1177,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dlwsfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfc(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ulwsfc'
@@ -1333,11 +1187,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%ulwsfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfc(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'sunsd_acc'
@@ -1345,31 +1197,26 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 's'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%suntim(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%suntim(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'watr_acc'
     ExtDiag(idx)%desc = 'total water runoff'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%runoff(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%runoff(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ecan_acc'
     ExtDiag(idx)%desc = 'total evaporation of intercepted water'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tecan(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tecan(:)
     enddo
 
     idx = idx + 1
@@ -1378,9 +1225,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total plant transpiration'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tetran(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tetran(:)
     enddo
 
     idx = idx + 1
@@ -1389,9 +1235,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total soil surface evaporation'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tedir(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tedir(:)
     enddo
 
     if (Model%lsm == Model%lsm_noahmp) then
@@ -1401,9 +1246,8 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = 'total water storage in aquifer'
      ExtDiag(idx)%unit = 'kg/m**2'
      ExtDiag(idx)%mod_name = 'gfs_phys'
-     allocate (ExtDiag(idx)%data(nblks))
      do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var2 => IntDiag%twa(Model%chunk_begin(nb):Model%chunk_end(nb))
+        ExtDiag(idx)%data(1)%var2 => IntDiag%twa(:)
      enddo
     endif
 
@@ -1414,11 +1258,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%ep(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%ep(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cwork_ave'
@@ -1427,12 +1269,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%cldwrk(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%cldwrk(:)
     enddo
-
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'u-gwd_ave'
@@ -1441,11 +1280,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dugwd(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dugwd(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'v-gwd_ave'
@@ -1454,11 +1291,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dvgwd(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dvgwd(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'psmean'
@@ -1466,11 +1301,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kPa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%psmean(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%psmean(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cnvprcp_ave'
@@ -1481,11 +1314,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%cnvprcp(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcp(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cnvprcpb_ave'
@@ -1495,22 +1326,18 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%cnvprcpb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcpb(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cnvprcp'
     ExtDiag(idx)%desc = 'surface convective precipitation rate'
     ExtDiag(idx)%unit = 'kg/m**2/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%cnvprcp(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcp(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'spfhmin2m'
@@ -1518,11 +1345,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%spfhmin(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%spfhmin(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'spfhmax2m'
@@ -1530,11 +1355,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%spfhmax(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%spfhmax(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'u10mmax'
@@ -1542,11 +1365,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%u10mmax(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%u10mmax(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'v10mmax'
@@ -1554,11 +1375,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%v10mmax(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%v10mmax(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'wind10mmax'
@@ -1566,9 +1385,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%wind10mmax(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%wind10mmax(:)
     enddo
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1577,11 +1395,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%u10max(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%u10max(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'v10max'
@@ -1589,11 +1405,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%v10max(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%v10max(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'spd10max'
@@ -1601,11 +1415,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%spd10max(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%spd10max(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 't02max'
@@ -1613,11 +1425,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%t02max(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%t02max(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 't02min'
@@ -1625,9 +1435,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%t02min(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%t02min(:)
     enddo
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1636,11 +1445,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%rh02max(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%rh02max(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'rh02min'
@@ -1648,22 +1455,18 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%rh02min(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%rh02min(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'pratemax'
     ExtDiag(idx)%desc = 'max hourly precipitation rate'
     ExtDiag(idx)%unit = 'mm h-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%pratemax(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%pratemax(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'frzr'
@@ -1671,11 +1474,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%frzr(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%frzr(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'frzrb'
@@ -1683,11 +1484,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%frzrb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%frzrb(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'frozr'
@@ -1695,11 +1494,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%frozr(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%frozr(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'frozrb'
@@ -1707,11 +1504,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%frozrb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%frozrb(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'tsnowp'
@@ -1719,11 +1514,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tsnowp(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tsnowp(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'tsnowpb'
@@ -1731,77 +1524,63 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tsnowpb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tsnowpb(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'rhonewsn'
     ExtDiag(idx)%desc = 'precipitation ice density'
     ExtDiag(idx)%unit = 'kg m^-3'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%rhonewsn1(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%rhonewsn1(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'rain'
     ExtDiag(idx)%desc = 'total rain at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%rain(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%rain(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'rainc'
     ExtDiag(idx)%desc = 'convective rain at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%rainc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%rainc(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ice'
     ExtDiag(idx)%desc = 'ice fall at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%ice(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%ice(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'snow'
     ExtDiag(idx)%desc = 'snow fall at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%snow(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%snow(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'graupel'
     ExtDiag(idx)%desc = 'graupel fall at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%graupel(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%graupel(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totice_ave'
@@ -1811,11 +1590,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%totice(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%totice(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'toticeb_ave'
@@ -1824,11 +1601,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%toticeb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%toticeb(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totsnw_ave'
@@ -1838,11 +1613,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%totsnw(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%totsnw(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totsnwb_ave'
@@ -1851,11 +1624,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%totsnwb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%totsnwb(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totgrp_ave'
@@ -1865,11 +1636,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%totgrp(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%totgrp(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totgrpb_ave'
@@ -1878,50 +1647,43 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%totgrpb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%totgrpb(:)
     enddo
-
-!    if(mpp_pe()==mpp_root_pe())print *,'in gfdl_diag_register,af totgrp,idx=',idx
-
     if(associated(Coupling%sfcdlw)) then
-    idx = idx + 1
-    ExtDiag(idx)%axes = 2
-    ExtDiag(idx)%name = 'sfcdlw'
-    ExtDiag(idx)%desc = 'sfcdlw'
-    ExtDiag(idx)%unit = 'W m-2'
-    ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Coupling%sfcdlw(Model%chunk_begin(nb):Model%chunk_end(nb))
-    enddo
+       idx = idx + 1
+       ExtDiag(idx)%axes = 2
+       ExtDiag(idx)%name = 'sfcdlw'
+       ExtDiag(idx)%desc = 'sfcdlw'
+       ExtDiag(idx)%unit = 'W m-2'
+       ExtDiag(idx)%mod_name = 'gfs_phys'
+       do nb = 1,nblks
+          ExtDiag(idx)%data(1)%var2 => Coupling%sfcdlw(:)
+       enddo
     endif
 
     if(associated(Coupling%htrlw)) then
-    idx = idx + 1
-    ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'htrlw'
-    ExtDiag(idx)%desc = 'htrlw'
-    ExtDiag(idx)%unit = 'W m-2'
-    ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => Coupling%htrlw(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-    enddo
+       idx = idx + 1
+       ExtDiag(idx)%axes = 3
+       ExtDiag(idx)%name = 'htrlw'
+       ExtDiag(idx)%desc = 'htrlw'
+       ExtDiag(idx)%unit = 'W m-2'
+       ExtDiag(idx)%mod_name = 'gfs_phys'
+       do nb = 1,nblks
+          ExtDiag(idx)%data(1)%var3 => Coupling%htrlw(:,:)
+       enddo
     endif
 
     if(associated(Radtend%lwhc)) then
-    idx = idx + 1
-    ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'lwhc'
-    ExtDiag(idx)%desc = 'lwhc'
-    ExtDiag(idx)%unit = 'K s-1'
-    ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => Radtend%lwhc(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-    enddo
+       idx = idx + 1
+       ExtDiag(idx)%axes = 3
+       ExtDiag(idx)%name = 'lwhc'
+       ExtDiag(idx)%desc = 'lwhc'
+       ExtDiag(idx)%unit = 'K s-1'
+       ExtDiag(idx)%mod_name = 'gfs_phys'
+       do nb = 1,nblks
+          ExtDiag(idx)%data(1)%var3 => Radtend%lwhc(:,:)
+       enddo
     endif
 
 !--- physics instantaneous diagnostics ---
@@ -1932,11 +1694,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%u10m(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%u10m(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'v10m'
@@ -1944,9 +1704,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%v10m(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%v10m(:)
     enddo
 
     idx = idx + 1
@@ -1956,22 +1715,18 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dpt2m(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dpt2m(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'hgt_hyblev1'
     ExtDiag(idx)%desc = 'layer 1 height'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%zlvl(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%zlvl(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'psurf'
@@ -1980,11 +1735,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mask = 'pseudo_ps'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%psurf(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%psurf(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'hpbl'
@@ -1992,11 +1745,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Tbd%hpbl(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Tbd%hpbl(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'pwat'
@@ -2004,11 +1755,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%pwat(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%pwat(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'tmp_hyblev1'
@@ -2016,11 +1765,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%t1(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%t1(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'spfh_hyblev1'
@@ -2028,11 +1775,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%q1(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%q1(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ugrd_hyblev1'
@@ -2040,11 +1785,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%u1(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%u1(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'vgrd_hyblev1'
@@ -2052,11 +1795,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%v1(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%v1(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'sfexc'
@@ -2064,11 +1805,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m2/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%chh(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%chh(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'acond'
@@ -2076,11 +1815,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%cmm(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%cmm(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dlwsfci'
@@ -2088,11 +1825,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dlwsfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfci(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ulwsfci'
@@ -2100,11 +1835,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%ulwsfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfci(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dswsfci'
@@ -2112,11 +1845,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dswsfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dswsfci(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'uswsfci'
@@ -2124,33 +1855,27 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%uswsfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%uswsfci(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dusfci'
     ExtDiag(idx)%desc = 'instantaneous u component of surface stress'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dusfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dusfci(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dvsfci'
     ExtDiag(idx)%desc = 'instantaneous v component of surface stress'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dvsfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dvsfci(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'shtfl'
@@ -2158,11 +1883,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dtsfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dtsfci(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'lhtfl'
@@ -2170,44 +1893,36 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dqsfci(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dqsfci(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'gfluxi'
     ExtDiag(idx)%desc = 'instantaneous surface ground heat flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%gfluxi(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%gfluxi(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'wilt'
     ExtDiag(idx)%desc = 'wiltimg point (volumetric)'
     ExtDiag(idx)%unit = 'Proportion'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%smcwlt2(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%smcwlt2(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'fldcp'
     ExtDiag(idx)%desc = 'Field Capacity (volumetric)'
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%smcref2(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%smcref2(:)
     enddo
-
     if (Model%lsm == Model%lsm_noahmp) then
      idx = idx + 1
      ExtDiag(idx)%axes = 2
@@ -2215,9 +1930,8 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = 'instantaneous precipitation advected heat flux'
      ExtDiag(idx)%unit = 'W/m**2'
      ExtDiag(idx)%mod_name = 'gfs_phys'
-     allocate (ExtDiag(idx)%data(nblks))
      do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var2 => IntDiag%pahi(Model%chunk_begin(nb):Model%chunk_end(nb))
+        ExtDiag(idx)%data(1)%var2 => IntDiag%pahi(:)
      enddo
     endif
 
@@ -2227,26 +1941,23 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous surface potential evaporation'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%epi(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%epi(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'wet1'
     ExtDiag(idx)%desc = 'normalized soil wetness'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     if (Model%lsm==Model%lsm_ruc) then
-      do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%wetness(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+       do nb = 1,nblks
+          ExtDiag(idx)%data(1)%var2 => Sfcprop%wetness(:)
+       enddo
     else
-      do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => IntDiag%wet1(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+       do nb = 1,nblks
+          ExtDiag(idx)%data(1)%var2 => IntDiag%wet1(:)
+       enddo
     endif
 
     idx = idx + 1
@@ -2256,11 +1967,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%sr(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%sr(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'crain_ave'
@@ -2270,11 +1979,9 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tdomr(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tdomr(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csnow_ave'
@@ -2284,11 +1991,9 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tdoms(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tdoms(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cfrzr_ave'
@@ -2298,11 +2003,9 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tdomzr(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tdomzr(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cicep_ave'
@@ -2312,77 +2015,64 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tdomip(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tdomip(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'refl_10cm'
     ExtDiag(idx)%desc = 'Radar reflectivity'
     ExtDiag(idx)%unit = 'dBz'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%refl_10cm(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%refl_10cm(:,:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'max_hail_diam_sfc'
     ExtDiag(idx)%desc = 'Maximum hail diameter at lowest model level'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%max_hail_diam_sfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%max_hail_diam_sfc(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'dkt'
     ExtDiag(idx)%desc = 'Atmospheric heat diffusivity'
     ExtDiag(idx)%unit = 'm2s-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dkt(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dkt(:,:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'dku'
     ExtDiag(idx)%desc = 'Atmospheric momentum diffusivity'
     ExtDiag(idx)%unit = 'm2s-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dku(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dku(:,:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'cldfra'
     ExtDiag(idx)%desc = 'Instantaneous 3D Cloud Fraction'
     ExtDiag(idx)%unit = 'frac'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%cldfra(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%cldfra(:,:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'cnvw'
     ExtDiag(idx)%desc = 'subgrid scale convective cloud water'
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     if( Model%ncnvw > 0 ) then
-      do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Tbd%phy_f3d(Model%chunk_begin(nb):Model%chunk_end(nb),:,Model%ncnvw)
-      enddo
+       do nb = 1,nblks
+          ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%ncnvw)
+       enddo
     endif
 
     if (Model%do_skeb) then
@@ -2392,20 +2082,17 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Coupling%skebu_wts(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 =>Coupling%skebu_wts(:,:)
       enddo
-
       idx = idx + 1
       ExtDiag(idx)%axes = 3
       ExtDiag(idx)%name = 'skebv_wts'
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Coupling%skebv_wts(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%skebv_wts(:,:)
       enddo
     endif
 
@@ -2415,20 +2102,17 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'level of dividing streamline'
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%zmtnblck(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%zmtnblck(:)
     enddo
-
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'refdmax'
     ExtDiag(idx)%desc = 'max hourly 1-km agl reflectivity'
     ExtDiag(idx)%unit = 'dBZ'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%refdmax(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%refdmax(:)
     enddo
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2436,11 +2120,9 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'max hourly -10C reflectivity'
     ExtDiag(idx)%unit = 'dBZ'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%refdmax263k(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%refdmax263k(:)
     enddo
-
     if (Model%do_sppt .or. Model%ca_global) then
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -2448,9 +2130,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Coupling%sppt_wts(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%sppt_wts(:,:)
       enddo
     endif
 
@@ -2461,9 +2142,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Coupling%shum_wts(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%shum_wts(:,:)
       enddo
     endif
 
@@ -2474,9 +2154,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp pbl perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Coupling%spp_wts_pbl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_pbl(:,:)
       enddo
     endif
 
@@ -2487,9 +2166,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp sfc perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Coupling%spp_wts_sfc(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_sfc(:,:)
       enddo
     endif
 
@@ -2500,9 +2178,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp mp perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Coupling%spp_wts_mp(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_mp(:,:)
       enddo
     endif
 
@@ -2513,9 +2190,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp gwd perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Coupling%spp_wts_gwd(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_gwd(:,:)
       enddo
     endif
 
@@ -2526,9 +2202,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp rad perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Coupling%spp_wts_rad(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_rad(:,:)
       enddo
     endif
 
@@ -2539,9 +2214,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp cu deep perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Coupling%spp_wts_cu_deep(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_cu_deep(:,:)
       enddo
     endif
 
@@ -2552,11 +2226,9 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation amplitude'
       ExtDiag(idx)%unit = 'none'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Coupling%sfc_wts(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%sfc_wts(:,:)
       enddo
-
     endif
 
     if (Model%do_ca) then
@@ -2566,9 +2238,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Cellular Automata'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%ca1(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%ca1(:)
       enddo
 
       idx = idx + 1
@@ -2577,9 +2248,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA deep conv'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%ca_deep(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%ca_deep(:)
       enddo
 
       idx = idx + 1
@@ -2588,9 +2258,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA turbulence'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%ca_turb(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%ca_turb(:)
       enddo
 
       idx = idx + 1
@@ -2599,9 +2268,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA shallow conv'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%ca_shal(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%ca_shal(:)
       enddo
 
       idx = idx + 1
@@ -2610,9 +2278,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA radiation'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%ca_rad(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%ca_rad(:)
       enddo
 
       idx = idx + 1
@@ -2621,9 +2288,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA microphys'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%ca_micro(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%ca_micro(:)
       enddo
     endif
 
@@ -2636,9 +2302,8 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'fraction'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%lakefrac(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%lakefrac(:)
       enddo
 
       idx = idx + 1
@@ -2648,9 +2313,8 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%lakedepth(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%lakedepth(:)
       enddo
 
       idx = idx + 1
@@ -2660,9 +2324,8 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%T_snow(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%T_snow(:)
       enddo
 
       idx = idx + 1
@@ -2672,9 +2335,8 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%T_ice(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%T_ice(:)
       enddo
 
       idx = idx + 1
@@ -2684,9 +2346,8 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'flag'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%int2 => Sfcprop%use_lake_model(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%int2 => Sfcprop%use_lake_model(:)
       enddo
 
       if(Model%iopt_lake==Model%iopt_lake_clm) then
@@ -2700,9 +2361,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'lake point is considered salty by clm lake model'
         ExtDiag(idx)%unit = '1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-           ExtDiag(idx)%data(nb)%int2 => Sfcprop%lake_is_salty(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%int2 => Sfcprop%lake_is_salty(:)
         enddo
 
         idx = idx + 1
@@ -2711,9 +2371,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'clm lake model considers the point to be so salty it cannot freeze'
         ExtDiag(idx)%unit = '1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-           ExtDiag(idx)%data(nb)%int2 => Sfcprop%lake_cannot_freeze(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%int2 => Sfcprop%lake_cannot_freeze(:)
         enddo
 
         idx = idx + 1
@@ -2723,9 +2382,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Sfcprop%lake_t2m(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_t2m(:)
         enddo
 
         idx = idx + 1
@@ -2735,9 +2393,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg/kg'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Sfcprop%lake_q2m(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_q2m(:)
         enddo
 
         idx = idx + 1
@@ -2747,9 +2404,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'fraction'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Sfcprop%lake_albedo(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_albedo(:)
         enddo
 
         idx = idx + 1
@@ -2759,9 +2415,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'mm'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Sfcprop%lake_h2osno2d(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_h2osno2d(:)
         enddo
 
         idx = idx + 1
@@ -2771,9 +2426,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'm'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Sfcprop%lake_sndpth2d(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_sndpth2d(:)
         enddo
 
         idx = idx + 1
@@ -2783,9 +2437,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'count'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Sfcprop%lake_snl2d(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_snl2d(:)
         enddo
 
         idx = idx + 1
@@ -2795,9 +2448,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Sfcprop%lake_tsfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_tsfc(:)
         enddo
 
         idx = idx + 1
@@ -2807,9 +2459,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-3'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Sfcprop%lake_savedtke12d(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_savedtke12d(:)
         enddo
 
         idx = idx + 1
@@ -2819,9 +2470,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'unitless'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Sfcprop%lake_ht(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_ht(:)
         enddo
 
       endif
@@ -2836,9 +2486,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'height of dividing streamline'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%zmtb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%zmtb(:)
     enddo
 
     idx = idx + 1
@@ -2847,9 +2496,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'height of OGW-launch'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%zogw(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%zogw(:)
     enddo
 
     idx = idx + 1
@@ -2858,9 +2506,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'height of LWB-level'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%zlwb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%zlwb(:)
     enddo
 
     idx = idx + 1
@@ -2869,9 +2516,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' OGW vertical MF at launch level'
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tau_ogw(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tau_ogw(:)
     enddo
 
     idx = idx + 1
@@ -2880,9 +2526,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' ORO-MTB integrated flux from surface'
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tau_mtb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tau_mtb(:)
     enddo
 
     idx = idx + 1
@@ -2891,9 +2536,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' ORO-TOFD integrated flux from surface'
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tau_tofd(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tau_tofd(:)
     enddo
 
     idx = idx + 1
@@ -2902,9 +2546,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' NGW momentum flux at launch level '
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%tau_ngw(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%tau_ngw(:)
     enddo
 
     idx = idx + 1
@@ -2913,9 +2556,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'axz_oro averaged E-W OROGW-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%du3dt_ogw(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_ogw(:,:)
     enddo
 
     idx = idx + 1
@@ -2924,21 +2566,18 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'axz_oro averaged E-W GWALL-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%du3dt_ngw(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_ngw(:,:)
     enddo
-!
-!
+
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'du3dt_mtb'
     ExtDiag(idx)%desc = 'axz_oro averaged E-W MTB-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%du3dt_mtb(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_mtb(:,:)
     enddo
 
     idx = idx + 1
@@ -2947,9 +2586,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'axz_oro averaged E-W TMS-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%du3dt_tms(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_tms(:,:)
     enddo
 
     idx = idx + 1
@@ -2958,9 +2596,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from mesoscale OGWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dudt_ogw(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_ogw(:,:)
     enddo
 
     idx = idx + 1
@@ -2969,9 +2606,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from mesoscale OGWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dvdt_ogw(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_ogw(:,:)
     enddo
 
     idx = idx + 1
@@ -2980,9 +2616,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from blocking drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dudt_obl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_obl(:,:)
     enddo
 
     idx = idx + 1
@@ -2991,9 +2626,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from blocking drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dvdt_obl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_obl(:,:)
     enddo
 
     ! 2D variables
@@ -3004,9 +2638,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from meso scale ogw'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%du_ogwcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%du_ogwcol(:)
     enddo
 
     idx = idx + 1
@@ -3015,9 +2648,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from meso scale ogw'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dv_ogwcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dv_ogwcol(:)
     enddo
 
     idx = idx + 1
@@ -3026,9 +2658,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from blocking drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%du_oblcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%du_oblcol(:)
     enddo
 
     idx = idx + 1
@@ -3037,9 +2668,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from blocking drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dv_oblcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dv_oblcol(:)
     enddo
 
     idx = idx + 1
@@ -3049,9 +2679,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dws3dt_ogw(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_ogw(:,:)
     enddo
 
     idx = idx + 1
@@ -3061,9 +2690,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dws3dt_obl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_obl(:,:)
     enddo
 
     ! Variables for GSL drag suite
@@ -3074,9 +2702,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from small scale GWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dudt_oss(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_oss(:,:)
     enddo
 
     idx = idx + 1
@@ -3085,9 +2712,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from small scale GWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dvdt_oss(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_oss(:,:)
     enddo
 
     idx = idx + 1
@@ -3096,9 +2722,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from form drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dudt_ofd(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_ofd(:,:)
     enddo
 
     idx = idx + 1
@@ -3107,9 +2732,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from form drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dvdt_ofd(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_ofd(:,:)
     enddo
 
     idx = idx + 1
@@ -3119,9 +2743,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dws3dt_oss(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_oss(:,:)
     enddo
 
     idx = idx + 1
@@ -3131,9 +2754,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%dws3dt_ofd(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_ofd(:,:)
     enddo
 
     idx = idx + 1
@@ -3143,9 +2765,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%ldu3dt_ogw(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ogw(:,:)
     enddo
 
     idx = idx + 1
@@ -3155,9 +2776,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%ldu3dt_obl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_obl(:,:)
     enddo
 
     idx = idx + 1
@@ -3167,9 +2787,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%ldu3dt_ofd(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ofd(:,:)
     enddo
 
     idx = idx + 1
@@ -3179,9 +2798,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%ldu3dt_oss(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_oss(:,:)
     enddo
 
     ! 2D variables
@@ -3192,9 +2810,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from small scale gwd'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%du_osscol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%du_osscol(:)
     enddo
 
     idx = idx + 1
@@ -3203,9 +2820,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from small scale gwd'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dv_osscol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dv_osscol(:)
     enddo
 
     idx = idx + 1
@@ -3214,9 +2830,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from form drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%du_ofdcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%du_ofdcol(:)
     enddo
 
     idx = idx + 1
@@ -3225,9 +2840,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from form drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dv_ofdcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dv_ofdcol(:)
     enddo
 
     idx = idx + 1
@@ -3237,9 +2851,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%du3_ogwcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%du3_ogwcol(:)
     enddo
 
     idx = idx + 1
@@ -3249,9 +2862,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dv3_ogwcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_ogwcol(:)
     enddo
 
     idx = idx + 1
@@ -3261,9 +2873,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%du3_oblcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%du3_oblcol(:)
     enddo
 
     idx = idx + 1
@@ -3273,9 +2884,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dv3_oblcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_oblcol(:)
     enddo
 
     idx = idx + 1
@@ -3285,9 +2895,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%du3_osscol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%du3_osscol(:)
     enddo
 
     idx = idx + 1
@@ -3297,9 +2906,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dv3_osscol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_osscol(:)
     enddo
 
     idx = idx + 1
@@ -3309,9 +2917,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%du3_ofdcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%du3_ofdcol(:)
     enddo
 
     idx = idx + 1
@@ -3321,9 +2928,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dv3_ofdcol(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_ofdcol(:)
     enddo
 
     ! UGWP non-stationary GWD outputs
@@ -3335,9 +2941,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%ldu3dt_ngw(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ngw(:,:)
     enddo
 
     idx = idx + 1
@@ -3347,9 +2952,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%ldv3dt_ngw(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%ldv3dt_ngw(:,:)
     enddo
 
     idx = idx + 1
@@ -3359,9 +2963,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K s-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%ldt3dt_ngw(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%ldt3dt_ngw(:,:)
     enddo
 
   ENDIF  ! if (Model%ldiag_ugwp)
@@ -3389,9 +2992,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-1 s-3'
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%time_avg = .TRUE.
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%upd_mf(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%upd_mf(:,:)
         enddo
 
         idx = idx + 1
@@ -3401,9 +3003,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-1 s-3'
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%time_avg = .TRUE.
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%dwn_mf(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%dwn_mf(:,:)
         enddo
 
         idx = idx + 1
@@ -3413,9 +3014,8 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-1 s-3'
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%time_avg = .TRUE.
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%det_mf(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%det_mf(:,:)
         enddo
 
       end if if_qdiag3d
@@ -3448,9 +3048,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean nir albedo with strong cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%alnsf(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%alnsf(:)
     enddo
 
     idx = idx + 1
@@ -3459,9 +3058,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean nir albedo with weak cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%alnwf(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%alnwf(:)
     enddo
 
     idx = idx + 1
@@ -3470,9 +3068,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean vis albedo with strong cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%alvsf(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%alvsf(:)
     enddo
 
     idx = idx + 1
@@ -3481,9 +3078,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean vis albedo with weak cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%alvwf(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%alvwf(:)
     enddo
 
     idx = idx + 1
@@ -3492,9 +3088,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'canopy water (cnwat in gfs data)'
     ExtDiag(idx)%unit = 'mm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%canopy(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%canopy(:)
     enddo
 
     idx = idx + 1
@@ -3503,9 +3098,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = '10-meter wind speed divided by lowest model wind speed'
     ExtDiag(idx)%unit = 'N/A'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%f10m(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%f10m(:)
     enddo
 
     idx = idx + 1
@@ -3514,9 +3108,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fractional coverage with strong cosz dependency'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%facsf(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%facsf(:)
     enddo
 
     idx = idx + 1
@@ -3525,9 +3118,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fractional coverage with weak cosz dependency'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%facwf(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 =>Sfcprop%facwf(:)
     enddo
 
     idx = idx + 1
@@ -3536,9 +3128,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fh parameter from PBL scheme'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%ffhh(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%ffhh(:)
     enddo
 
     idx = idx + 1
@@ -3547,9 +3138,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fm parameter from PBL scheme'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%ffmm(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%ffmm(:)
     enddo
 
     idx = idx + 1
@@ -3558,9 +3148,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'uustar surface frictional wind'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%uustar(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%uustar(:)
     enddo
 
     idx = idx + 1
@@ -3569,9 +3158,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface slope type'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%int2 => Sfcprop%slope(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%int2 => Sfcprop%slope(:)
     enddo
 
     idx = idx + 1
@@ -3580,9 +3168,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface ice concentration (ice=1; no ice=0)'
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%fice(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%fice(:)
     enddo
 
     idx = idx + 1
@@ -3591,9 +3178,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sea ice thickness (icetk in gfs_data)'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%hice(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%hice(:)
     enddo
 
     idx = idx + 1
@@ -3602,9 +3188,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'maximum snow albedo in fraction'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%snoalb(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%snoalb(:)
     enddo
 
     idx = idx + 1
@@ -3613,9 +3198,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'maximum fractional coverage of green vegetation'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%shdmax(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%shdmax(:)
     enddo
 
     idx = idx + 1
@@ -3624,9 +3208,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'minimum fractional coverage of green vegetation'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%shdmin(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%shdmin(:)
     enddo
 
     idx = idx + 1
@@ -3636,9 +3219,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one/cn_th
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%snowd(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%snowd(:)
     enddo
 
     idx = idx + 1
@@ -3647,9 +3229,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous sublimation (evaporation from snow)'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%sbsno(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%sbsno(:)
     enddo
 
     idx = idx + 1
@@ -3658,9 +3239,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous direct evaporation over land'
     ExtDiag(idx)%unit = 'W m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%evbs(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%evbs(:)
     enddo
 
     idx = idx + 1
@@ -3669,9 +3249,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous canopy evaporation'
     ExtDiag(idx)%unit = 'W m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%evcw(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%evcw(:)
     enddo
 
     idx = idx + 1
@@ -3680,9 +3259,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous transpiration'
     ExtDiag(idx)%unit = 'W m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%trans(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => IntDiag%trans(:)
     enddo
 
     if (Model%lsm == Model%lsm_ruc) then
@@ -3693,9 +3271,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface albedo over land'
       ExtDiag(idx)%unit = 'fraction'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%sfalb_lnd(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%sfalb_lnd(:)
       enddo
 
       idx = idx + 1
@@ -3704,9 +3281,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'density of frozen precipitation'
       ExtDiag(idx)%unit = 'kg m-3'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%rhofr(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%rhofr(:)
       enddo
 
       idx = idx + 1
@@ -3715,9 +3291,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated frozen precipitation over land'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%snowfallac_land(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%snowfallac_land(:)
       enddo
 
       idx = idx + 1
@@ -3726,9 +3301,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated SWE of frozen precipitation over land'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%acsnow_land(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%acsnow_land(:)
       enddo
 
       idx = idx + 1
@@ -3737,9 +3311,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'accumulated snow melt over land'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => IntDiag%snowmt_land(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => IntDiag%snowmt_land(:)
       enddo
 
       idx = idx + 1
@@ -3748,9 +3321,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated frozen precipitation over ice'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%snowfallac_ice(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%snowfallac_ice(:)
       enddo
 
       idx = idx + 1
@@ -3759,9 +3331,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated SWE of frozen precipitation over ice'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%acsnow_ice(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%acsnow_ice(:)
       enddo
 
       idx = idx + 1
@@ -3770,9 +3341,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'accumulated snow melt over ice'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => IntDiag%snowmt_ice(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => IntDiag%snowmt_ice(:)
       enddo
     endif ! RUC lsm
 
@@ -3783,9 +3353,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%srflag(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%srflag(:)
     enddo
 
     idx = idx + 1
@@ -3794,9 +3363,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'soil type in integer 1-9'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%int2 => Sfcprop%stype(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%int2 => Sfcprop%stype(:)
     enddo
 
     idx = idx + 1
@@ -3805,11 +3373,9 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'soil color in integer 1-20'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%int2 => Sfcprop%scolor(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%int2 => Sfcprop%scolor(:)
     enddo
-
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3817,9 +3383,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'land fraction'
     ExtDiag(idx)%unit = 'fraction [0:1]'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%landfrac(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%landfrac(:)
     enddo
 
     idx = idx + 1
@@ -3829,9 +3394,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%q2m(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%q2m(:)
     enddo
 
     idx = idx + 1
@@ -3841,9 +3405,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%t2m(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%t2m(:)
     enddo
 
     idx = idx + 1
@@ -3852,9 +3415,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface temperature'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%tsfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%tsfc(:)
     enddo
 
     idx = idx + 1
@@ -3863,9 +3425,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface zonal current'
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%usfco(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%usfco(:)
     enddo
 
     idx = idx + 1
@@ -3874,9 +3435,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface meridional current'
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%vsfco(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%vsfco(:)
     enddo
 
     if (Model%frac_grid) then
@@ -3888,9 +3448,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'internal ice temperature layer ' // trim(xtra)
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Sfcprop%tiice(Model%chunk_begin(nb):Model%chunk_end(nb),num)
+           ExtDiag(idx)%data(1)%var2 => Sfcprop%tiice(:,num)
         enddo
       enddo
     end if
@@ -3901,9 +3460,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'deep soil temperature'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%tg3(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%tg3(:)
     enddo
 
     idx = idx + 1
@@ -3912,9 +3470,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface temperature over ice fraction'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%tisfc(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%tisfc(:)
     enddo
 
     idx = idx + 1
@@ -3923,9 +3480,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total time-step precipitation'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Sfcprop%tprcp(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%tprcp(:)
     enddo
 
     idx = idx + 1
@@ -3934,9 +3490,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'vegetation type in integer'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%int2 => sfcprop%vtype(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%int2 => sfcprop%vtype(:)
     enddo
 
     idx = idx + 1
@@ -3945,9 +3500,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface snow water equivalent'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%weasd(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%weasd(:)
     enddo
 
     idx = idx + 1
@@ -3956,9 +3510,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface snow water equivalent over ice'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%weasdi(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%weasdi(:)
     enddo
 
     idx = idx + 1
@@ -3967,9 +3520,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'snow depth over ice'
     ExtDiag(idx)%unit = 'mm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%snodi(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%snodi(:)
     enddo
 
     idx = idx + 1
@@ -3979,9 +3531,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'gpm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%oro(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%oro(:)
     enddo
 
     idx = idx + 1
@@ -3990,9 +3541,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sea-land-ice mask (0-sea, 1-land, 2-ice)'
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%slmsk(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%slmsk(:)
     enddo
 
     idx = idx + 1
@@ -4002,9 +3552,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one/cn_100
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%zorl(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%zorl(:)
     enddo
 
     idx = idx + 1
@@ -4014,9 +3563,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_100
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%vfrac(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%vfrac(:)
     enddo
 
     if (Model%lsm==Model%lsm_ruc) then
@@ -4027,9 +3575,8 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'fraction'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%cnvfac = cn_100
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => sfcprop%wetness(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => sfcprop%wetness(:)
       enddo
     end if
 
@@ -4039,9 +3586,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sfc nir beam sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Coupling%nirbmdi(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Coupling%nirbmdi(:)
     enddo
 
     idx = idx + 1
@@ -4050,9 +3596,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sfc nir diff sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Coupling%nirdfdi(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Coupling%nirdfdi(:)
     enddo
 
     idx = idx + 1
@@ -4061,9 +3606,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sfc uv+vis beam sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Coupling%visbmdi(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Coupling%visbmdi(:)
     enddo
 
     idx = idx + 1
@@ -4072,9 +3616,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' sfc uv+vis diff sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => Coupling%visdfdi(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => Coupling%visdfdi(:)
     enddo
 
     idx = idx + 1
@@ -4083,9 +3626,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'leaf area index'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%xlaixy(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%xlaixy(:)
     enddo
 
     do num = 1,Model%nvegcat
@@ -4096,9 +3638,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fraction of vegetation category'//trim(xtra)
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => sfcprop%vegtype_frac(Model%chunk_begin(nb):Model%chunk_end(nb),num)
+         ExtDiag(idx)%data(1)%var2 => sfcprop%vegtype_frac(:,num)
       enddo
     enddo
 
@@ -4110,9 +3651,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fraction of soil category'//trim(xtra)
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => sfcprop%soiltype_frac(Model%chunk_begin(nb):Model%chunk_end(nb),num)
+         ExtDiag(idx)%data(1)%var2 => sfcprop%soiltype_frac(:,num)
       enddo
     enddo
 
@@ -4125,10 +3665,9 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'liquid soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
       ExtDiag(idx)%unit = 'm**3/m**3'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => sfcprop%sh2o(Model%chunk_begin(nb):Model%chunk_end(nb),num)
-      enddo
+         ExtDiag(idx)%data(1)%var2 => sfcprop%sh2o(:,num)
+         enddo
     enddo
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -4136,9 +3675,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'liquid soil moisture'
     ExtDiag(idx)%unit = 'm**3/m**3'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => sfcprop%sh2o(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => sfcprop%sh2o(:,:)
     enddo
   else
     do num = 1,Model%lsoil_lsm
@@ -4157,9 +3695,8 @@ module GFS_diagnostics
 #endif
 ! *DH
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => sfcprop%slc(Model%chunk_begin(nb):Model%chunk_end(nb),num)
+         ExtDiag(idx)%data(1)%var2 => sfcprop%slc(:,num)
       enddo
     enddo
     idx = idx + 1
@@ -4168,9 +3705,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'liquid soil moisture'
     ExtDiag(idx)%unit = 'm**3/m**3'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => sfcprop%slc(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => sfcprop%slc(:,:)
     enddo
   endif
 
@@ -4183,9 +3719,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'volumetric soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
       ExtDiag(idx)%unit = 'fraction'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => sfcprop%smois(Model%chunk_begin(nb):Model%chunk_end(nb),num)
+         ExtDiag(idx)%data(1)%var2 => sfcprop%smois(:,num)
       enddo
     enddo
     idx = idx + 1
@@ -4194,33 +3729,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'volumetric soil moisture'
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => sfcprop%smois(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-    enddo
-  else
-    do num = 1,Model%lsoil_lsm
-      write (xtra,'(i1)') num
-      idx = idx + 1
-      ExtDiag(idx)%axes = 2
-      ExtDiag(idx)%name = 'soilw'//trim(xtra)
-      ExtDiag(idx)%desc = 'volumetric soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
-      ExtDiag(idx)%unit = 'fraction'
-      ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
-      do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => sfcprop%smc(Model%chunk_begin(nb):Model%chunk_end(nb),num)
-      enddo
-    enddo
-    idx = idx + 1
-    ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'soilw'
-    ExtDiag(idx)%desc = 'volumetric soil moisture'
-    ExtDiag(idx)%unit = 'fraction'
-    ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => sfcprop%smc(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+       ExtDiag(idx)%data(1)%var3 => sfcprop%smois(:,:)
     enddo
   endif
 
@@ -4233,9 +3743,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'soil temperature ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => sfcprop%tslb(Model%chunk_begin(nb):Model%chunk_end(nb),num)
+           ExtDiag(idx)%data(1)%var2 => sfcprop%tslb(:,num)
         enddo
       enddo
       idx = idx + 1
@@ -4244,9 +3753,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'soil temperature'
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => sfcprop%tslb(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => sfcprop%tslb(:,:)
       enddo
     else
       do num = 1,Model%lsoil_lsm
@@ -4257,9 +3765,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'soil temperature ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => sfcprop%stc(Model%chunk_begin(nb):Model%chunk_end(nb),num)
+           ExtDiag(idx)%data(1)%var2 => sfcprop%stc(:,num)
         enddo
       enddo
       idx = idx + 1
@@ -4268,9 +3775,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'soil temperature'
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => sfcprop%stc(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => sfcprop%stc(:,:)
       enddo
     endif
 
@@ -4284,9 +3790,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst reference or foundation temperature'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%tref(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%tref(:)
     enddo
 
     idx = idx + 1
@@ -4295,9 +3800,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst sub-layer cooling thickness'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%z_c(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%z_c(:)
     enddo
 
     idx = idx + 1
@@ -4306,9 +3810,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient1 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%c_0(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%c_0(:)
     enddo
 
     idx = idx + 1
@@ -4317,9 +3820,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient2 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%c_d(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%c_d(:)
     enddo
 
     idx = idx + 1
@@ -4328,9 +3830,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient3 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%w_0(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%w_0(:)
     enddo
 
     idx = idx + 1
@@ -4339,9 +3840,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient4 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%w_d(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%w_d(:)
     enddo
 
     idx = idx + 1
@@ -4350,9 +3850,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst heat content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'k*m'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%xt(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%xt(:)
     enddo
 
     idx = idx + 1
@@ -4361,9 +3860,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst salinity content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%xs(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%xs(:)
     enddo
 
     idx = idx + 1
@@ -4372,9 +3870,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst u-current content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'm2/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%xu(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%xu(:)
     enddo
 
     idx = idx + 1
@@ -4383,9 +3880,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst v-current content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'm2/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%xv(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%xv(:)
     enddo
 
     idx = idx + 1
@@ -4394,9 +3890,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst diurnal thermocline layer thickness'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%xz(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%xz(:)
     enddo
 
     idx = idx + 1
@@ -4405,20 +3900,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst mixed layer thickness'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%zm(Model%chunk_begin(nb):Model%chunk_end(nb))
-    enddo
-
-    idx = idx + 1
-    ExtDiag(idx)%axes = 2
-    ExtDiag(idx)%name = 'xtts'
-    ExtDiag(idx)%desc = 'nsst d(xt)/d(ts)'
-    ExtDiag(idx)%unit = 'm'
-    ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%xtts(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%zm(:)
     enddo
 
     idx = idx + 1
@@ -4427,9 +3910,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst d(xt)/d(ts)'
     ExtDiag(idx)%unit = 'm/k'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%xzts(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%xzts(:)
     enddo
 
     idx = idx + 1
@@ -4438,9 +3920,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst thickness of free convection layer'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%d_conv(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%d_conv(:)
     enddo
 
     idx = idx + 1
@@ -4449,9 +3930,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst index to start dtlm run or not'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%ifd(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%ifd(:)
     enddo
 
     idx = idx + 1
@@ -4460,9 +3940,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst sub-layer cooling amount'
     ExtDiag(idx)%unit = 'k'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%dt_cool(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%dt_cool(:)
     enddo
 
     idx = idx + 1
@@ -4471,9 +3950,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst sensible heat flux due to rainfall'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => sfcprop%qrain(Model%chunk_begin(nb):Model%chunk_end(nb))
+       ExtDiag(idx)%data(1)%var2 => sfcprop%qrain(:)
     enddo
 !--------------------------nsst variables
   endif
@@ -4487,9 +3965,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of water-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => Statein%qgrs(Model%chunk_begin(nb):Model%chunk_end(nb),:,Model%ntwa)
+           ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntwa)
         enddo
 
         idx = idx + 1
@@ -4498,9 +3975,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'water-friendly surface aerosol source'
         ExtDiag(idx)%unit = 'kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Coupling%nwfa2d(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%var2 => Coupling%nwfa2d(:)
         enddo
       elseif (Model%mraerosol) then
         idx = idx + 1
@@ -4509,9 +3985,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of water-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => Stateout%gq0(Model%chunk_begin(nb):Model%chunk_end(nb),:,Model%ntwa)
+           ExtDiag(idx)%data(1)%var3 => Stateout%gq0(:,:,Model%ntwa)
         enddo
       endif
     endif
@@ -4524,9 +3999,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of ice-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => Statein%qgrs(Model%chunk_begin(nb):Model%chunk_end(nb),:,Model%ntia)
+           ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntia)
         enddo
 
         idx = idx + 1
@@ -4535,9 +4009,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'ice-friendly surface aerosol source'
         ExtDiag(idx)%unit = 'kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var2 => Coupling%nifa2d(Model%chunk_begin(nb):Model%chunk_end(nb))
+           ExtDiag(idx)%data(1)%var2 => Coupling%nifa2d(:)
         enddo
       else if (Model%mraerosol) then
         idx = idx + 1
@@ -4546,9 +4019,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of ice-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => Stateout%gq0(Model%chunk_begin(nb):Model%chunk_end(nb),:,Model%ntia)
+           ExtDiag(idx)%data(1)%var3 =>Stateout%gq0(:,:,Model%ntia)
         enddo
       end if
     endif
@@ -4572,9 +4044,8 @@ module GFS_diagnostics
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%intpl_method = 'bilinear'
         ExtDiag(idx)%time_avg = .false.
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%thompson_ext_diag3d(Model%chunk_begin(nb):Model%chunk_end(nb),:,num)
+           ExtDiag(idx)%data(1)%var3 =>IntDiag%thompson_ext_diag3d(:,:,num)
         enddo
       enddo
     end if thompson_extended_diagnostics
@@ -4586,9 +4057,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'smoke concentration'
       ExtDiag(idx)%unit = 'kg kg-1'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Statein%qgrs(Model%chunk_begin(nb):Model%chunk_end(nb),:,Model%ntfsmoke)
+         ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntfsmoke)
       enddo
     endif
 
@@ -4600,9 +4070,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface fire heat flux'
       ExtDiag(idx)%unit = 'W m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%fire_heat_flux(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%fire_heat_flux(:)
       enddo
 
       idx = idx + 1
@@ -4611,9 +4080,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'ration of the burnt area to the grid cell area'
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%frac_grid_burned(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%frac_grid_burned(:)
       enddo
 
       idx = idx + 1
@@ -4622,9 +4090,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'emission of fine dust for smoke'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%emdust(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%emdust(:)
       enddo
 
       idx = idx + 1
@@ -4633,9 +4100,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'emission of seas for smoke'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%emseas(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%emseas(:)
       enddo
 
       idx = idx + 1
@@ -4644,9 +4110,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'emission of anoc for thompson mp'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%emanoc(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%emanoc(:)
       enddo
 
       idx = idx + 1
@@ -4655,9 +4120,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'coeff bb for smoke'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%coef_bb_dc(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%coef_bb_dc(:)
       enddo
 
       idx = idx + 1
@@ -4666,9 +4130,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'minimum smoke plume height'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%min_fplume(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%min_fplume(:)
       enddo
 
       idx = idx + 1
@@ -4677,9 +4140,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'maximum smoke plume height'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%max_fplume(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%max_fplume(:)
       enddo
 
       idx = idx + 1
@@ -4688,19 +4150,18 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'hourly fire weather potential'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%rrfs_hwp(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%rrfs_hwp(:)
       enddo
+
       idx = idx + 1
       ExtDiag(idx)%axes = 2
       ExtDiag(idx)%name = 'HWP_ave'
       ExtDiag(idx)%desc = 'averaged fire weather potential'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%rrfs_hwp_ave(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%rrfs_hwp_ave(:)
       enddo
 
       extended_smoke_dust_diagnostics: if ( Model%extended_sd_diags ) then
@@ -4711,9 +4172,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'BL average wind speed'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%uspdavg(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%uspdavg(:)
       enddo
 
       idx = idx + 1
@@ -4722,9 +4182,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'BL depth modified parcel method'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%hpbl_thetav(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Coupling%hpbl_thetav(:)
       enddo
 
       idx = idx + 1
@@ -4733,9 +4192,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'dry deposition smoke'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%drydep_flux(Model%chunk_begin(nb):Model%chunk_end(nb),1)
+         ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,1)
       enddo
 
       idx = idx + 1
@@ -4744,9 +4202,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'dry deposition dust'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%drydep_flux(Model%chunk_begin(nb):Model%chunk_end(nb),2)
+         ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,2)
       enddo
 
       idx = idx + 1
@@ -4755,9 +4212,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'dry deposition coarsepm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%drydep_flux(Model%chunk_begin(nb):Model%chunk_end(nb),3)
+         ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,3)
       enddo
 
       idx = idx + 1
@@ -4766,9 +4222,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'resolved wet deposition smoke'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%wetdpr_flux(Model%chunk_begin(nb):Model%chunk_end(nb),1)
+         ExtDiag(idx)%data(1)%var2 => Coupling%wetdpr_flux(:,1)
       enddo
 
       idx = idx + 1
@@ -4777,9 +4232,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'resolved wet deposition dust'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%wetdpr_flux(Model%chunk_begin(nb):Model%chunk_end(nb),2)
+         ExtDiag(idx)%data(1)%var2 =>	Coupling%wetdpr_flux(:,2)
       enddo
 
       idx = idx + 1
@@ -4788,9 +4242,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'resolved wet deposition coarsepm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%wetdpr_flux(Model%chunk_begin(nb):Model%chunk_end(nb),3)
+         ExtDiag(idx)%data(1)%var2 =>	Coupling%wetdpr_flux(:,3)
       enddo
 
       idx = idx + 1
@@ -4799,9 +4252,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'convective wet deposition smoke'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%wetdpc_flux(Model%chunk_begin(nb):Model%chunk_end(nb),1)
+         ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,1)
       enddo
 
       idx = idx + 1
@@ -4810,9 +4262,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'convective wet deposition dust'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%wetdpc_flux(Model%chunk_begin(nb):Model%chunk_end(nb),2)
+         ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,2)
       enddo
 
       idx = idx + 1
@@ -4821,9 +4272,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'convective wet deposition coarsepm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Coupling%wetdpc_flux(Model%chunk_begin(nb):Model%chunk_end(nb),3)
+         ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,3)
       enddo
 
       idx = idx + 1
@@ -4832,9 +4282,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'hour of peak smoke emissions'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var2 => Sfcprop%peak_hr(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%peak_hr(:)
       enddo
 
       idx = idx + 1
@@ -4843,9 +4292,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fire type'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%int2 => Sfcprop%fire_type(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%int2 => Sfcprop%fire_type(:)
       enddo
 
       idx = idx + 1
@@ -4854,9 +4302,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'lu nofire pixes'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%lu_nofire(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%lu_nofire(:)
       enddo
 
       idx = idx + 1
@@ -4865,9 +4312,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'lu qfire pixes'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%lu_qfire(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%lu_qfire(:)
       enddo
 
       idx = idx + 1
@@ -4876,24 +4322,20 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'coefficient to scale the fire activity depending on the fire duration'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var2 => Sfcprop%fhist(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%fhist(:)
       enddo
 
       if (Model%ebb_dcycle == 2 ) then
-
-      idx = idx + 1
-      ExtDiag(idx)%axes = 2
-      ExtDiag(idx)%name = 'fire_end_hr'
-      ExtDiag(idx)%desc = 'Hours since fire was last detected'
-      ExtDiag(idx)%unit = 'hrs'
-      ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
-      do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var2 => Sfcprop%smoke2d_RRFS(Model%chunk_begin(nb):Model%chunk_end(nb),3)
-      enddo
-
+         idx = idx + 1
+         ExtDiag(idx)%axes = 2
+         ExtDiag(idx)%name = 'fire_end_hr'
+         ExtDiag(idx)%desc = 'Hours since fire was last detected'
+         ExtDiag(idx)%unit = 'hrs'
+         ExtDiag(idx)%mod_name = 'gfs_sfc'
+         do nb = 1,nblks
+            ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,3)
+         enddo
       endif
 
       endif  extended_smoke_dust_diagnostics
@@ -4905,11 +4347,9 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'input smoke emission'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var2 => Sfcprop%ebb_smoke_in(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%ebb_smoke_in(:)
       enddo
-
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4917,9 +4357,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'output frp'
       ExtDiag(idx)%unit = 'mw'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var2 => Sfcprop%frp_output(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%frp_output(:)
       enddo
 
       smoke_forecast_mode: if (Model%ebb_dcycle == 2 ) then
@@ -4930,9 +4369,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Total EBB Emissions'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var2 => Sfcprop%smoke2d_RRFS(Model%chunk_begin(nb):Model%chunk_end(nb),1)
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,1)
       enddo
 
       idx = idx + 1
@@ -4941,11 +4379,9 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Daily mean Fire Radiative Power'
       ExtDiag(idx)%unit = 'mw'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var2 => Sfcprop%smoke2d_RRFS(Model%chunk_begin(nb):Model%chunk_end(nb),2)
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,2)
       enddo
-
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4953,9 +4389,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Daily mean Hourly Wildfire Potential'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var2 => Sfcprop%smoke2d_RRFS(Model%chunk_begin(nb):Model%chunk_end(nb),4)
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,4)
       enddo
 
       endif smoke_forecast_mode
@@ -4966,9 +4401,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'smoke emission'
       ExtDiag(idx)%unit = 'ug/m2/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var3 => Coupling%ebu_smoke(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%ebu_smoke(:,:)
       enddo
 
       idx = idx + 1
@@ -4977,9 +4411,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = '3d total extinction at 550nm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var3 => Radtend%ext550(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Radtend%ext550(:,:)
       enddo
     endif
 
@@ -4995,10 +4428,8 @@ module GFS_diagnostics
        ExtDiag(idx)%unit = 'K s-1'
        ExtDiag(idx)%mod_name = 'gfs_phys'
        ExtDiag(idx)%time_avg = .FALSE.
-
-       allocate (ExtDiag(idx)%data(nblks))
        do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => Tbd%dfi_radar_tten(Model%chunk_begin(nb):Model%chunk_end(nb),:,i)
+          ExtDiag(idx)%data(1)%var3 => Tbd%dfi_radar_tten(:,:,i)
        enddo
     enddo
 
@@ -5011,9 +4442,8 @@ module GFS_diagnostics
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ! CCPP physics units are flashes per minute
       ExtDiag(idx)%cnvfac = 5.0_kind_phys
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => IntDiag%ltg1_max(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => IntDiag%ltg1_max(:)
       enddo
 
       idx = idx + 1
@@ -5024,9 +4454,8 @@ module GFS_diagnostics
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ! CCPP physics units are flashes per minute
       ExtDiag(idx)%cnvfac = 5.0_kind_phys
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => IntDiag%ltg2_max(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => IntDiag%ltg2_max(:)
       enddo
 
       idx = idx + 1
@@ -5037,9 +4466,8 @@ module GFS_diagnostics
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ! CCPP physics units are flashes per minute
       ExtDiag(idx)%cnvfac = 5.0_kind_phys
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => IntDiag%ltg3_max(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => IntDiag%ltg3_max(:)
       enddo
     endif
 
@@ -5052,29 +4480,28 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'effective radius of cloud liquid water particle'
       ExtDiag(idx)%unit = 'um'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Tbd%phy_f3d(Model%chunk_begin(nb):Model%chunk_end(nb),:,Model%nleffr)
+         ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%nleffr)
       enddo
+
       idx = idx + 1
       ExtDiag(idx)%axes = 3
       ExtDiag(idx)%name = 'cieffr'
       ExtDiag(idx)%desc = 'effective radius of stratiform cloud ice particle in um'
       ExtDiag(idx)%unit = 'um'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Tbd%phy_f3d(Model%chunk_begin(nb):Model%chunk_end(nb),:,Model%nieffr)
+         ExtDiag(idx)%data(1)%var3 =>	Tbd%phy_f3d(:,:,Model%nieffr)
       enddo
+      
       idx = idx + 1
       ExtDiag(idx)%axes = 3
       ExtDiag(idx)%name = 'cseffr'
       ExtDiag(idx)%desc = 'effective radius of stratiform cloud snow particle in um'
       ExtDiag(idx)%unit = 'um'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Tbd%phy_f3d(Model%chunk_begin(nb):Model%chunk_end(nb),:,Model%nseffr)
+         ExtDiag(idx)%data(1)%var3 =>	Tbd%phy_f3d(:,:,Model%nseffr)
       enddo
     endif
 
@@ -5087,9 +4514,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'height of highest plume'
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => IntDiag%ztop_plume(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => IntDiag%ztop_plume(:)
       enddo
 
       idx = idx + 1
@@ -5098,9 +4524,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'maximum mass-flux in column'
       ExtDiag(idx)%unit = 'm s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => IntDiag%maxmf(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => IntDiag%maxmf(:)
       enddo
 
       idx = idx + 1
@@ -5109,9 +4534,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'maximum width of plumes in grid column'
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => IntDiag%maxwidth(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => IntDiag%maxwidth(:)
       enddo
     endif
 
@@ -5122,9 +4546,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'monin obukhov surface stability parameter'
       ExtDiag(idx)%unit = 'n/a'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%zol(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%zol(:)
       enddo
 
       idx = idx + 1
@@ -5133,9 +4556,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface exchange coefficient for heat'
       ExtDiag(idx)%unit = 'W m-2 K-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%flhc(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%flhc(:)
       enddo
 
       idx = idx + 1
@@ -5144,9 +4566,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface exchange coefficient for moisture'
       ExtDiag(idx)%unit = 'kg m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop%flqc(Model%chunk_begin(nb):Model%chunk_end(nb))
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%flqc(:)
       enddo
     endif
 
@@ -5157,9 +4578,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'subgrid cloud fraction'
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Tbd%CLDFRA_BL(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Tbd%CLDFRA_BL(:,:)
       enddo
 
       idx = idx + 1
@@ -5168,9 +4588,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'subgrid cloud mixing ratio'
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Tbd%QC_BL(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Tbd%QC_BL(:,:)
       enddo
 
       idx = idx + 1
@@ -5179,9 +4598,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'turbulent mixing length'
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Tbd%el_pbl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Tbd%el_pbl(:,:)
       enddo
 
       idx = idx + 1
@@ -5190,9 +4608,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = '2 X TKE (from mynn)'
       ExtDiag(idx)%unit = 'm2 s-2'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var3 => Tbd%QKE(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Tbd%QKE(:,:)
       enddo
 
       if (Model%bl_mynn_output > 0) then
@@ -5203,9 +4620,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'updraft area fraction (from mynn)'
         ExtDiag(idx)%unit = '-'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%edmf_a(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_a(:,:)
         enddo
 
         idx = idx + 1
@@ -5214,9 +4630,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'mean updraft vertical veloctity (mynn)'
         ExtDiag(idx)%unit = 'm s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%edmf_w(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_w(:,:)
         enddo
 
         idx = idx + 1
@@ -5225,9 +4640,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'updraft total water (from mynn)'
         ExtDiag(idx)%unit = 'kg kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%edmf_qt(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_qt(:,:)
         enddo
 
         idx = idx + 1
@@ -5236,9 +4650,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'mean liquid potential temperature (mynn)'
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%edmf_thl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_thl(:,:)
         enddo
 
         idx = idx + 1
@@ -5247,9 +4660,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'updraft entrainment rate (from mynn)'
         ExtDiag(idx)%unit = 'm-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%edmf_ent(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_ent(:,:)
         enddo
 
         idx = idx + 1
@@ -5258,9 +4670,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'mean updraft liquid water (mynn)'
         ExtDiag(idx)%unit = 'kg kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%edmf_qc(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_qc(:,:)
         enddo
 
         idx = idx + 1
@@ -5269,9 +4680,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'subsidence temperature tendency (from mynn)'
         ExtDiag(idx)%unit = 'K s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%sub_thl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%sub_thl(:,:)
         enddo
 
         idx = idx + 1
@@ -5280,9 +4690,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'subsidence water vapor tendency (mynn)'
         ExtDiag(idx)%unit = 'kg kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%sub_sqv(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%sub_sqv(:,:)
         enddo
 
         idx = idx + 1
@@ -5291,9 +4700,8 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'detrainment temperature tendency (from mynn)'
         ExtDiag(idx)%unit = 'K s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%det_thl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+           ExtDiag(idx)%data(1)%var3 => IntDiag%det_thl(:,:)
         enddo
 
         idx = idx + 1
@@ -5302,11 +4710,9 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'detrainment water vapor tendency (mynn)'
         ExtDiag(idx)%unit = 'kg kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        allocate (ExtDiag(idx)%data(nblks))
         do nb = 1,nblks
-          ExtDiag(idx)%data(nb)%var3 => IntDiag%det_sqv(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-        enddo
-
+           ExtDiag(idx)%data(1)%var3 => IntDiag%det_sqv(:,:)
+           enddo
       endif
     endif
 
@@ -5366,9 +4772,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%time_avg = Model%aux2d_time_avg(num)
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%aux2d(Model%chunk_begin(nb):Model%chunk_end(nb),num)
+       ExtDiag(idx)%data(1)%var2 => IntDiag%aux2d(:,num)
     enddo
   enddo
 
@@ -5383,9 +4788,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%time_avg = Model%aux3d_time_avg(num)
-    allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var3 => IntDiag%aux3d(Model%chunk_begin(nb):Model%chunk_end(nb),:,num)
+       ExtDiag(idx)%data(1)%var3 => IntDiag%aux3d(:,:,num)
     enddo
   enddo
 
@@ -5404,79 +4808,67 @@ module GFS_diagnostics
     integer :: nk, idx0, iblk
 
     do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_snow_z3d(Model%chunk_begin(iblk):Model%chunk_end(iblk),:), 'lake_snow_z3d', 'lake snow level depth', 'm')
+      call link_all_levels(Sfcprop%lake_snow_z3d(:,:), 'lake_snow_z3d', 'lake snow level depth', 'm',iblk)
     enddo
 
     do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_snow_dz3d(Model%chunk_begin(iblk):Model%chunk_end(iblk),:), 'lake_snow_dz3d', 'lake snow level thickness', 'm')
+      call link_all_levels(Sfcprop%lake_snow_dz3d(:,:), 'lake_snow_dz3d', 'lake snow level thickness', 'm',iblk)
     enddo
 
     do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_snow_zi3d(Model%chunk_begin(iblk):Model%chunk_end(iblk),:), 'lake_snow_zi3d', 'lake snow interface depth', 'm')
+      call link_all_levels(Sfcprop%lake_snow_zi3d(:,:), 'lake_snow_zi3d', 'lake snow interface depth', 'm',iblk)
     enddo
 
     do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_h2osoi_vol3d(Model%chunk_begin(iblk):Model%chunk_end(iblk),:), 'lake_h2osoi_vol3d', 'volumetric soil water', 'm3 m-3')
+      call link_all_levels(Sfcprop%lake_h2osoi_vol3d(:,:), 'lake_h2osoi_vol3d', 'volumetric soil water', 'm3 m-3',iblk)
     enddo
 
     do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_h2osoi_liq3d(Model%chunk_begin(iblk):Model%chunk_end(iblk),:), 'lake_h2osoi_liq3d', 'soil liquid water content', 'kg m-2')
+      call link_all_levels(Sfcprop%lake_h2osoi_liq3d(:,:), 'lake_h2osoi_liq3d', 'soil liquid water content', 'kg m-2',iblk)
     enddo
 
     do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_h2osoi_ice3d(Model%chunk_begin(iblk):Model%chunk_end(iblk),:), 'lake_h2osoi_ice3d', 'soil ice water content', 'kg m-2')
+      call link_all_levels(Sfcprop%lake_h2osoi_ice3d(:,:), 'lake_h2osoi_ice3d', 'soil ice water content', 'kg m-2',iblk)
     enddo
 
     do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_t_soisno3d(Model%chunk_begin(iblk):Model%chunk_end(iblk),:), 'lake_t_soisno3d', 'snow or soil level temperature', 'K')
+      call link_all_levels(Sfcprop%lake_t_soisno3d(:,:), 'lake_t_soisno3d', 'snow or soil level temperature', 'K',iblk)
     enddo
 
     do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_t_lake3d(Model%chunk_begin(iblk):Model%chunk_end(iblk),:), 'lake_t_lake3d', 'lake layer temperature', 'K')
+      call link_all_levels(Sfcprop%lake_t_lake3d(:,:), 'lake_t_lake3d', 'lake layer temperature', 'K',iblk)
     enddo
 
     do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_icefrac3d(Model%chunk_begin(iblk):Model%chunk_end(iblk),:), 'lake_icefrac3d', 'lake fractional ice cover', 'fraction')
+      call link_all_levels(Sfcprop%lake_icefrac3d(:,:), 'lake_icefrac3d', 'lake fractional ice cover', 'fraction',iblk)
     enddo
 
   contains
 
-    subroutine link_all_levels(var3d, varname, levelname, unit)
+    subroutine link_all_levels(var3d, varname, levelname, unit, ib)
       implicit none
       real(kind=kind_phys), target :: var3d(:,:)
       character(len=*), intent(in) :: varname, levelname, unit
+      integer, intent(in) :: ib
       integer k, b, namelen
 
-      if(iblk==1) then
-        namelen = 30+max(len(varname),len(levelname))
-        allocate(character(namelen) :: fullname)
-        idx0 = idx
-      endif
+      namelen = 30+max(len(varname),len(levelname))
+      allocate(character(namelen) :: fullname)
+      idx0 = idx
 
       var_z_loop: do k=1,size(var3d,2)
-        idx = idx0 + k
-        if(iblk==1) then
-          ExtDiag(idx)%axes = 2
-          write(fullname,"(A,'_',I0)") trim(varname),k
-          ExtDiag(idx)%name = trim(fullname)
-          write(fullname,"(A,' level ',I0,' of ',I0)") trim(levelname),k,size(var3d,2)
-          ExtDiag(idx)%desc = trim(fullname)
-          ExtDiag(idx)%unit = trim(unit)
-          ExtDiag(idx)%mod_name = 'gfs_sfc'
-          ExtDiag(idx)%intpl_method = 'nearest_stod'
-
-          allocate (ExtDiag(idx)%data(nblks))
-          do b=1,nblks
-            nullify(ExtDiag(idx)%data(b)%var2)
-          enddo
-        endif
-
-        ExtDiag(idx)%data(iblk)%var2 => var3d(:,k)
+         idx = idx0 + k
+         ExtDiag(idx)%axes = 2
+         write(fullname,"(A,'_',I0)") trim(varname),k
+         ExtDiag(idx)%name = trim(fullname)
+         write(fullname,"(A,' level ',I0,' of ',I0)") trim(levelname),k,size(var3d,2)
+         ExtDiag(idx)%desc = trim(fullname)
+         ExtDiag(idx)%unit = trim(unit)
+         ExtDiag(idx)%mod_name = 'gfs_sfc'
+         ExtDiag(idx)%intpl_method = 'nearest_stod'
+         ExtDiag(idx)%data(1)%var2 => var3d(:,k)
       enddo var_z_loop
 
-      if(iblk==nblks) then
-        deallocate(fullname)
-      endif
     end subroutine link_all_levels
   end subroutine clm_lake_externaldiag_populate
 

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -4161,6 +4161,7 @@ module GFS_diagnostics
          ExtDiag(idx)%data%var2 => var3d(:,k)
       enddo var_z_loop
 
+      deallocate(fullname)
     end subroutine link_all_levels
   end subroutine clm_lake_externaldiag_populate
 

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -319,10 +319,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'w/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    allocate (ExtDiag(idx)%data(nblks))
-    do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag%dswsfcci(Model%chunk_begin(nb):Model%chunk_end(nb))
-    enddo    
+    ExtDiag(idx)%data%var2 => IntDiag%dswsfcci(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -3711,31 +3711,54 @@ module GFS_diagnostics
   endif
 
   if (Model%lsm == Model%lsm_ruc) then
-    do num = 1,Model%lsoil_lsm
-      write (xtra,'(i1)') num
-      idx = idx + 1
-      ExtDiag(idx)%axes = 2
-      ExtDiag(idx)%name = 'soilw'//trim(xtra)
-      ExtDiag(idx)%desc = 'volumetric soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
-      ExtDiag(idx)%unit = 'fraction'
-      ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => sfcprop%smois(:,num)
-      enddo
-    enddo
-    idx = idx + 1
-    ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'soilw'
-    ExtDiag(idx)%desc = 'volumetric soil moisture'
-    ExtDiag(idx)%unit = 'fraction'
-    ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => sfcprop%smois(:,:)
-    enddo
+     do num = 1,Model%lsoil_lsm
+        write (xtra,'(i1)') num
+        idx = idx + 1
+        ExtDiag(idx)%axes = 2
+        ExtDiag(idx)%name = 'soilw'//trim(xtra)
+        ExtDiag(idx)%desc = 'volumetric soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
+        ExtDiag(idx)%unit = 'fraction'
+        ExtDiag(idx)%mod_name = 'gfs_sfc'
+        do nb = 1,nblks
+           ExtDiag(idx)%data(1)%var2 => sfcprop%smois(:,num)
+        enddo
+     enddo
+     idx = idx + 1
+     ExtDiag(idx)%axes = 3
+     ExtDiag(idx)%name = 'soilw'
+     ExtDiag(idx)%desc = 'volumetric soil moisture'
+     ExtDiag(idx)%unit = 'fraction'
+     ExtDiag(idx)%mod_name = 'gfs_sfc'
+     do nb = 1,nblks
+        ExtDiag(idx)%data(1)%var3 => sfcprop%smois(:,:)
+     enddo
+  else
+     do num = 1,Model%lsoil_lsm
+        write (xtra,'(i1)') num
+        idx = idx + 1
+        ExtDiag(idx)%axes = 2
+        ExtDiag(idx)%name = 'soilw'//trim(xtra)
+        ExtDiag(idx)%desc = 'volumetric soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
+        ExtDiag(idx)%unit = 'fraction'
+        ExtDiag(idx)%mod_name = 'gfs_sfc'
+        do nb = 1,nblks
+           ExtDiag(idx)%data(1)%var2 => sfcprop%smc(:,num)
+        enddo
+     enddo
+     idx = idx + 1
+     ExtDiag(idx)%axes = 3
+     ExtDiag(idx)%name = 'soilw'
+     ExtDiag(idx)%desc = 'volumetric soil moisture'
+     ExtDiag(idx)%unit = 'fraction'
+     ExtDiag(idx)%mod_name = 'gfs_sfc'
+     allocate (ExtDiag(idx)%data(nblks))
+     do nb = 1,nblks
+        ExtDiag(idx)%data(1)%var3 => sfcprop%smc(:,:)
+     enddo
   endif
 
-    if (Model%lsm == Model%lsm_ruc) then
-      do num = 1,Model%lsoil_lsm
+  if (Model%lsm == Model%lsm_ruc) then
+     do num = 1,Model%lsoil_lsm
         write (xtra,'(i1)') num
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -3756,18 +3779,18 @@ module GFS_diagnostics
       do nb = 1,nblks
          ExtDiag(idx)%data(1)%var3 => sfcprop%tslb(:,:)
       enddo
-    else
+   else
       do num = 1,Model%lsoil_lsm
-        write (xtra,'(i1)') num
-        idx = idx + 1
-        ExtDiag(idx)%axes = 2
-        ExtDiag(idx)%name = 'soilt'//trim(xtra)
-        ExtDiag(idx)%desc = 'soil temperature ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
-        ExtDiag(idx)%unit = 'K'
-        ExtDiag(idx)%mod_name = 'gfs_sfc'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => sfcprop%stc(:,num)
-        enddo
+         write (xtra,'(i1)') num
+         idx = idx + 1
+         ExtDiag(idx)%axes = 2
+         ExtDiag(idx)%name = 'soilt'//trim(xtra)
+         ExtDiag(idx)%desc = 'soil temperature ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
+         ExtDiag(idx)%unit = 'K'
+         ExtDiag(idx)%mod_name = 'gfs_sfc'
+         do nb = 1,nblks
+            ExtDiag(idx)%data(1)%var2 => sfcprop%stc(:,num)
+         enddo
       enddo
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -3778,7 +3801,7 @@ module GFS_diagnostics
       do nb = 1,nblks
          ExtDiag(idx)%data(1)%var3 => sfcprop%stc(:,:)
       enddo
-    endif
+   endif
 
 !--------------------------nsst variables
   if (model%nstf_name(1) > 0) then
@@ -3904,6 +3927,16 @@ module GFS_diagnostics
        ExtDiag(idx)%data(1)%var2 => sfcprop%zm(:)
     enddo
 
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'xtts'
+    ExtDiag(idx)%desc = 'nsst d(xt)/d(ts)'
+    ExtDiag(idx)%unit = 'm'
+    ExtDiag(idx)%mod_name = 'gfs_sfc'
+    do nb = 1,nblks
+       ExtDiag(idx)%data(1)%var2 => sfcprop%xtts(:)
+    enddo
+    
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'xzts'

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -4346,9 +4346,8 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'smoke emission'
       ExtDiag(idx)%unit = 'ug/m2/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
-       ExtDiag(idx)%data(nb)%var3 => Coupling%ebu_smoke(Model%chunk_begin(nb):Model%chunk_end(nb),:)
+         ExtDiag(idx)%data(1)%var3 => Coupling%ebu_smoke(:,:)
       enddo
 
       idx = idx + 1

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -39,7 +39,7 @@ module GFS_diagnostics
     character(len=64)    :: mask
     character(len=64)    :: intpl_method
     real(kind=kind_phys) :: cnvfac
-    type(data_subtype), dimension(1)   :: data
+    type(data_subtype), dimension(1) :: data
    end type GFS_externaldiag_type
 
   !--- public data type ---
@@ -53,17 +53,17 @@ module GFS_diagnostics
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
  ! Helper function for GFS_externaldiag_populate to handle the massive dtend(:,:,dtidx(:,:)) array
-    subroutine add_dtend(Model,ExtDiag,IntDiag,idx,nblks,itrac,iprocess,desc,unit)
+    subroutine add_dtend(Model,ExtDiag,IntDiag,idx,itrac,iprocess,desc,unit)
     implicit none
     type(GFS_control_type),       intent(in)    :: Model
     type(GFS_externaldiag_type),  intent(inout) :: ExtDiag(:)
     type(GFS_diag_type),          intent(in)    :: IntDiag
-    integer, intent(in) :: nblks, itrac, iprocess
+    integer, intent(in) :: itrac, iprocess
     integer, intent(inout) :: idx
     real(kind=kind_phys), pointer :: dtend(:,:,:) ! Assumption: dtend is null iff all(dtidx <= 1)
     character(len=*), intent(in), optional :: desc, unit
 
-    integer :: idtend, nb, nlev
+    integer :: idtend, nlev
 
     idtend = Model%dtidx(itrac,iprocess)
     if(idtend>=1) then
@@ -83,9 +83,7 @@ module GFS_diagnostics
           ExtDiag(idx)%unit = trim(Model%dtend_var_labels(itrac)%unit)
        endif
        nlev = size(IntDiag%dtend,2)
-       do nb = 1,nblks
-          ExtDiag(idx)%data(1)%var3 => IntDiag%dtend(:,:,idtend)
-       enddo
+       ExtDiag(idx)%data(1)%var3 => IntDiag%dtend(:,:,idtend)
     endif
   end subroutine add_dtend
 
@@ -138,7 +136,7 @@ module GFS_diagnostics
     type(GFS_init_type),          intent(in)    :: Init_parm
 
 !--- local variables
-    integer :: idt, idx, num, nb, nblks, NFXR, idtend, ichem, itrac, iprocess, i, nlev
+    integer :: idt, idx, num, NFXR, idtend, ichem, itrac, iprocess, i, nlev
     character(len=2) :: xtra
     real(kind=kind_phys), parameter :: cn_one = 1._kind_phys
     real(kind=kind_phys), parameter :: cn_100 = 100._kind_phys
@@ -147,7 +145,6 @@ module GFS_diagnostics
     character(len=30) :: namestr, descstr
 
     NFXR = Model%NFXR
-    nblks = 1!Model%nchunks
     nlev = size(Statein%qgrs,2)
     
     ExtDiag(:)%id = -99
@@ -168,9 +165,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'frac'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%cldfra2d(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%cldfra2d(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -179,9 +174,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'frac'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%total_albedo(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%total_albedo(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -190,9 +183,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%lwp_ex(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%lwp_ex(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -201,9 +192,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%iwp_ex(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%iwp_ex(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -212,9 +201,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%lwp_fc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%lwp_fc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -222,10 +209,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total ice water path from cloud fraction scheme'
     ExtDiag(idx)%unit = 'kg m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%iwp_fc(:)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%iwp_fc(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -235,10 +220,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%mask = 'positive_flux'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,3)
-       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,4)
-    enddo
+    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,3)
+    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,4)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -249,9 +232,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfc(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -259,10 +240,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous surface downward longwave flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfci(:)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfci(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -272,10 +251,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfc(:)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfc(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -284,10 +261,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,23)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,23)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -297,9 +272,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,2)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,2)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -308,10 +281,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,1)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,1)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -319,10 +290,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous surface upward longwave flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfci(:)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -334,9 +303,7 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,4)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,4)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -344,10 +311,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous surface downward shortwave flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dswsfci(:)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dswsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -358,10 +323,8 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,3)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,3)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -369,10 +332,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous surface upward shortwave flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%uswsfci(:)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%uswsfci(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -382,10 +343,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,21)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,21)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -395,10 +354,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,22)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,22)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -409,9 +366,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,24)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,24)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'vddsf_ave'
@@ -421,9 +377,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,25)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,25)
+    
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'nbdsf_ave'
@@ -433,9 +388,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,26)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,26)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'nddsf_ave'
@@ -444,10 +398,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,27)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,27)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csulf_avetoa'
@@ -456,10 +409,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,28)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,28)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csusf_avetoa'
@@ -468,10 +420,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,29)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,29)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csdlf_ave'
@@ -480,10 +431,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,30)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,30)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csusf_ave'
@@ -492,10 +442,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,31)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,31)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csdsf_ave'
@@ -504,20 +453,18 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,32)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,32)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csdsf'
     ExtDiag(idx)%desc = 'Clear Sky Instantateous Downward Short Wave Flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,32)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,32)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csulf_ave'
@@ -526,10 +473,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,33)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,33)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'DSWRFtoa'
@@ -539,10 +485,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,23)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,23)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'USWRFtoa'
@@ -552,10 +497,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_sw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,2)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,2)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ULWRFtoa'
@@ -565,10 +509,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_lw'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,1)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,1)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDC_aveclm'
@@ -577,10 +520,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,17)
-    enddo
+    ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,17)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDC_avebndcl'
@@ -589,42 +531,38 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,18)
-    enddo
+    ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,18)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDCcnvcl'
     ExtDiag(idx)%desc = 'convective cloud layer total cloud cover'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%cnvfac = cn_100
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Cldprop%cv(:)
-    enddo
+    ExtDiag(idx)%cnvfac = cn_100    
+    ExtDiag(idx)%data(1)%var2 => Cldprop%cv(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PREScnvclt'
     ExtDiag(idx)%desc = 'pressure at convective cloud top level'
     ExtDiag(idx)%unit = 'pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%mask = 'cldmask'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => Cldprop%cvt(:)
-       ExtDiag(idx)%data(1)%var21 => Cldprop%cv(:)
-    enddo
+    ExtDiag(idx)%mask = 'cldmask'    
+    ExtDiag(idx)%data(1)%var2  => Cldprop%cvt(:)
+    ExtDiag(idx)%data(1)%var21 => Cldprop%cv(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PREScnvclb'
     ExtDiag(idx)%desc = 'pressure at convective cloud bottom level'
     ExtDiag(idx)%unit = 'pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%mask = 'cldmask'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => Cldprop%cvb(:)
-       ExtDiag(idx)%data(1)%var21 => Cldprop%cv(:)
-    enddo
+    ExtDiag(idx)%mask = 'cldmask'    
+    ExtDiag(idx)%data(1)%var2  => Cldprop%cvb(:)
+    ExtDiag(idx)%data(1)%var21 => Cldprop%cv(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDC_avehcl'
@@ -633,10 +571,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,5)
-    enddo
+    ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,5)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -647,10 +583,9 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
     ExtDiag(idx)%mask = "cldmask_ratio"
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,8)
-       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
-    enddo
+    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,8)
+    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PRES_avehcb'
@@ -659,11 +594,10 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    ExtDiag(idx)%mask = "cldmask_ratio"
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,11)
-       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
-    enddo
+    ExtDiag(idx)%mask = "cldmask_ratio"    
+    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,11)
+    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TEMP_avehct'
@@ -672,11 +606,10 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    ExtDiag(idx)%mask = "cldmask_ratio"
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,14)
-       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
-    enddo
+    ExtDiag(idx)%mask = "cldmask_ratio"    
+    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,14)
+    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,5)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDC_avemcl'
@@ -685,10 +618,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,6)
-    enddo
+    ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,6)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PRES_avemct'
@@ -697,11 +629,10 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    ExtDiag(idx)%mask = "cldmask_ratio"
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,9)
-       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
-    enddo
+    ExtDiag(idx)%mask = "cldmask_ratio"    
+    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,9)
+    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PRES_avemcb'
@@ -710,11 +641,10 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    ExtDiag(idx)%mask = "cldmask_ratio"
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,12)
-       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
-    enddo
+    ExtDiag(idx)%mask = "cldmask_ratio"    
+    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,12)
+    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TEMP_avemct'
@@ -723,11 +653,10 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    ExtDiag(idx)%mask = "cldmask_ratio"
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,15)
-       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
-    enddo
+    ExtDiag(idx)%mask = "cldmask_ratio"    
+    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,15)
+    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,6)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TCDC_avelcl'
@@ -736,10 +665,9 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
-    ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,7)
-    enddo
+    ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,7)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PRES_avelct'
@@ -748,11 +676,10 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    ExtDiag(idx)%mask = "cldmask_ratio"
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,10)
-       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
-    enddo
+    ExtDiag(idx)%mask = "cldmask_ratio"    
+    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,10)
+    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'PRES_avelcb'
@@ -761,11 +688,10 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    ExtDiag(idx)%mask = "cldmask_ratio"
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,13)
-       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
-    enddo
+    ExtDiag(idx)%mask = "cldmask_ratio"    
+    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,13)
+    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'TEMP_avelct'
@@ -774,11 +700,10 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
-    ExtDiag(idx)%mask = "cldmask_ratio"
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,16)
-       ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
-    enddo
+    ExtDiag(idx)%mask = "cldmask_ratio"    
+    ExtDiag(idx)%data(1)%var2  => IntDiag%fluxr(:,16)
+    ExtDiag(idx)%data(1)%var21 => IntDiag%fluxr(:,7)
+
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -786,10 +711,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total aerosol optical depth at 550 nm'
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,34)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,34)
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -798,9 +721,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,35)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,35)
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -808,10 +729,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'soot aerosol optical depth at 550 nm'
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,36)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,36)
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -819,10 +738,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'waso aerosol optical depth at 550 nm'
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,37)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,37)
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -830,10 +747,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'suso aerosol optical depth at 550 nm'
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,38)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,38)
 !--- aerosol diagnostics ---
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -841,10 +756,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'salt aerosol optical depth at 550 nm'
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,39)
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,39)
 !--- air quality diagnostics ---
   if (Model%cplaqm) then
     if (associated(IntDiag%aod)) then
@@ -854,9 +767,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total aerosol optical depth at 550 nm'
       ExtDiag(idx)%unit = 'numerical'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => IntDiag%aod(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => IntDiag%aod(:)
     endif
   endif
 
@@ -871,9 +782,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fluxr diagnostic '//trim(xtra)//' - GFS radiation'
       ExtDiag(idx)%unit = 'XXX'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,num)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => IntDiag%fluxr(:,num)
     enddo
 
 !--- the next two appear to be appear to be coupling fields in gloopr
@@ -900,7 +809,7 @@ module GFS_diagnostics
 !rab    enddo
 
 ! DH gfortran cannot point to members of arrays of derived types such
-! as IntDiag(nb)%topfsw(:)%upfxc (the compilation succeeds, but the
+! as IntDiag(1)%topfsw(:)%upfxc (the compilation succeeds, but the
 ! pointers do not reference the correct data and the output either
 ! contains garbage (Inf, NaN), or the netCDF I/O layer crashes.
 #ifndef __GFORTRAN__
@@ -910,10 +819,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total sky upward sw flux at toa - GFS radiation'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%upfxc
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%upfxc
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -921,10 +828,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total sky downward sw flux at toa - GFS radiation'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%dnfxc
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%dnfxc
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -932,10 +837,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'clear sky upward sw flux at toa - GFS radiation'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%upfx0
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%topfsw(:)%upfx0
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -943,10 +846,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total sky upward lw flux at toa - GFS radiation'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%topflw(:)%upfxc
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%topflw(:)%upfxc
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -954,10 +855,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'clear sky upward lw flux at toa - GFS radiation'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%topflw(:)%upfx0
-    enddo
+    ExtDiag(idx)%intpl_method = 'bilinear'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%topflw(:)%upfx0
 #endif
 
 !--- physics accumulated diagnostics ---
@@ -966,40 +865,36 @@ module GFS_diagnostics
     ExtDiag(idx)%name = 'ssrun_acc'
     ExtDiag(idx)%desc = 'Accumulated surface storm water runoff'
     ExtDiag(idx)%unit = 'kg/m**2'
-    ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%srunoff(:)
-    enddo
+    ExtDiag(idx)%mod_name = 'gfs_phys'    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%srunoff(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'evbs_ave'
     ExtDiag(idx)%desc = 'Direct Evaporation from Bare Soil'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%evbsa(:)
-    enddo
+    ExtDiag(idx)%time_avg = .TRUE.    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%evbsa(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'evcw_ave'
     ExtDiag(idx)%desc = 'Canopy water evaporation'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%evcwa(:)
-    enddo
+    ExtDiag(idx)%time_avg = .TRUE.    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%evcwa(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'snohf'
     ExtDiag(idx)%desc = 'Snow Phase Change Heat Flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%snohfa(:)
-    enddo
+    ExtDiag(idx)%time_avg = .TRUE.    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%snohfa(:)
+
     if (Model%lsm == Model%lsm_noahmp) then
      idx = idx + 1
      ExtDiag(idx)%axes = 2
@@ -1007,10 +902,8 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = ' Total Precipitation Advected Heat'
      ExtDiag(idx)%unit = 'W/m**2'
      ExtDiag(idx)%mod_name = 'gfs_phys'
-     ExtDiag(idx)%time_avg = .TRUE.
-     do nb = 1,nblks
-        ExtDiag(idx)%data(1)%var2 => IntDiag%paha(:)
-     enddo
+     ExtDiag(idx)%time_avg = .TRUE.     
+     ExtDiag(idx)%data(1)%var2 => IntDiag%paha(:)
     endif
 
     idx = idx + 1
@@ -1020,19 +913,17 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%transa(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%transa(:)
+    
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'sbsno_ave'
     ExtDiag(idx)%desc = 'Sublimation (evaporation from snow)'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%sbsnoa(:)
-    enddo
+    ExtDiag(idx)%time_avg = .TRUE.    
+    ExtDiag(idx)%data(1)%var2 => IntDiag%sbsnoa(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'snowc_ave'
@@ -1041,18 +932,16 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%cnvfac = cn_100
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%snowca(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%snowca(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'snowc'
     ExtDiag(idx)%desc = 'snow cover '
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%sncovr(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%sncovr(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'soilm'
@@ -1060,10 +949,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%mask = "land_only"
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%soilm(:)
+    ExtDiag(idx)%data(1)%var2  => IntDiag%soilm(:)
        ExtDiag(idx)%data(1)%var21 => Sfcprop%slmsk(:)
-    enddo
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'tmpmin2m'
@@ -1071,9 +959,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tmpmin(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tmpmin(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'tmpmax2m'
@@ -1081,9 +968,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tmpmax(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tmpmax(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dusfc'
@@ -1093,9 +979,8 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dusfc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dusfc(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dvsfc'
@@ -1105,9 +990,8 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dvsfc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dvsfc(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'shtfl_ave'
@@ -1117,9 +1001,8 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dtsfc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dtsfc(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'lhtfl_ave'
@@ -1129,9 +1012,8 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dqsfc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dqsfc(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totprcp_ave'
@@ -1142,9 +1024,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%totprcp(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%totprcp(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totprcpb_ave'
@@ -1154,9 +1035,8 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%totprcpb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%totprcpb(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'gflux_ave'
@@ -1166,10 +1046,9 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
     !    ExtDiag(idx)%mask = "land_ice_only"
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2  => IntDiag%gflux(:)
-       !ExtDiag(idx)%data(1)%var21 => Sfcprop%slmsk(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2  => IntDiag%gflux(:)
+    !ExtDiag(idx)%data(1)%var21 => Sfcprop%slmsk(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dlwsfc'
@@ -1177,9 +1056,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfc(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ulwsfc'
@@ -1187,9 +1065,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfc(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'sunsd_acc'
@@ -1197,27 +1074,23 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 's'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%suntim(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%suntim(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'watr_acc'
     ExtDiag(idx)%desc = 'total water runoff'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%runoff(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%runoff(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ecan_acc'
     ExtDiag(idx)%desc = 'total evaporation of intercepted water'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tecan(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tecan(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1225,9 +1098,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total plant transpiration'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tetran(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tetran(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1235,9 +1106,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total soil surface evaporation'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tedir(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tedir(:)
 
     if (Model%lsm == Model%lsm_noahmp) then
      idx = idx + 1
@@ -1246,9 +1115,7 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = 'total water storage in aquifer'
      ExtDiag(idx)%unit = 'kg/m**2'
      ExtDiag(idx)%mod_name = 'gfs_phys'
-     do nb = 1,nblks
-        ExtDiag(idx)%data(1)%var2 => IntDiag%twa(:)
-     enddo
+     ExtDiag(idx)%data(1)%var2 => IntDiag%twa(:)
     endif
 
     idx = idx + 1
@@ -1258,9 +1125,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'mm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%ep(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%ep(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cwork_ave'
@@ -1269,9 +1135,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%cldwrk(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%cldwrk(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'u-gwd_ave'
@@ -1280,9 +1145,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dugwd(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dugwd(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'v-gwd_ave'
@@ -1291,9 +1155,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dvgwd(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dvgwd(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'psmean'
@@ -1301,9 +1164,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kPa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%psmean(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%psmean(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cnvprcp_ave'
@@ -1314,9 +1176,8 @@ module GFS_diagnostics
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcp(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcp(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cnvprcpb_ave'
@@ -1326,18 +1187,16 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcpb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcpb(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cnvprcp'
     ExtDiag(idx)%desc = 'surface convective precipitation rate'
     ExtDiag(idx)%unit = 'kg/m**2/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcp(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%cnvprcp(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'spfhmin2m'
@@ -1345,9 +1204,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%spfhmin(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%spfhmin(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'spfhmax2m'
@@ -1355,9 +1213,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%spfhmax(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%spfhmax(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'u10mmax'
@@ -1365,9 +1222,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%u10mmax(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%u10mmax(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'v10mmax'
@@ -1375,9 +1231,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%v10mmax(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%v10mmax(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'wind10mmax'
@@ -1385,9 +1240,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%wind10mmax(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%wind10mmax(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'u10max'
@@ -1395,9 +1249,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%u10max(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%u10max(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'v10max'
@@ -1405,9 +1258,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%v10max(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%v10max(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'spd10max'
@@ -1415,9 +1267,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%spd10max(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%spd10max(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 't02max'
@@ -1425,9 +1276,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%t02max(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%t02max(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 't02min'
@@ -1435,9 +1285,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%t02min(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%t02min(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'rh02max'
@@ -1445,9 +1294,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%rh02max(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%rh02max(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'rh02min'
@@ -1455,18 +1303,16 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%rh02min(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%rh02min(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'pratemax'
     ExtDiag(idx)%desc = 'max hourly precipitation rate'
     ExtDiag(idx)%unit = 'mm h-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%pratemax(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%pratemax(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'frzr'
@@ -1474,9 +1320,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%frzr(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%frzr(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'frzrb'
@@ -1484,9 +1329,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%frzrb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%frzrb(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'frozr'
@@ -1494,9 +1338,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%frozr(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%frozr(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'frozrb'
@@ -1504,9 +1347,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%frozrb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%frozrb(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'tsnowp'
@@ -1514,9 +1356,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tsnowp(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tsnowp(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'tsnowpb'
@@ -1524,63 +1365,56 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tsnowpb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tsnowpb(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'rhonewsn'
     ExtDiag(idx)%desc = 'precipitation ice density'
     ExtDiag(idx)%unit = 'kg m^-3'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%rhonewsn1(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%rhonewsn1(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'rain'
     ExtDiag(idx)%desc = 'total rain at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%rain(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%rain(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'rainc'
     ExtDiag(idx)%desc = 'convective rain at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%rainc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%rainc(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ice'
     ExtDiag(idx)%desc = 'ice fall at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%ice(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%ice(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'snow'
     ExtDiag(idx)%desc = 'snow fall at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%snow(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%snow(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'graupel'
     ExtDiag(idx)%desc = 'graupel fall at this time step'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%graupel(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%graupel(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totice_ave'
@@ -1590,9 +1424,8 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%totice(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%totice(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'toticeb_ave'
@@ -1601,9 +1434,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%toticeb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%toticeb(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totsnw_ave'
@@ -1613,9 +1445,8 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%totsnw(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%totsnw(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totsnwb_ave'
@@ -1624,9 +1455,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%totsnwb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%totsnwb(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totgrp_ave'
@@ -1636,9 +1466,8 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'full'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%totgrp(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%totgrp(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'totgrpb_ave'
@@ -1647,9 +1476,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%cnvfac = cn_th
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%totgrpb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%totgrpb(:)
+
     if(associated(Coupling%sfcdlw)) then
        idx = idx + 1
        ExtDiag(idx)%axes = 2
@@ -1657,9 +1485,7 @@ module GFS_diagnostics
        ExtDiag(idx)%desc = 'sfcdlw'
        ExtDiag(idx)%unit = 'W m-2'
        ExtDiag(idx)%mod_name = 'gfs_phys'
-       do nb = 1,nblks
-          ExtDiag(idx)%data(1)%var2 => Coupling%sfcdlw(:)
-       enddo
+       ExtDiag(idx)%data(1)%var2 => Coupling%sfcdlw(:)
     endif
 
     if(associated(Coupling%htrlw)) then
@@ -1669,9 +1495,7 @@ module GFS_diagnostics
        ExtDiag(idx)%desc = 'htrlw'
        ExtDiag(idx)%unit = 'W m-2'
        ExtDiag(idx)%mod_name = 'gfs_phys'
-       do nb = 1,nblks
-          ExtDiag(idx)%data(1)%var3 => Coupling%htrlw(:,:)
-       enddo
+       ExtDiag(idx)%data(1)%var3 => Coupling%htrlw(:,:)
     endif
 
     if(associated(Radtend%lwhc)) then
@@ -1681,9 +1505,7 @@ module GFS_diagnostics
        ExtDiag(idx)%desc = 'lwhc'
        ExtDiag(idx)%unit = 'K s-1'
        ExtDiag(idx)%mod_name = 'gfs_phys'
-       do nb = 1,nblks
-          ExtDiag(idx)%data(1)%var3 => Radtend%lwhc(:,:)
-       enddo
+       ExtDiag(idx)%data(1)%var3 => Radtend%lwhc(:,:)
     endif
 
 !--- physics instantaneous diagnostics ---
@@ -1694,9 +1516,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%u10m(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%u10m(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'v10m'
@@ -1704,9 +1525,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%v10m(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%v10m(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -1715,18 +1534,16 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dpt2m(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dpt2m(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'hgt_hyblev1'
     ExtDiag(idx)%desc = 'layer 1 height'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%zlvl(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%zlvl(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'psurf'
@@ -1735,9 +1552,8 @@ module GFS_diagnostics
     ExtDiag(idx)%mask = 'pseudo_ps'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%psurf(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%psurf(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'hpbl'
@@ -1745,9 +1561,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Tbd%hpbl(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Tbd%hpbl(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'pwat'
@@ -1755,9 +1570,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%pwat(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%pwat(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'tmp_hyblev1'
@@ -1765,9 +1579,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%t1(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%t1(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'spfh_hyblev1'
@@ -1775,9 +1588,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%q1(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%q1(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ugrd_hyblev1'
@@ -1785,9 +1597,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%u1(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%u1(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'vgrd_hyblev1'
@@ -1795,9 +1606,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'vector_bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%v1(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%v1(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'sfexc'
@@ -1805,9 +1615,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/m2/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%chh(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%chh(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'acond'
@@ -1815,9 +1624,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%cmm(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%cmm(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dlwsfci'
@@ -1825,9 +1633,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfci(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dlwsfci(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'ulwsfci'
@@ -1835,9 +1642,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfci(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%ulwsfci(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dswsfci'
@@ -1845,9 +1651,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dswsfci(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dswsfci(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'uswsfci'
@@ -1855,27 +1660,24 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%uswsfci(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%uswsfci(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dusfci'
     ExtDiag(idx)%desc = 'instantaneous u component of surface stress'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dusfci(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dusfci(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'dvsfci'
     ExtDiag(idx)%desc = 'instantaneous v component of surface stress'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dvsfci(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dvsfci(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'shtfl'
@@ -1883,9 +1685,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dtsfci(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dtsfci(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'lhtfl'
@@ -1893,36 +1694,32 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dqsfci(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dqsfci(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'gfluxi'
     ExtDiag(idx)%desc = 'instantaneous surface ground heat flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%gfluxi(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%gfluxi(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'wilt'
     ExtDiag(idx)%desc = 'wiltimg point (volumetric)'
     ExtDiag(idx)%unit = 'Proportion'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%smcwlt2(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%smcwlt2(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'fldcp'
     ExtDiag(idx)%desc = 'Field Capacity (volumetric)'
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%smcref2(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%smcref2(:)
+
     if (Model%lsm == Model%lsm_noahmp) then
      idx = idx + 1
      ExtDiag(idx)%axes = 2
@@ -1930,9 +1727,7 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = 'instantaneous precipitation advected heat flux'
      ExtDiag(idx)%unit = 'W/m**2'
      ExtDiag(idx)%mod_name = 'gfs_phys'
-     do nb = 1,nblks
-        ExtDiag(idx)%data(1)%var2 => IntDiag%pahi(:)
-     enddo
+     ExtDiag(idx)%data(1)%var2 => IntDiag%pahi(:)
     endif
 
     idx = idx + 1
@@ -1941,9 +1736,8 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous surface potential evaporation'
     ExtDiag(idx)%unit = 'mm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%epi(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%epi(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'wet1'
@@ -1951,13 +1745,9 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     if (Model%lsm==Model%lsm_ruc) then
-       do nb = 1,nblks
-          ExtDiag(idx)%data(1)%var2 => Sfcprop%wetness(:)
-       enddo
+       ExtDiag(idx)%data(1)%var2 => Sfcprop%wetness(:)
     else
-       do nb = 1,nblks
-          ExtDiag(idx)%data(1)%var2 => IntDiag%wet1(:)
-       enddo
+       ExtDiag(idx)%data(1)%var2 => IntDiag%wet1(:)
     endif
 
     idx = idx + 1
@@ -1967,9 +1757,8 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%sr(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%sr(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'crain_ave'
@@ -1979,9 +1768,8 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tdomr(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tdomr(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'csnow_ave'
@@ -1991,9 +1779,8 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tdoms(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tdoms(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cfrzr_ave'
@@ -2003,9 +1790,8 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tdomzr(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tdomzr(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'cicep_ave'
@@ -2015,64 +1801,56 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%cnvfac = cn_one
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tdomip(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tdomip(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'refl_10cm'
     ExtDiag(idx)%desc = 'Radar reflectivity'
     ExtDiag(idx)%unit = 'dBz'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%refl_10cm(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%refl_10cm(:,:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'max_hail_diam_sfc'
     ExtDiag(idx)%desc = 'Maximum hail diameter at lowest model level'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%max_hail_diam_sfc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%max_hail_diam_sfc(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'dkt'
     ExtDiag(idx)%desc = 'Atmospheric heat diffusivity'
     ExtDiag(idx)%unit = 'm2s-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dkt(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dkt(:,:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'dku'
     ExtDiag(idx)%desc = 'Atmospheric momentum diffusivity'
     ExtDiag(idx)%unit = 'm2s-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dku(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dku(:,:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'cldfra'
     ExtDiag(idx)%desc = 'Instantaneous 3D Cloud Fraction'
     ExtDiag(idx)%unit = 'frac'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%cldfra(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%cldfra(:,:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 3
     ExtDiag(idx)%name = 'cnvw'
     ExtDiag(idx)%desc = 'subgrid scale convective cloud water'
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    if( Model%ncnvw > 0 ) then
-       do nb = 1,nblks
-          ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%ncnvw)
-       enddo
+    if( Model%ncnvw > 0 ) then       
+       ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%ncnvw)
     endif
 
     if (Model%do_skeb) then
@@ -2082,18 +1860,15 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 =>Coupling%skebu_wts(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 =>Coupling%skebu_wts(:,:)
+
       idx = idx + 1
       ExtDiag(idx)%axes = 3
       ExtDiag(idx)%name = 'skebv_wts'
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Coupling%skebv_wts(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Coupling%skebv_wts(:,:)
     endif
 
     idx = idx + 1
@@ -2102,27 +1877,24 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'level of dividing streamline'
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%zmtnblck(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%zmtnblck(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'refdmax'
     ExtDiag(idx)%desc = 'max hourly 1-km agl reflectivity'
     ExtDiag(idx)%unit = 'dBZ'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%refdmax(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%refdmax(:)
+
     idx = idx + 1
     ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'refdmax263k'
     ExtDiag(idx)%desc = 'max hourly -10C reflectivity'
     ExtDiag(idx)%unit = 'dBZ'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%refdmax263k(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%refdmax263k(:)
+
     if (Model%do_sppt .or. Model%ca_global) then
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -2130,9 +1902,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Coupling%sppt_wts(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Coupling%sppt_wts(:,:)
     endif
 
     if (Model%do_shum) then
@@ -2142,9 +1912,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation velocity'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Coupling%shum_wts(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Coupling%shum_wts(:,:)
     endif
 
     if (Model%do_spp) then
@@ -2154,9 +1922,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp pbl perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_pbl(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_pbl(:,:)
     endif
 
     if (Model%do_spp) then
@@ -2166,9 +1932,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp sfc perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_sfc(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_sfc(:,:)
     endif
 
     if (Model%do_spp) then
@@ -2178,9 +1942,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp mp perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_mp(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_mp(:,:)
     endif
 
     if (Model%do_spp) then
@@ -2190,9 +1952,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp gwd perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_gwd(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_gwd(:,:)
     endif
 
     if (Model%do_spp) then
@@ -2202,9 +1962,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp rad perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_rad(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_rad(:,:)
     endif
 
     if (Model%do_spp) then
@@ -2214,9 +1972,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'spp cu deep perturbation wts'
       ExtDiag(idx)%unit = 'm/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_cu_deep(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Coupling%spp_wts_cu_deep(:,:)
     endif
 
     if (Model%lndp_type /= 0) then
@@ -2226,9 +1982,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'perturbation amplitude'
       ExtDiag(idx)%unit = 'none'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Coupling%sfc_wts(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Coupling%sfc_wts(:,:)
     endif
 
     if (Model%do_ca) then
@@ -2238,9 +1992,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Cellular Automata'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%ca1(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%ca1(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2248,9 +2000,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA deep conv'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%ca_deep(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%ca_deep(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2258,9 +2008,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA turbulence'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%ca_turb(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%ca_turb(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2268,9 +2016,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA shallow conv'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%ca_shal(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%ca_shal(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2278,19 +2024,15 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'CA radiation'
       ExtDiag(idx)%unit = '%'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%ca_rad(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%ca_rad(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
       ExtDiag(idx)%name = 'ca_micro'
       ExtDiag(idx)%desc = 'CA microphys'
       ExtDiag(idx)%unit = '%'
-      ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%ca_micro(:)
-      enddo
+      ExtDiag(idx)%mod_name = 'gfs_phys'      
+      ExtDiag(idx)%data(1)%var2 => Coupling%ca_micro(:)
     endif
 
   if (Model%lkm/=0) then
@@ -2302,9 +2044,7 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'fraction'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%lakefrac(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%lakefrac(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2313,9 +2053,7 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%lakedepth(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%lakedepth(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2324,9 +2062,7 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%T_snow(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%T_snow(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2335,9 +2071,7 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%T_ice(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%T_ice(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -2346,14 +2080,12 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'flag'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%intpl_method = 'nearest_stod'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%int2 => Sfcprop%use_lake_model(:)
-      enddo
+      ExtDiag(idx)%data(1)%int2 => Sfcprop%use_lake_model(:)
 
       if(Model%iopt_lake==Model%iopt_lake_clm) then
 
         ! Populate the 3D arrays separately since the code is complicated:
-        call clm_lake_externaldiag_populate(ExtDiag, Model, Sfcprop, idx, cn_one, nblks)
+        call clm_lake_externaldiag_populate(ExtDiag, Model, Sfcprop, idx, cn_one)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2361,9 +2093,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'lake point is considered salty by clm lake model'
         ExtDiag(idx)%unit = '1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%int2 => Sfcprop%lake_is_salty(:)
-        enddo
+        ExtDiag(idx)%data(1)%int2 => Sfcprop%lake_is_salty(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2371,9 +2101,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'clm lake model considers the point to be so salty it cannot freeze'
         ExtDiag(idx)%unit = '1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%int2 => Sfcprop%lake_cannot_freeze(:)
-        enddo
+        ExtDiag(idx)%data(1)%int2 => Sfcprop%lake_cannot_freeze(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2382,9 +2110,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_t2m(:)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_t2m(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2393,9 +2119,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg/kg'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_q2m(:)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_q2m(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2404,9 +2128,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'fraction'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_albedo(:)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_albedo(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2415,9 +2137,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'mm'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_h2osno2d(:)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_h2osno2d(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2426,9 +2146,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'm'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_sndpth2d(:)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_sndpth2d(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2437,9 +2155,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'count'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_snl2d(:)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_snl2d(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2448,9 +2164,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_tsfc(:)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_tsfc(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2459,9 +2173,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-3'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_savedtke12d(:)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_savedtke12d(:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -2470,12 +2182,9 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'unitless'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
         ExtDiag(idx)%intpl_method = 'nearest_stod'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_ht(:)
-        enddo
-
-      endif
-
+        ExtDiag(idx)%data(1)%var2 => Sfcprop%lake_ht(:)
+     endif
+     !
   endif
 
   if (Model%ldiag_ugwp) THEN
@@ -2486,9 +2195,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'height of dividing streamline'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%zmtb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%zmtb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2496,9 +2203,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'height of OGW-launch'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%zogw(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%zogw(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2506,9 +2211,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'height of LWB-level'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%zlwb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%zlwb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2516,9 +2219,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' OGW vertical MF at launch level'
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tau_ogw(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tau_ogw(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2526,9 +2227,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' ORO-MTB integrated flux from surface'
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tau_mtb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tau_mtb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2536,9 +2235,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' ORO-TOFD integrated flux from surface'
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tau_tofd(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tau_tofd(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2546,9 +2243,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' NGW momentum flux at launch level '
     ExtDiag(idx)%unit = 'N/m2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%tau_ngw(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%tau_ngw(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2556,9 +2251,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'axz_oro averaged E-W OROGW-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_ogw(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_ogw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2566,9 +2259,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'axz_oro averaged E-W GWALL-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_ngw(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_ngw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2576,9 +2267,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'axz_oro averaged E-W MTB-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_mtb(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_mtb(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2586,9 +2275,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'axz_oro averaged E-W TMS-tendency'
     ExtDiag(idx)%unit = 'm/s/s'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_tms(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%du3dt_tms(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2596,9 +2283,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from mesoscale OGWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_ogw(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_ogw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2606,9 +2291,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from mesoscale OGWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_ogw(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_ogw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2616,9 +2299,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from blocking drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_obl(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_obl(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2626,9 +2307,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from blocking drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_obl(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_obl(:,:)
 
     ! 2D variables
 
@@ -2638,9 +2317,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from meso scale ogw'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%du_ogwcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%du_ogwcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2648,9 +2325,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from meso scale ogw'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dv_ogwcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dv_ogwcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2658,9 +2333,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from blocking drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%du_oblcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%du_oblcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2668,9 +2341,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from blocking drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dv_oblcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dv_oblcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2679,9 +2350,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_ogw(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_ogw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2690,9 +2359,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_obl(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_obl(:,:)
 
     ! Variables for GSL drag suite
 
@@ -2702,9 +2369,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from small scale GWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_oss(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_oss(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2712,9 +2377,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from small scale GWD'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_oss(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_oss(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2722,9 +2385,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'x wind tendency from form drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_ofd(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dudt_ofd(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2732,9 +2393,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'y wind tendency from form drag'
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_ofd(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dvdt_ofd(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2743,9 +2402,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_oss(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_oss(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2754,9 +2411,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_ofd(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%dws3dt_ofd(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2765,9 +2420,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ogw(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ogw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2776,9 +2429,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_obl(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_obl(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2787,9 +2438,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ofd(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ofd(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2798,9 +2447,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_oss(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_oss(:,:)
 
     ! 2D variables
 
@@ -2810,9 +2457,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from small scale gwd'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%du_osscol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%du_osscol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2820,9 +2465,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from small scale gwd'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dv_osscol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dv_osscol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2830,9 +2473,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated x momentum flux from form drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%du_ofdcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%du_ofdcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2840,9 +2481,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'integrated y momentum flux from form drag'
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dv_ofdcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dv_ofdcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2851,9 +2490,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%du3_ogwcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%du3_ogwcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2862,9 +2499,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_ogwcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_ogwcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2873,9 +2508,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%du3_oblcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%du3_oblcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2884,9 +2517,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_oblcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_oblcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2895,9 +2526,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%du3_osscol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%du3_osscol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2906,9 +2535,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_osscol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_osscol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2917,9 +2544,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%du3_ofdcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%du3_ofdcol(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -2928,9 +2553,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'Pa'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_ofdcol(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%dv3_ofdcol(:)
 
     ! UGWP non-stationary GWD outputs
 
@@ -2941,9 +2564,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ngw(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%ldu3dt_ngw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2952,9 +2573,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm s-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%ldv3dt_ngw(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%ldv3dt_ngw(:,:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -2963,9 +2582,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K s-1'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%time_avg = .TRUE.
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%ldt3dt_ngw(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%ldt3dt_ngw(:,:)
 
   ENDIF  ! if (Model%ldiag_ugwp)
 
@@ -2978,7 +2595,7 @@ module GFS_diagnostics
       do iprocess=1,Model%nprocess
         do itrac=1,Model%ntracp100
           if(Model%dtidx(itrac,iprocess)>=1) then
-            call add_dtend(Model,ExtDiag,IntDiag,idx,nblks,itrac,iprocess)
+            call add_dtend(Model,ExtDiag,IntDiag,idx,itrac,iprocess)
           endif
         enddo
       enddo
@@ -2992,9 +2609,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-1 s-3'
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%time_avg = .TRUE.
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%upd_mf(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%upd_mf(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -3003,9 +2618,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-1 s-3'
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%time_avg = .TRUE.
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%dwn_mf(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%dwn_mf(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -3014,9 +2627,7 @@ module GFS_diagnostics
         ExtDiag(idx)%unit = 'kg m-1 s-3'
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%time_avg = .TRUE.
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%det_mf(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%det_mf(:,:)
 
       end if if_qdiag3d
 
@@ -3048,9 +2659,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean nir albedo with strong cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%alnsf(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%alnsf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3058,9 +2667,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean nir albedo with weak cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%alnwf(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%alnwf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3068,9 +2675,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean vis albedo with strong cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%alvsf(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%alvsf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3078,9 +2683,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'mean vis albedo with weak cosz dependency'
     ExtDiag(idx)%unit = '%'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%alvwf(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%alvwf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3088,9 +2691,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'canopy water (cnwat in gfs data)'
     ExtDiag(idx)%unit = 'mm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%canopy(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%canopy(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3098,9 +2699,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = '10-meter wind speed divided by lowest model wind speed'
     ExtDiag(idx)%unit = 'N/A'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%f10m(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%f10m(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3108,9 +2707,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fractional coverage with strong cosz dependency'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%facsf(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%facsf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3118,9 +2715,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fractional coverage with weak cosz dependency'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 =>Sfcprop%facwf(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 =>Sfcprop%facwf(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3128,9 +2723,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fh parameter from PBL scheme'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%ffhh(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%ffhh(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3138,9 +2731,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'fm parameter from PBL scheme'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%ffmm(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%ffmm(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3148,9 +2739,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'uustar surface frictional wind'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%uustar(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%uustar(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3158,9 +2747,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface slope type'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%int2 => Sfcprop%slope(:)
-    enddo
+    ExtDiag(idx)%data(1)%int2 => Sfcprop%slope(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3168,9 +2755,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface ice concentration (ice=1; no ice=0)'
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%fice(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%fice(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3178,9 +2763,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sea ice thickness (icetk in gfs_data)'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%hice(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%hice(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3188,9 +2771,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'maximum snow albedo in fraction'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%snoalb(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%snoalb(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3198,9 +2779,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'maximum fractional coverage of green vegetation'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%shdmax(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%shdmax(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3208,9 +2787,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'minimum fractional coverage of green vegetation'
     ExtDiag(idx)%unit = 'XXX'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%shdmin(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%shdmin(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3219,9 +2796,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one/cn_th
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%snowd(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%snowd(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3229,9 +2804,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous sublimation (evaporation from snow)'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%sbsno(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%sbsno(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3239,9 +2812,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous direct evaporation over land'
     ExtDiag(idx)%unit = 'W m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%evbs(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%evbs(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3249,9 +2820,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous canopy evaporation'
     ExtDiag(idx)%unit = 'W m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%evcw(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%evcw(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3259,9 +2828,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'instantaneous transpiration'
     ExtDiag(idx)%unit = 'W m-2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%trans(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%trans(:)
 
     if (Model%lsm == Model%lsm_ruc) then
 
@@ -3271,9 +2838,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface albedo over land'
       ExtDiag(idx)%unit = 'fraction'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%sfalb_lnd(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%sfalb_lnd(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3281,9 +2846,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'density of frozen precipitation'
       ExtDiag(idx)%unit = 'kg m-3'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%rhofr(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%rhofr(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3291,9 +2854,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated frozen precipitation over land'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%snowfallac_land(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%snowfallac_land(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3301,9 +2862,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated SWE of frozen precipitation over land'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%acsnow_land(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%acsnow_land(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3311,9 +2870,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'accumulated snow melt over land'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => IntDiag%snowmt_land(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => IntDiag%snowmt_land(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3321,9 +2878,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated frozen precipitation over ice'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%snowfallac_ice(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%snowfallac_ice(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3331,9 +2886,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'total accumulated SWE of frozen precipitation over ice'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%acsnow_ice(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%acsnow_ice(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -3341,9 +2894,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'accumulated snow melt over ice'
       ExtDiag(idx)%unit = 'kg m-2'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => IntDiag%snowmt_ice(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => IntDiag%snowmt_ice(:)
     endif ! RUC lsm
 
     idx = idx + 1
@@ -3353,9 +2904,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%srflag(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%srflag(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3363,9 +2912,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'soil type in integer 1-9'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%int2 => Sfcprop%stype(:)
-    enddo
+    ExtDiag(idx)%data(1)%int2 => Sfcprop%stype(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3373,9 +2920,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'soil color in integer 1-20'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%int2 => Sfcprop%scolor(:)
-    enddo
+    ExtDiag(idx)%data(1)%int2 => Sfcprop%scolor(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3383,9 +2928,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'land fraction'
     ExtDiag(idx)%unit = 'fraction [0:1]'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%landfrac(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%landfrac(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3394,9 +2937,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'kg/kg'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%q2m(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%q2m(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3405,9 +2946,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%intpl_method = 'bilinear'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%t2m(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%t2m(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3415,9 +2954,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface temperature'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%tsfc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%tsfc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3425,9 +2962,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface zonal current'
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%usfco(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%usfco(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3435,9 +2970,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface meridional current'
     ExtDiag(idx)%unit = 'm/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%vsfco(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%vsfco(:)
 
     if (Model%frac_grid) then
       do num = 1,Model%kice
@@ -3448,9 +2981,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'internal ice temperature layer ' // trim(xtra)
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Sfcprop%tiice(:,num)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => Sfcprop%tiice(:,num)
       enddo
     end if
 
@@ -3460,9 +2991,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'deep soil temperature'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%tg3(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%tg3(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3470,9 +2999,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface temperature over ice fraction'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%tisfc(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%tisfc(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3480,9 +3007,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'total time-step precipitation'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Sfcprop%tprcp(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Sfcprop%tprcp(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3490,9 +3015,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'vegetation type in integer'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%int2 => sfcprop%vtype(:)
-    enddo
+    ExtDiag(idx)%data(1)%int2 => sfcprop%vtype(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3500,9 +3023,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface snow water equivalent'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%weasd(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%weasd(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3510,9 +3031,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'surface snow water equivalent over ice'
     ExtDiag(idx)%unit = 'kg/m**2'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%weasdi(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%weasdi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3520,9 +3039,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'snow depth over ice'
     ExtDiag(idx)%unit = 'mm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%snodi(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%snodi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3531,9 +3048,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'gpm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%oro(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%oro(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3541,9 +3056,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sea-land-ice mask (0-sea, 1-land, 2-ice)'
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%slmsk(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%slmsk(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3552,9 +3065,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_one/cn_100
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%zorl(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%zorl(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3563,9 +3074,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'fraction'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
     ExtDiag(idx)%cnvfac = cn_100
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%vfrac(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%vfrac(:)
 
     if (Model%lsm==Model%lsm_ruc) then
       idx = idx + 1
@@ -3575,9 +3084,7 @@ module GFS_diagnostics
       ExtDiag(idx)%unit = 'fraction'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ExtDiag(idx)%cnvfac = cn_100
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => sfcprop%wetness(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => sfcprop%wetness(:)
     end if
 
     idx = idx + 1
@@ -3586,9 +3093,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sfc nir beam sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Coupling%nirbmdi(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Coupling%nirbmdi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3596,9 +3101,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sfc nir diff sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Coupling%nirdfdi(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Coupling%nirdfdi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3606,9 +3109,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'sfc uv+vis beam sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Coupling%visbmdi(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Coupling%visbmdi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3616,9 +3117,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = ' sfc uv+vis diff sw downward flux'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => Coupling%visdfdi(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => Coupling%visdfdi(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3626,9 +3125,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'leaf area index'
     ExtDiag(idx)%unit = 'number'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%xlaixy(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%xlaixy(:)
 
     do num = 1,Model%nvegcat
       write (xtra,'(i2)') num
@@ -3638,9 +3135,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fraction of vegetation category'//trim(xtra)
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => sfcprop%vegtype_frac(:,num)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => sfcprop%vegtype_frac(:,num)
     enddo
 
     do num = 1,Model%nsoilcat
@@ -3651,9 +3146,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fraction of soil category'//trim(xtra)
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => sfcprop%soiltype_frac(:,num)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => sfcprop%soiltype_frac(:,num)
     enddo
 
   if (Model%lsm == Model%lsm_ruc) then
@@ -3665,9 +3158,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'liquid soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
       ExtDiag(idx)%unit = 'm**3/m**3'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => sfcprop%sh2o(:,num)
-         enddo
+      ExtDiag(idx)%data(1)%var2 => sfcprop%sh2o(:,num)
     enddo
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -3675,9 +3166,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'liquid soil moisture'
     ExtDiag(idx)%unit = 'm**3/m**3'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => sfcprop%sh2o(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => sfcprop%sh2o(:,:)
   else
     do num = 1,Model%lsoil_lsm
       write (xtra,'(i1)') num
@@ -3695,9 +3184,7 @@ module GFS_diagnostics
 #endif
 ! *DH
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => sfcprop%slc(:,num)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => sfcprop%slc(:,num)
     enddo
     idx = idx + 1
     ExtDiag(idx)%axes = 3
@@ -3705,9 +3192,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'liquid soil moisture'
     ExtDiag(idx)%unit = 'm**3/m**3'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => sfcprop%slc(:,:)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => sfcprop%slc(:,:)
   endif
 
   if (Model%lsm == Model%lsm_ruc) then
@@ -3719,9 +3204,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'volumetric soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
         ExtDiag(idx)%unit = 'fraction'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => sfcprop%smois(:,num)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => sfcprop%smois(:,num)
      enddo
      idx = idx + 1
      ExtDiag(idx)%axes = 3
@@ -3729,9 +3212,7 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = 'volumetric soil moisture'
      ExtDiag(idx)%unit = 'fraction'
      ExtDiag(idx)%mod_name = 'gfs_sfc'
-     do nb = 1,nblks
-        ExtDiag(idx)%data(1)%var3 => sfcprop%smois(:,:)
-     enddo
+     ExtDiag(idx)%data(1)%var3 => sfcprop%smois(:,:)
   else
      do num = 1,Model%lsoil_lsm
         write (xtra,'(i1)') num
@@ -3741,9 +3222,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'volumetric soil moisture ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
         ExtDiag(idx)%unit = 'fraction'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => sfcprop%smc(:,num)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => sfcprop%smc(:,num)
      enddo
      idx = idx + 1
      ExtDiag(idx)%axes = 3
@@ -3751,9 +3230,7 @@ module GFS_diagnostics
      ExtDiag(idx)%desc = 'volumetric soil moisture'
      ExtDiag(idx)%unit = 'fraction'
      ExtDiag(idx)%mod_name = 'gfs_sfc'
-     do nb = 1,nblks
-        ExtDiag(idx)%data(1)%var3 => sfcprop%smc(:,:)
-     enddo
+     ExtDiag(idx)%data(1)%var3 => sfcprop%smc(:,:)
   endif
 
   if (Model%lsm == Model%lsm_ruc) then
@@ -3765,9 +3242,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'soil temperature ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => sfcprop%tslb(:,num)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => sfcprop%tslb(:,num)
       enddo
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -3775,9 +3250,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'soil temperature'
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => sfcprop%tslb(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => sfcprop%tslb(:,:)
    else
       do num = 1,Model%lsoil_lsm
          write (xtra,'(i1)') num
@@ -3787,9 +3260,7 @@ module GFS_diagnostics
          ExtDiag(idx)%desc = 'soil temperature ' // trim(soil_layer_depth(Model%lsm, Model%lsm_ruc, Model%lsm_noah, num))
          ExtDiag(idx)%unit = 'K'
          ExtDiag(idx)%mod_name = 'gfs_sfc'
-         do nb = 1,nblks
-            ExtDiag(idx)%data(1)%var2 => sfcprop%stc(:,num)
-         enddo
+         ExtDiag(idx)%data(1)%var2 => sfcprop%stc(:,num)
       enddo
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -3797,9 +3268,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'soil temperature'
       ExtDiag(idx)%unit = 'K'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => sfcprop%stc(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => sfcprop%stc(:,:)
    endif
 
 !--------------------------nsst variables
@@ -3812,9 +3281,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst reference or foundation temperature'
     ExtDiag(idx)%unit = 'K'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%tref(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%tref(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3822,9 +3289,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst sub-layer cooling thickness'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%z_c(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%z_c(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3832,9 +3297,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient1 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'numerical'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%c_0(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%c_0(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3842,9 +3305,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient2 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%c_d(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%c_d(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3852,9 +3313,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient3 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%w_0(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%w_0(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3862,9 +3321,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst coefficient4 to calculate d(tz)/d(ts)'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%w_d(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%w_d(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3872,9 +3329,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst heat content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'k*m'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%xt(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%xt(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3882,9 +3337,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst salinity content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%xs(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%xs(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3892,9 +3345,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst u-current content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'm2/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%xu(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%xu(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3902,9 +3353,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst v-current content in diurnal thermocline layer'
     ExtDiag(idx)%unit = 'm2/s'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%xv(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%xv(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3912,9 +3361,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst diurnal thermocline layer thickness'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%xz(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%xz(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3922,9 +3369,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst mixed layer thickness'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%zm(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%zm(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3932,9 +3377,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst d(xt)/d(ts)'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%xtts(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%xtts(:)
     
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3942,9 +3385,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst d(xt)/d(ts)'
     ExtDiag(idx)%unit = 'm/k'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%xzts(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%xzts(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3952,9 +3393,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst thickness of free convection layer'
     ExtDiag(idx)%unit = 'm'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%d_conv(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%d_conv(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3962,9 +3401,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst index to start dtlm run or not'
     ExtDiag(idx)%unit = 'n/a'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%ifd(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%ifd(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3972,9 +3409,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst sub-layer cooling amount'
     ExtDiag(idx)%unit = 'k'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%dt_cool(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%dt_cool(:)
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
@@ -3982,9 +3417,7 @@ module GFS_diagnostics
     ExtDiag(idx)%desc = 'nsst sensible heat flux due to rainfall'
     ExtDiag(idx)%unit = 'W/m**2'
     ExtDiag(idx)%mod_name = 'gfs_sfc'
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => sfcprop%qrain(:)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => sfcprop%qrain(:)
 !--------------------------nsst variables
   endif
 
@@ -3997,9 +3430,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of water-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntwa)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntwa)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -4007,9 +3438,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'water-friendly surface aerosol source'
         ExtDiag(idx)%unit = 'kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Coupling%nwfa2d(:)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => Coupling%nwfa2d(:)
       elseif (Model%mraerosol) then
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4017,9 +3446,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of water-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => Stateout%gq0(:,:,Model%ntwa)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => Stateout%gq0(:,:,Model%ntwa)
       endif
     endif
 
@@ -4031,9 +3458,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of ice-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntia)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntia)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 2
@@ -4041,9 +3466,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'ice-friendly surface aerosol source'
         ExtDiag(idx)%unit = 'kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_sfc'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var2 => Coupling%nifa2d(:)
-        enddo
+        ExtDiag(idx)%data(1)%var2 => Coupling%nifa2d(:)
       else if (Model%mraerosol) then
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4051,9 +3474,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'number concentration of ice-friendly aerosols'
         ExtDiag(idx)%unit = 'kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 =>Stateout%gq0(:,:,Model%ntia)
-        enddo
+        ExtDiag(idx)%data(1)%var3 =>Stateout%gq0(:,:,Model%ntia)
       end if
     endif
 
@@ -4076,9 +3497,7 @@ module GFS_diagnostics
         ExtDiag(idx)%mod_name = 'gfs_phys'
         ExtDiag(idx)%intpl_method = 'bilinear'
         ExtDiag(idx)%time_avg = .false.
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 =>IntDiag%thompson_ext_diag3d(:,:,num)
-        enddo
+        ExtDiag(idx)%data(1)%var3 =>IntDiag%thompson_ext_diag3d(:,:,num)
       enddo
     end if thompson_extended_diagnostics
 
@@ -4089,9 +3508,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'smoke concentration'
       ExtDiag(idx)%unit = 'kg kg-1'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntfsmoke)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Statein%qgrs(:,:,Model%ntfsmoke)
     endif
 
     if (Model%rrfs_sd .and. Model%ntsmoke>0) then
@@ -4102,9 +3519,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface fire heat flux'
       ExtDiag(idx)%unit = 'W m-2'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%fire_heat_flux(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%fire_heat_flux(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4112,9 +3527,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'ration of the burnt area to the grid cell area'
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%frac_grid_burned(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%frac_grid_burned(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4122,9 +3535,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'emission of fine dust for smoke'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%emdust(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%emdust(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4132,9 +3543,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'emission of seas for smoke'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%emseas(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%emseas(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4142,9 +3551,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'emission of anoc for thompson mp'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%emanoc(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%emanoc(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4152,9 +3559,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'coeff bb for smoke'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%coef_bb_dc(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%coef_bb_dc(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4162,9 +3567,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'minimum smoke plume height'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%min_fplume(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%min_fplume(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4172,9 +3575,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'maximum smoke plume height'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%max_fplume(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%max_fplume(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4182,9 +3583,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'hourly fire weather potential'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%rrfs_hwp(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%rrfs_hwp(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4192,9 +3591,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'averaged fire weather potential'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%rrfs_hwp_ave(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%rrfs_hwp_ave(:)
 
       extended_smoke_dust_diagnostics: if ( Model%extended_sd_diags ) then
 
@@ -4204,9 +3601,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'BL average wind speed'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%uspdavg(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%uspdavg(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4214,9 +3609,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'BL depth modified parcel method'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%hpbl_thetav(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%hpbl_thetav(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4224,9 +3617,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'dry deposition smoke'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,1)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,1)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4234,9 +3625,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'dry deposition dust'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,2)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,2)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4244,9 +3633,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'dry deposition coarsepm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,3)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%drydep_flux(:,3)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4254,9 +3641,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'resolved wet deposition smoke'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%wetdpr_flux(:,1)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpr_flux(:,1)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4264,9 +3649,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'resolved wet deposition dust'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 =>	Coupling%wetdpr_flux(:,2)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpr_flux(:,2)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4274,9 +3657,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'resolved wet deposition coarsepm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 =>	Coupling%wetdpr_flux(:,3)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpr_flux(:,3)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4284,9 +3665,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'convective wet deposition smoke'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,1)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,1)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4294,9 +3673,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'convective wet deposition dust'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,2)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,2)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4304,9 +3681,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'convective wet deposition coarsepm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,3)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Coupling%wetdpc_flux(:,3)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4314,9 +3689,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'hour of peak smoke emissions'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%peak_hr(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%peak_hr(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4324,9 +3697,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'fire type'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%int2 => Sfcprop%fire_type(:)
-      enddo
+      ExtDiag(idx)%data(1)%int2 => Sfcprop%fire_type(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4334,9 +3705,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'lu nofire pixes'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%lu_nofire(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%lu_nofire(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4344,9 +3713,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'lu qfire pixes'
       ExtDiag(idx)%unit = ''
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%lu_qfire(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%lu_qfire(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4354,9 +3721,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'coefficient to scale the fire activity depending on the fire duration'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%fhist(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%fhist(:)
 
       if (Model%ebb_dcycle == 2 ) then
          idx = idx + 1
@@ -4365,9 +3730,7 @@ module GFS_diagnostics
          ExtDiag(idx)%desc = 'Hours since fire was last detected'
          ExtDiag(idx)%unit = 'hrs'
          ExtDiag(idx)%mod_name = 'gfs_sfc'
-         do nb = 1,nblks
-            ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,3)
-         enddo
+         ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,3)
       endif
 
       endif  extended_smoke_dust_diagnostics
@@ -4378,9 +3741,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'smoke emission'
       ExtDiag(idx)%unit = 'ug/m2/s'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Coupling%ebu_smoke(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Coupling%ebu_smoke(:,:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4388,9 +3749,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'input smoke emission'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%ebb_smoke_in(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%ebb_smoke_in(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4398,9 +3757,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'output frp'
       ExtDiag(idx)%unit = 'mw'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%frp_output(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%frp_output(:)
 
       smoke_forecast_mode: if (Model%ebb_dcycle == 2 ) then
 
@@ -4410,9 +3767,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Total EBB Emissions'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,1)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,1)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4420,9 +3775,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Daily mean Fire Radiative Power'
       ExtDiag(idx)%unit = 'mw'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,2)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,2)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4430,9 +3783,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'Daily mean Hourly Wildfire Potential'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,4)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%smoke2d_RRFS(:,4)
 
       endif smoke_forecast_mode
 
@@ -4442,9 +3793,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = '3d total extinction at 550nm'
       ExtDiag(idx)%unit = ' '
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Radtend%ext550(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Radtend%ext550(:,:)
     endif
 
     do i=1,Model%num_dfi_radar
@@ -4459,9 +3808,7 @@ module GFS_diagnostics
        ExtDiag(idx)%unit = 'K s-1'
        ExtDiag(idx)%mod_name = 'gfs_phys'
        ExtDiag(idx)%time_avg = .FALSE.
-       do nb = 1,nblks
-          ExtDiag(idx)%data(1)%var3 => Tbd%dfi_radar_tten(:,:,i)
-       enddo
+       ExtDiag(idx)%data(1)%var3 => Tbd%dfi_radar_tten(:,:,i)
     enddo
 
     if(Model%lightning_threat) then
@@ -4473,9 +3820,7 @@ module GFS_diagnostics
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ! CCPP physics units are flashes per minute
       ExtDiag(idx)%cnvfac = 5.0_kind_phys
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => IntDiag%ltg1_max(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => IntDiag%ltg1_max(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4485,9 +3830,7 @@ module GFS_diagnostics
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ! CCPP physics units are flashes per minute
       ExtDiag(idx)%cnvfac = 5.0_kind_phys
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => IntDiag%ltg2_max(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => IntDiag%ltg2_max(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4497,9 +3840,7 @@ module GFS_diagnostics
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       ! CCPP physics units are flashes per minute
       ExtDiag(idx)%cnvfac = 5.0_kind_phys
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => IntDiag%ltg3_max(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => IntDiag%ltg3_max(:)
     endif
 
     ! Cloud effective radii from Microphysics
@@ -4511,9 +3852,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'effective radius of cloud liquid water particle'
       ExtDiag(idx)%unit = 'um'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%nleffr)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%nleffr)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -4521,9 +3860,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'effective radius of stratiform cloud ice particle in um'
       ExtDiag(idx)%unit = 'um'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 =>	Tbd%phy_f3d(:,:,Model%nieffr)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%nieffr)
       
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -4531,9 +3868,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'effective radius of stratiform cloud snow particle in um'
       ExtDiag(idx)%unit = 'um'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 =>	Tbd%phy_f3d(:,:,Model%nseffr)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Tbd%phy_f3d(:,:,Model%nseffr)
     endif
 
     !MYNN
@@ -4545,9 +3880,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'height of highest plume'
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => IntDiag%ztop_plume(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => IntDiag%ztop_plume(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4555,9 +3888,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'maximum mass-flux in column'
       ExtDiag(idx)%unit = 'm s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => IntDiag%maxmf(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => IntDiag%maxmf(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4565,9 +3896,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'maximum width of plumes in grid column'
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => IntDiag%maxwidth(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => IntDiag%maxwidth(:)
     endif
 
     if (Model%do_mynnsfclay) then
@@ -4577,9 +3906,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'monin obukhov surface stability parameter'
       ExtDiag(idx)%unit = 'n/a'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%zol(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%zol(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4587,9 +3914,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface exchange coefficient for heat'
       ExtDiag(idx)%unit = 'W m-2 K-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%flhc(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%flhc(:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
@@ -4597,9 +3922,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'surface exchange coefficient for moisture'
       ExtDiag(idx)%unit = 'kg m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var2 => Sfcprop%flqc(:)
-      enddo
+      ExtDiag(idx)%data(1)%var2 => Sfcprop%flqc(:)
     endif
 
     if (Model%do_mynnedmf) then
@@ -4609,9 +3932,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'subgrid cloud fraction'
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Tbd%CLDFRA_BL(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Tbd%CLDFRA_BL(:,:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -4619,9 +3940,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'subgrid cloud mixing ratio'
       ExtDiag(idx)%unit = 'frac'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Tbd%QC_BL(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Tbd%QC_BL(:,:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -4629,9 +3948,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'turbulent mixing length'
       ExtDiag(idx)%unit = 'm'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Tbd%el_pbl(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Tbd%el_pbl(:,:)
 
       idx = idx + 1
       ExtDiag(idx)%axes = 3
@@ -4639,9 +3956,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = '2 X TKE (from mynn)'
       ExtDiag(idx)%unit = 'm2 s-2'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      do nb = 1,nblks
-         ExtDiag(idx)%data(1)%var3 => Tbd%QKE(:,:)
-      enddo
+      ExtDiag(idx)%data(1)%var3 => Tbd%QKE(:,:)
 
       if (Model%bl_mynn_output > 0) then
 
@@ -4651,9 +3966,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'updraft area fraction (from mynn)'
         ExtDiag(idx)%unit = '-'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_a(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_a(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4661,9 +3974,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'mean updraft vertical veloctity (mynn)'
         ExtDiag(idx)%unit = 'm s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_w(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_w(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4671,9 +3982,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'updraft total water (from mynn)'
         ExtDiag(idx)%unit = 'kg kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_qt(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_qt(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4681,9 +3990,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'mean liquid potential temperature (mynn)'
         ExtDiag(idx)%unit = 'K'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_thl(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_thl(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4691,9 +3998,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'updraft entrainment rate (from mynn)'
         ExtDiag(idx)%unit = 'm-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_ent(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_ent(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4701,9 +4006,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'mean updraft liquid water (mynn)'
         ExtDiag(idx)%unit = 'kg kg-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_qc(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%edmf_qc(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4711,9 +4014,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'subsidence temperature tendency (from mynn)'
         ExtDiag(idx)%unit = 'K s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%sub_thl(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%sub_thl(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4721,9 +4022,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'subsidence water vapor tendency (mynn)'
         ExtDiag(idx)%unit = 'kg kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%sub_sqv(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%sub_sqv(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4731,9 +4030,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'detrainment temperature tendency (from mynn)'
         ExtDiag(idx)%unit = 'K s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%det_thl(:,:)
-        enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%det_thl(:,:)
 
         idx = idx + 1
         ExtDiag(idx)%axes = 3
@@ -4741,9 +4038,7 @@ module GFS_diagnostics
         ExtDiag(idx)%desc = 'detrainment water vapor tendency (mynn)'
         ExtDiag(idx)%unit = 'kg kg-1 s-1'
         ExtDiag(idx)%mod_name = 'gfs_phys'
-        do nb = 1,nblks
-           ExtDiag(idx)%data(1)%var3 => IntDiag%det_sqv(:,:)
-           enddo
+        ExtDiag(idx)%data(1)%var3 => IntDiag%det_sqv(:,:)
       endif
     endif
 
@@ -4803,9 +4098,7 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%time_avg = Model%aux2d_time_avg(num)
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var2 => IntDiag%aux2d(:,num)
-    enddo
+    ExtDiag(idx)%data(1)%var2 => IntDiag%aux2d(:,num)
   enddo
 
   ! Auxiliary 3d arrays to output (for debugging)
@@ -4819,24 +4112,21 @@ module GFS_diagnostics
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
     ExtDiag(idx)%time_avg = Model%aux3d_time_avg(num)
-    do nb = 1,nblks
-       ExtDiag(idx)%data(1)%var3 => IntDiag%aux3d(:,:,num)
-    enddo
+    ExtDiag(idx)%data(1)%var3 => IntDiag%aux3d(:,:,num)
   enddo
 
   end subroutine GFS_externaldiag_populate
 
-  subroutine clm_lake_externaldiag_populate(ExtDiag, Model, Sfcprop, idx, cn_one, nblks)
+  subroutine clm_lake_externaldiag_populate(ExtDiag, Model, Sfcprop, idx, cn_one)
     implicit none
     type(GFS_externaldiag_type),  intent(inout) :: ExtDiag(:)
     type(GFS_control_type),       intent(in)    :: Model
     type(GFS_sfcprop_type),       intent(in)    :: Sfcprop
     integer,                      intent(inout) :: idx
-    integer,                      intent(in)    :: nblks
     real(kind=kind_phys),         intent(in)    :: cn_one
     character(:), allocatable :: fullname
 
-    integer :: nk, idx0, iblk
+    integer :: nk, idx0
 
     call link_all_levels(Sfcprop%lake_snow_z3d(:,:),     'lake_snow_z3d',     'lake snow level depth',          'm')
     call link_all_levels(Sfcprop%lake_snow_dz3d(:,:),    'lake_snow_dz3d',    'lake snow level thickness',      'm')

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -4807,49 +4807,22 @@ module GFS_diagnostics
 
     integer :: nk, idx0, iblk
 
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_snow_z3d(:,:), 'lake_snow_z3d', 'lake snow level depth', 'm',iblk)
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_snow_dz3d(:,:), 'lake_snow_dz3d', 'lake snow level thickness', 'm',iblk)
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_snow_zi3d(:,:), 'lake_snow_zi3d', 'lake snow interface depth', 'm',iblk)
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_h2osoi_vol3d(:,:), 'lake_h2osoi_vol3d', 'volumetric soil water', 'm3 m-3',iblk)
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_h2osoi_liq3d(:,:), 'lake_h2osoi_liq3d', 'soil liquid water content', 'kg m-2',iblk)
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_h2osoi_ice3d(:,:), 'lake_h2osoi_ice3d', 'soil ice water content', 'kg m-2',iblk)
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_t_soisno3d(:,:), 'lake_t_soisno3d', 'snow or soil level temperature', 'K',iblk)
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_t_lake3d(:,:), 'lake_t_lake3d', 'lake layer temperature', 'K',iblk)
-    enddo
-
-    do iblk=1,nblks
-      call link_all_levels(Sfcprop%lake_icefrac3d(:,:), 'lake_icefrac3d', 'lake fractional ice cover', 'fraction',iblk)
-    enddo
+    call link_all_levels(Sfcprop%lake_snow_z3d(:,:),     'lake_snow_z3d',     'lake snow level depth',          'm')
+    call link_all_levels(Sfcprop%lake_snow_dz3d(:,:),    'lake_snow_dz3d',    'lake snow level thickness',      'm')
+    call link_all_levels(Sfcprop%lake_snow_zi3d(:,:),    'lake_snow_zi3d',    'lake snow interface depth',      'm')
+    call link_all_levels(Sfcprop%lake_h2osoi_vol3d(:,:), 'lake_h2osoi_vol3d', 'volumetric soil water',          'm3 m-3')
+    call link_all_levels(Sfcprop%lake_h2osoi_liq3d(:,:), 'lake_h2osoi_liq3d', 'soil liquid water content',      'kg m-2')
+    call link_all_levels(Sfcprop%lake_h2osoi_ice3d(:,:), 'lake_h2osoi_ice3d', 'soil ice water content',         'kg m-2')
+    call link_all_levels(Sfcprop%lake_t_soisno3d(:,:),   'lake_t_soisno3d',   'snow or soil level temperature', 'K')
+    call link_all_levels(Sfcprop%lake_t_lake3d(:,:),     'lake_t_lake3d',     'lake layer temperature',         'K')
+    call link_all_levels(Sfcprop%lake_icefrac3d(:,:),    'lake_icefrac3d',    'lake fractional ice cover',      'fraction')
 
   contains
 
-    subroutine link_all_levels(var3d, varname, levelname, unit, ib)
+    subroutine link_all_levels(var3d, varname, levelname, unit)
       implicit none
       real(kind=kind_phys), target :: var3d(:,:)
       character(len=*), intent(in) :: varname, levelname, unit
-      integer, intent(in) :: ib
       integer k, b, namelen
 
       namelen = 30+max(len(varname),len(levelname))

--- a/ccpp/driver/GFS_init.F90
+++ b/ccpp/driver/GFS_init.F90
@@ -49,7 +49,6 @@ module GFS_init
     type(GFS_init_type),         intent(in)    :: Init_parm
 
     !--- local variables
-    integer :: nb
     integer :: nblks
     integer :: nt
     integer :: nthrds

--- a/ccpp/driver/GFS_restart.F90
+++ b/ccpp/driver/GFS_restart.F90
@@ -10,19 +10,16 @@ module GFS_restart
   use GFS_diagnostics,  only: GFS_externaldiag_type
 
   type var_subtype
-    real(kind=kind_phys), pointer :: var2p(:)   => null()  !< 2D data saved in packed format [dim(ix)]
-    real(kind=kind_phys), pointer :: var3p(:,:) => null()  !< 3D data saved in packed format [dim(ix,levs)]
+     real(kind=kind_phys), dimension(:),   pointer :: var2(:)   => null()
+     real(kind=kind_phys), dimension(:,:), pointer :: var3(:,:) => null()
   end type var_subtype
 
   type GFS_restart_type
-    integer           :: num2d                    !< current number of registered 2D restart variables
-    integer           :: num3d                    !< current number of registered 3D restart variables
-    integer           :: fdiag                    !< index of first diagnostic field in restart file
-    integer           :: ldiag                    !< index of last diagnostic field in restart file
-
-    character(len=32), allocatable :: name2d(:)   !< variable name as it will appear in the restart file
-    character(len=32), allocatable :: name3d(:)   !< variable name as it will appear in the restart file
-    type(var_subtype), allocatable :: data(:,:)   !< holds pointers to data in packed format (allocated to (nblks,max(2d/3dfields))
+     integer           :: axes     !< Rank of data (2D or 3D).
+     logical           :: diag     !< True for diagnostic field.
+     logical           :: reset    !< If true, zero out diagnostic field.
+     character(len=32) :: name     !< variable name as it will appear in the restart file.
+     type(var_subtype) :: data(1)  !< Holds pointers to contiguous data.
   end type GFS_restart_type
 
   public GFS_restart_type, GFS_restart_populate
@@ -33,18 +30,19 @@ module GFS_restart
 !---------------------
 ! GFS_restart_populate
 !---------------------
-  subroutine GFS_restart_populate (Restart, Model, Statein, Stateout, Sfcprop, &
-                                   Coupling, Grid, Tbd, Cldprop, Radtend, IntDiag, Init_parm, ExtDiag)
+  subroutine GFS_restart_populate (Restart, Model, Statein, Stateout, Sfcprop,     &
+                                   Coupling, Grid, Tbd, Cldprop, Radtend, IntDiag, &
+                                   Init_parm, ExtDiag)
 !----------------------------------------------------------------------------------------!
-!   RESTART_METADATA                                                                         !
-!     Restart%num2d          [int*4  ]  number of 2D variables to output             !
-!     Restart%num3d          [int*4  ]  number of 3D variables to output             !
-!     Restart%name2d         [char=32]  variable name in restart file                !
-!     Restart%name3d         [char=32]  variable name in restart file                !
-!     Restart%fld2d(:,:,:)   [real*8 ]  pointer to 2D data (im,nblks,MAX_RSTRT)      !
-!     Restart%fld3d(:,:,:,:) [real*8 ]  pointer to 3D data (im,levs,nblks,MAX_RSTRT) !
+!   RESTART_METADATA                                                                     !
+!     Restart%axes           [int*4  ]  Number of axes (rank) of variable                !
+!     Restart%diag           [logical]  Flag to indicate diagnostic variable             !
+!     Restart%reset          [logical]  Flag to indicate diagnostics need to be reset    !
+!     Restart%name           [char=32]  Variable name in restart file                    !
+!     Restart%data(1)%var2(:)   [real*8 ]  pointer to 2D data (im)                       !
+!     Restart%data(1)%var3(:,:) [real*8 ]  pointer to 3D data (im,levs)                  !
 !----------------------------------------------------------------------------------------!
-    type(GFS_restart_type),     intent(inout) :: Restart
+    type(GFS_restart_type),     intent(inout), allocatable :: Restart(:)
     type(GFS_control_type),     intent(in)    :: Model
     type(GFS_statein_type),     intent(in)    :: Statein
     type(GFS_stateout_type),    intent(in)    :: Stateout
@@ -61,15 +59,13 @@ module GFS_restart
     !--- local variables
     integer :: idx, ndiag_rst
     integer :: ndiag_idx(20), itime
-    integer :: nblks, num, nb, max_rstrt, offset 
+    integer ::  num, offset
     character(len=2) :: c2 = ''
     logical :: surface_layer_saves_rainprev
-    
-    nblks = size(Init_parm%blksz)
-    max_rstrt = size(Restart%name2d)
+    integer :: num2d, num3d
 
     !--- check if continuous accumulated total precip and total cnvc precip are
-    !requested in output 
+    !    requested in output. If so, store location into Diagnsotic type.
     ndiag_rst = 0
     ndiag_idx(1:20) = 0
     do idx=1, size(ExtDiag)
@@ -102,10 +98,8 @@ module GFS_restart
       endif
     enddo
 
-    ! Store first and last index of diagnostic fields:
-    Restart%fdiag = 3 + Model%ntot2d + Model%nctp + 1
-    Restart%ldiag = 3 + Model%ntot2d + Model%nctp + ndiag_rst
-    Restart%num2d = 3 + Model%ntot2d + Model%nctp + ndiag_rst
+    ! Number of required 2D restart variables.
+    num2d = 3 + Model%ntot2d + Model%nctp + ndiag_rst
 
     ! The CLM Lake Model needs raincprev and rainncprv, which some
     ! surface layer schemes save, and some don't. If the surface layer
@@ -113,113 +107,115 @@ module GFS_restart
     ! separately for clm_lake.
     surface_layer_saves_rainprev = .false.
 
+    ! Do we have any 2D restart varaibles dependent on physics scheme?
     ! GF
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
-      Restart%num2d = Restart%num2d + 3
+       num2d = num2d + 3
     endif
     ! Unified convection
     if (Model%imfdeepcnv == Model%imfdeepcnv_c3) then
-      Restart%num2d = Restart%num2d + 3
+       num2d = num2d + 3
     endif
     ! CA
     if (Model%imfdeepcnv == 2 .and. Model%do_ca) then
-      Restart%num2d = Restart%num2d + 1
+       num2d = num2d + 1
     endif
     ! NoahMP
     if (Model%lsm == Model%lsm_noahmp) then
-      Restart%num2d = Restart%num2d + 10
-      surface_layer_saves_rainprev = .true.
+       num2d = num2d + 10
+       surface_layer_saves_rainprev = .true.
     endif
     ! RUC 
     if (Model%lsm == Model%lsm_ruc) then
-      Restart%num2d = Restart%num2d + 5
-      surface_layer_saves_rainprev = .true.
+       num2d = num2d + 5
+       surface_layer_saves_rainprev = .true.
     endif
     ! MYNN SFC
     if (Model%do_mynnsfclay) then
-      Restart%num2d = Restart%num2d + 13
+       num2d = num2d + 13
     endif
     ! Save rain prev for lake if surface layer doesn't.
     if (Model%lkm>0 .and. Model%iopt_lake==Model%iopt_lake_clm .and. &
          .not.surface_layer_saves_rainprev) then
-      Restart%num2d = Restart%num2d + 2
+       num2d = num2d + 2
     endif
     ! Thompson aerosol-aware
     if (Model%imp_physics == Model%imp_physics_thompson .and. Model%ltaerosol) then
-      Restart%num2d = Restart%num2d + 2
+       num2d = num2d + 2
     endif
     if (Model%do_cap_suppress .and. Model%num_dfi_radar>0) then
-      Restart%num2d = Restart%num2d + Model%num_dfi_radar
+       num2d = num2d + Model%num_dfi_radar
     endif
     if (Model%rrfs_sd) then
-      Restart%num2d = Restart%num2d + 6
+       num2d = num2d + 6
     endif
 
-    Restart%num3d = Model%ntot3d
+    ! Number of required 3D restart variables.
+    num3d = Model%ntot3d
+
+    ! Do we have any 3D restart varaibles dependent on physics scheme?
     if (Model%num_dfi_radar>0) then
-      Restart%num3d = Restart%num3d + Model%num_dfi_radar
+       num3d = num3d + Model%num_dfi_radar
     endif
     if(Model%lrefres) then
-       Restart%num3d = Model%ntot3d+1
+       num3d = Model%ntot3d+1
     endif
     ! General Convection
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
-      Restart%num3d = Restart%num3d + 1
+       num3d = num3d + 1
     endif
     ! GF
     if (Model%imfdeepcnv == 3) then
-      Restart%num3d = Restart%num3d + 3
+       num3d = num3d + 3
     endif
     ! Unified convection
     if (Model%imfdeepcnv == 5) then
-      Restart%num3d = Restart%num3d + 4
+       num3d = num3d + 4
     endif
     ! MYNN PBL
     if (Model%do_mynnedmf) then
-      Restart%num3d = Restart%num3d + 9
+       num3d = num3d + 9
     endif
     if (Model%rrfs_sd) then
-      Restart%num3d = Restart%num3d + 4
+       num3d = num3d + 4
     endif
     !Prognostic area fraction
     if (Model%progsigma) then
-       Restart%num3d = Restart%num3d + 2
+       num3d = num3d + 2
     endif
 
     if (Model%num_dfi_radar > 0) then
       do itime=1,Model%dfi_radar_max_intervals
         if(Model%ix_dfi_radar(itime)>0) then
-          Restart%num3d = Restart%num3d + 1
+           num3d = num3d + 1
         endif
       enddo
     endif
-
-    allocate (Restart%name2d(Restart%num2d))
-    allocate (Restart%name3d(Restart%num3d))
-    allocate (Restart%data(nblks,max(Restart%num2d,Restart%num3d)))
-
-    Restart%name2d(:) = ' '
-    Restart%name3d(:) = ' '
+    print*,'SWALES GFS_restart_populate num2d+num3d = ',num2d+num3d
+    !--- Allocate Restart data type.
+    allocate (Restart(num2d+num3d))
+    Restart(:)%diag  = .false.
+    Restart(:)%reset = .false.
 
     !--- Cldprop variables
-    Restart%name2d(1) = 'cv'
-    Restart%name2d(2) = 'cvt'
-    Restart%name2d(3) = 'cvb'
-    do nb = 1,nblks
-      Restart%data(nb,1)%var2p => Cldprop%cv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      Restart%data(nb,2)%var2p => Cldprop%cvt(Model%chunk_begin(nb):Model%chunk_end(nb))
-      Restart%data(nb,3)%var2p => Cldprop%cvb(Model%chunk_begin(nb):Model%chunk_end(nb))
-    enddo
+    Restart(1)%name = 'cv'
+    Restart(1)%axes = 2
+    Restart(1)%data(1)%var2 => Cldprop%cv(:)
+    Restart(2)%name = 'cvt'
+    Restart(2)%axes = 2
+    Restart(2)%data(1)%var2 => Cldprop%cvt(:)
+    Restart(3)%name = 'cvb'
+    Restart(3)%axes = 2
+    Restart(3)%data(1)%var2 => Cldprop%cvb(:)
 
     !--- phy_f2d variables
     offset = 3
     do num = 1,Model%ntot2d
        !--- set the variable name
       write(c2,'(i2.2)') num
-      Restart%name2d(num+offset) = 'phy_f2d_'//c2
-      do nb = 1,nblks
-        Restart%data(nb,num+offset)%var2p => Tbd%phy_f2d(Model%chunk_begin(nb):Model%chunk_end(nb),num)
-      enddo
+      Restart(num+offset)%name = 'phy_f2d_'//c2
+      Restart(num+offset)%axes = 2
+      Restart(num+offset)%data(1)%var2 => Tbd%phy_f2d(:,num)
     enddo
     offset = offset + Model%ntot2d
 
@@ -228,10 +224,9 @@ module GFS_restart
       do num = 1, Model%nctp
        !--- set the variable name
         write(c2,'(i2.2)') num
-        Restart%name2d(num+offset) = 'phy_fctd_'//c2
-        do nb = 1,nblks
-          Restart%data(nb,num+offset)%var2p => Tbd%phy_fctd(Model%chunk_begin(nb):Model%chunk_end(nb),num)
-        enddo
+        Restart(num+offset)%name = 'phy_fctd_'//c2
+        Restart(num+offset)%axes = 2
+        Restart(num+offset)%data(1)%var2 => Tbd%phy_fctd(:,num)
       enddo
       offset = offset + Model%nctp
     endif
@@ -239,12 +234,12 @@ module GFS_restart
     !--- Diagnostic variables
     do idx = 1,ndiag_rst
       if( ndiag_idx(idx) > 0 ) then
-        Restart%name2d(offset+idx) = trim(ExtDiag(ndiag_idx(idx))%name)
-        do nb = 1,nblks
-          Restart%data(nb,offset+idx)%var2p => ExtDiag(ndiag_idx(idx))%data(1)%var2(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(offset+idx)%name  = trim(ExtDiag(ndiag_idx(idx))%name)
+        Restart(offset+idx)%axes  = 2
+        Restart(offset+idx)%diag  = .true.
+        Restart(offset+idx)%reset = .true.
+        Restart(offset+idx)%data(1)%var2 => ExtDiag(ndiag_idx(idx))%data(1)%var2(:)
       endif
-!      print *,'in restart 2d field, Restart%name2d(',offset+idx,')=',trim(Restart%name2d(offset+idx))
     enddo
 
     num = offset + ndiag_rst
@@ -252,223 +247,184 @@ module GFS_restart
     !CA
     if (Model%imfdeepcnv == 2 .and. Model%do_ca) then
       num = num + 1
-      Restart%name2d(num) = 'ca_condition'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Coupling%condition(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'ca_condition'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Coupling%condition(:)
     endif
     ! Unified convection
     if (Model%imfdeepcnv == Model%imfdeepcnv_c3) then
       num = num + 1
-      Restart%name2d(num) = 'gf_2d_conv_act'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%conv_act(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'gf_2d_conv_act'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%conv_act(:)
       num = num + 1
-      Restart%name2d(num) = 'gf_2d_conv_act_m'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%conv_act_m(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'gf_2d_conv_act_m'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%conv_act_m(:)
       num = num + 1
-      Restart%name2d(num) = 'aod_gf'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Tbd%aod_gf(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'aod_gf'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Tbd%aod_gf(:)
     endif
     !--- RAP/HRRR-specific variables, 2D
     ! GF
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
       num = num + 1
-      Restart%name2d(num) = 'gf_2d_conv_act'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%conv_act(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'gf_2d_conv_act'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%conv_act(:)
       num = num + 1
-      Restart%name2d(num) = 'gf_2d_conv_act_m'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%conv_act_m(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'gf_2d_conv_act_m'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%conv_act_m(:)
       num = num + 1
-      Restart%name2d(num) = 'aod_gf'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Tbd%aod_gf(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'aod_gf'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Tbd%aod_gf(:)
     endif
     ! NoahMP
     if (Model%lsm == Model%lsm_noahmp) then
       num = num + 1
-      Restart%name2d(num) = 'noahmp_2d_raincprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%raincprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'noahmp_2d_raincprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%raincprv(:)
       num = num + 1
-      Restart%name2d(num) = 'noahmp_2d_rainncprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%rainncprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'noahmp_2d_rainncprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%rainncprv(:)
       num = num + 1
-      Restart%name2d(num) = 'noahmp_2d_iceprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%iceprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'noahmp_2d_iceprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%iceprv(:)
       num = num + 1
-      Restart%name2d(num) = 'noahmp_2d_snowprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%snowprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'noahmp_2d_snowprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%snowprv(:)
       num = num + 1
-      Restart%name2d(num) = 'noahmp_2d_graupelprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%graupelprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'noahmp_2d_graupelprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%graupelprv(:)
       num = num + 1
-      Restart%name2d(num) = 'noahmp_2d_draincprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%draincprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'noahmp_2d_draincprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%draincprv(:)
       num = num + 1
-      Restart%name2d(num) = 'noahmp_2d_drainncprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%drainncprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'noahmp_2d_drainncprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%drainncprv(:)
       num = num + 1
-      Restart%name2d(num) = 'noahmp_2d_diceprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%diceprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'noahmp_2d_diceprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%diceprv(:)
       num = num + 1
-      Restart%name2d(num) = 'noahmp_2d_dsnowprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%dsnowprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'noahmp_2d_dsnowprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%dsnowprv(:)
       num = num + 1
-      Restart%name2d(num) = 'noahmp_2d_dgraupelprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%dgraupelprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'noahmp_2d_dgraupelprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%dgraupelprv(:)
     endif
     ! RUC 
     if (Model%lsm == Model%lsm_ruc) then
       num = num + 1
-      Restart%name2d(num) = 'ruc_2d_raincprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%raincprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'ruc_2d_raincprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%raincprv(:)
       num = num + 1
-      Restart%name2d(num) = 'ruc_2d_rainncprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%rainncprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'ruc_2d_rainncprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%rainncprv(:)
       num = num + 1
-      Restart%name2d(num) = 'ruc_2d_iceprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%iceprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'ruc_2d_iceprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%iceprv(:)
       num = num + 1
-      Restart%name2d(num) = 'ruc_2d_snowprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%snowprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'ruc_2d_snowprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%snowprv(:)
       num = num + 1
-      Restart%name2d(num) = 'ruc_2d_graupelprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%graupelprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'ruc_2d_graupelprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%graupelprv(:)
     endif
     ! MYNN SFC
     if (Model%do_mynnsfclay) then
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_uustar'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%uustar(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_uustar'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%uustar(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_hpbl'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Tbd%hpbl(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_hpbl'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Tbd%hpbl(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_ustm'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%ustm(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_ustm'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%ustm(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_zol'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%zol(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_zol'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%zol(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_mol'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%mol(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_mol'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%mol(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_flhc'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%flhc(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_flhc'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%flhc(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_flqc'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%flqc(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_flqc'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%flqc(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_chs2'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%chs2(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_chs2'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%chs2(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_cqs2'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%cqs2(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_cqs2'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%cqs2(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_lh'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%lh(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_lh'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%lh(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_hflx'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%hflx(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_hflx'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%hflx(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_evap'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%evap(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_evap'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%evap(:)
         num = num + 1
-        Restart%name2d(num) = 'mynn_2d_qss'
-        do nb = 1,nblks
-          Restart%data(nb,num)%var2p => Sfcprop%qss(Model%chunk_begin(nb):Model%chunk_end(nb))
-        enddo
+        Restart(num)%name = 'mynn_2d_qss'
+        Restart(num)%axes = 2
+        Restart(num)%data(1)%var2 => Sfcprop%qss(:)
     endif
     ! Save rain prev for lake if surface layer doesn't.
     if (Model%lkm>0 .and. Model%iopt_lake==Model%iopt_lake_clm .and. &
          .not.surface_layer_saves_rainprev) then
       num = num + 1
-      Restart%name2d(num) = 'raincprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%raincprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'raincprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%raincprv(:)
       num = num + 1
-      Restart%name2d(num) = 'rainncprv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Sfcprop%rainncprv(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'rainncprv'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Sfcprop%rainncprv(:)
     endif
     ! Thompson aerosol-aware
     if (Model%imp_physics == Model%imp_physics_thompson .and. Model%ltaerosol) then
       num = num + 1
-      Restart%name2d(num) = 'thompson_2d_nwfa2d'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Coupling%nwfa2d(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'thompson_2d_nwfa2d'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Coupling%nwfa2d(:)
       num = num + 1
-      Restart%name2d(num) = 'thompson_2d_nifa2d'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Coupling%nifa2d(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'thompson_2d_nifa2d'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Coupling%nifa2d(:)
     endif
 
     ! Convection suppression
@@ -477,13 +433,12 @@ module GFS_restart
         if(Model%ix_dfi_radar(itime)>0) then
           num = num + 1
           if(itime==1) then
-            Restart%name2d(num) = 'cap_suppress'
+            Restart(num)%name = 'cap_suppress'
           else
-            write(Restart%name2d(num),'("cap_suppress_",I0)') itime
+            write(Restart(num)%name,'("cap_suppress_",I0)') itime
           endif
-          do nb = 1,nblks
-            Restart%data(nb,num)%var2p => Tbd%cap_suppress(Model%chunk_begin(nb):Model%chunk_end(nb),Model%ix_dfi_radar(itime))
-          enddo
+          Restart(num)%axes = 2
+          Restart(num)%data(1)%var2 => Tbd%cap_suppress(:,Model%ix_dfi_radar(itime))
         endif
       enddo
     endif
@@ -491,52 +446,44 @@ module GFS_restart
     ! RRFS-SD
     if (Model%rrfs_sd) then
       num = num + 1
-      Restart%name2d(num) = 'ddvel_1'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Coupling%ddvel(Model%chunk_begin(nb):Model%chunk_end(nb),1)
-      enddo
+      Restart(num)%name = 'ddvel_1'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Coupling%ddvel(:,1)
       num = num + 1
-      Restart%name2d(num) = 'ddvel_2'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Coupling%ddvel(Model%chunk_begin(nb):Model%chunk_end(nb),2)
-      enddo
+      Restart(num)%name = 'ddvel_2'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Coupling%ddvel(:,2)
       num = num + 1
-      Restart%name2d(num) = 'min_fplume'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Coupling%min_fplume(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'min_fplume'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Coupling%min_fplume(:)
       num = num + 1
-      Restart%name2d(num) = 'max_fplume'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Coupling%max_fplume(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'max_fplume'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Coupling%max_fplume(:)
       num = num + 1
-      Restart%name2d(num) = 'rrfs_hwp'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Coupling%rrfs_hwp(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'rrfs_hwp'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Coupling%rrfs_hwp(:)
       num = num + 1
-      Restart%name2d(num) = 'rrfs_hwp_ave'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var2p => Coupling%rrfs_hwp_ave(Model%chunk_begin(nb):Model%chunk_end(nb))
-      enddo
+      Restart(num)%name = 'rrfs_hwp_ave'
+      Restart(num)%axes = 2
+      Restart(num)%data(1)%var2 => Coupling%rrfs_hwp_ave(:)
     endif
 
     !--- phy_f3d variables
     do num = 1,Model%ntot3d
        !--- set the variable name
       write(c2,'(i2.2)') num
-      Restart%name3d(num) = 'phy_f3d_'//c2
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%phy_f3d(Model%chunk_begin(nb):Model%chunk_end(nb),:,num)
-      enddo
+      Restart(num)%name = 'phy_f3d_'//c2
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%phy_f3d(:,:,num)
     enddo
     if (Model%lrefres) then
       num = Model%ntot3d+1
-      restart%name3d(num) = 'ref_f3d'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => IntDiag%refl_10cm(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'ref_f3d'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => IntDiag%refl_10cm(:,:)
     endif
     if (Model%lrefres) then
        num = Model%ntot3d+1
@@ -547,112 +494,94 @@ module GFS_restart
     !Prognostic closure
     if(Model%progsigma)then
        num = num + 1
-       Restart%name3d(num) = 'sas_3d_qgrs_dsave'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%prevsq(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
-      num = num + 1
-      Restart%name3d(num) = 'sas_3d_dqdt_qmicro'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Coupling%dqdt_qmicro(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+       Restart(num)%name = 'sas_3d_qgrs_dsave'
+       Restart(num)%axes = 3
+       Restart(num)%data(1)%var3 => Tbd%prevsq(:,:)
+       num = num + 1
+       Restart(num)%name = 'sas_3d_dqdt_qmicro'
+       Restart(num)%axes = 3
+       Restart(num)%data(1)%var3 => Coupling%dqdt_qmicro(:,:)
     endif
 
     !--Convection variable used in CB cloud fraction. Presently this
     !--is only needed in sgscloud_radpre for imfdeepcnv == imfdeepcnv_gf.
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf .or. Model%imfdeepcnv == Model%imfdeepcnv_c3) then
       num = num + 1
-      Restart%name3d(num) = 'cnv_3d_ud_mf'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%ud_mf(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'cnv_3d_ud_mf'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%ud_mf(:,:)
     endif
 
     !Unified convection scheme                                                                                                                                                                    
     if (Model%imfdeepcnv == Model%imfdeepcnv_c3) then
       num = num + 1
-      Restart%name3d(num) = 'gf_3d_prevst'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%prevst(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'gf_3d_prevst'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%prevst(:,:)
       num = num + 1
-      Restart%name3d(num) = 'gf_3d_prevsq'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%prevsq(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'gf_3d_prevsq'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%prevsq(:,:)
       num = num + 1
-      Restart%name3d(num) = 'gf_3d_qci_conv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Coupling%qci_conv(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'gf_3d_qci_conv'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Coupling%qci_conv(:,:)
     endif
 
     !--- RAP/HRRR-specific variables, 3D
     ! GF
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
       num = num + 1
-      Restart%name3d(num) = 'gf_3d_prevst'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%prevst(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'gf_3d_prevst'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%prevst(:,:)
       num = num + 1
-      Restart%name3d(num) = 'gf_3d_prevsq'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%prevsq(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'gf_3d_prevsq'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%prevsq(:,:)
       num = num + 1
-      Restart%name3d(num) = 'gf_3d_qci_conv'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Coupling%qci_conv(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'gf_3d_qci_conv'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Coupling%qci_conv(:,:)
     endif
     ! MYNN PBL
     if (Model%do_mynnedmf) then
       num = num + 1
-      Restart%name3d(num) = 'mynn_3d_cldfra_bl'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%cldfra_bl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'mynn_3d_cldfra_bl'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%cldfra_bl(:,:)
       num = num + 1
-      Restart%name3d(num) = 'mynn_3d_qc_bl'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%qc_bl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'mynn_3d_qc_bl'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%qc_bl(:,:)
       num = num + 1
-      Restart%name3d(num) = 'mynn_3d_qi_bl'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%qi_bl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'mynn_3d_qi_bl'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%qi_bl(:,:)
       num = num + 1
-      Restart%name3d(num) = 'mynn_3d_el_pbl'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%el_pbl(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'mynn_3d_el_pbl'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%el_pbl(:,:)
       num = num + 1
-      Restart%name3d(num) = 'mynn_3d_sh3d'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%sh3d(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'mynn_3d_sh3d'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%sh3d(:,:)
       num = num + 1
-      Restart%name3d(num) = 'mynn_3d_qke'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%qke(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'mynn_3d_qke'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%qke(:,:)
       num = num + 1
-      Restart%name3d(num) = 'mynn_3d_tsq'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%tsq(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'mynn_3d_tsq'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%tsq(:,:)
       num = num + 1
-      Restart%name3d(num) = 'mynn_3d_qsq'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%qsq(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'mynn_3d_qsq'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%qsq(:,:)
       num = num + 1
-      Restart%name3d(num) = 'mynn_3d_cov'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Tbd%cov(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'mynn_3d_cov'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Tbd%cov(:,:)
     endif
 
     ! Radar-derived microphysics temperature tendencies
@@ -661,39 +590,33 @@ module GFS_restart
         if(Model%ix_dfi_radar(itime)>0) then
           num = num + 1
           if(itime==1) then
-            Restart%name3d(num) = 'radar_tten'
+            Restart(num)%name = 'radar_tten'
           else
-            write(Restart%name3d(num),'("radar_tten_",I0)') itime
+            write(Restart(num)%name,'("radar_tten_",I0)') itime
           endif
-          do nb = 1,nblks
-            Restart%data(nb,num)%var3p => Tbd%dfi_radar_tten( &
-              Model%chunk_begin(nb):Model%chunk_end(nb),:,Model%ix_dfi_radar(itime))
-          enddo
+          Restart(num)%axes = 3
+          Restart(num)%data(1)%var3 => Tbd%dfi_radar_tten(:,:,Model%ix_dfi_radar(itime))
         endif
       enddo
     endif
 
     if(Model%rrfs_sd) then
       num = num + 1
-      Restart%name3d(num) = 'chem3d_1'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Coupling%chem3d(Model%chunk_begin(nb):Model%chunk_end(nb),:,1)
-      enddo
+      Restart(num)%name = 'chem3d_1'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Coupling%chem3d(:,:,1)
       num = num + 1
-      Restart%name3d(num) = 'chem3d_2'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Coupling%chem3d(Model%chunk_begin(nb):Model%chunk_end(nb),:,2)
-      enddo
+      Restart(num)%name = 'chem3d_2'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Coupling%chem3d(:,:,2)
       num = num + 1
-      Restart%name3d(num) = 'chem3d_3'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Coupling%chem3d(Model%chunk_begin(nb):Model%chunk_end(nb),:,3)
-      enddo
+      Restart(num)%name = 'chem3d_3'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Coupling%chem3d(:,:,3)
       num = num + 1
-      Restart%name3d(num) = 'ext550'
-      do nb = 1,nblks
-        Restart%data(nb,num)%var3p => Radtend%ext550(Model%chunk_begin(nb):Model%chunk_end(nb),:)
-      enddo
+      Restart(num)%name = 'ext550'
+      Restart(num)%axes = 3
+      Restart(num)%data(1)%var3 => Radtend%ext550(:,:)
     endif
 
   end subroutine GFS_restart_populate

--- a/ccpp/driver/GFS_restart.F90
+++ b/ccpp/driver/GFS_restart.F90
@@ -244,7 +244,7 @@ module GFS_restart
         Restart(idx)%axes  = 2
         Restart(idx)%diag  = .true.
         Restart(idx)%reset = .true.
-        Restart(idx)%data%var2 => ExtDiag(ndiag_idx(num))%data(1)%var2(:)
+        Restart(idx)%data%var2 => ExtDiag(ndiag_idx(num))%data%var2(:)
       endif
     enddo
 

--- a/ccpp/driver/GFS_restart.F90
+++ b/ccpp/driver/GFS_restart.F90
@@ -241,7 +241,7 @@ module GFS_restart
       if( ndiag_idx(idx) > 0 ) then
         Restart%name2d(offset+idx) = trim(ExtDiag(ndiag_idx(idx))%name)
         do nb = 1,nblks
-          Restart%data(nb,offset+idx)%var2p => ExtDiag(ndiag_idx(idx))%data(nb)%var2
+          Restart%data(nb,offset+idx)%var2p => ExtDiag(ndiag_idx(idx))%data(1)%var2(Model%chunk_begin(nb):Model%chunk_end(nb))
         enddo
       endif
 !      print *,'in restart 2d field, Restart%name2d(',offset+idx,')=',trim(Restart%name2d(offset+idx))

--- a/ccpp/driver/GFS_restart.F90
+++ b/ccpp/driver/GFS_restart.F90
@@ -10,16 +10,16 @@ module GFS_restart
   use GFS_diagnostics,  only: GFS_externaldiag_type
 
   type var_subtype
-     real(kind=kind_phys), dimension(:),   pointer :: var2(:)   => null()
-     real(kind=kind_phys), dimension(:,:), pointer :: var3(:,:) => null()
+     real(kind=kind_phys), dimension(:),   pointer :: var2 => null()
+     real(kind=kind_phys), dimension(:,:), pointer :: var3 => null()
   end type var_subtype
 
   type GFS_restart_type
-     integer           :: axes     !< Rank of data (2D or 3D).
-     logical           :: diag     !< True for diagnostic field.
-     logical           :: reset    !< If true, zero out diagnostic field.
-     character(len=32) :: name     !< variable name as it will appear in the restart file.
-     type(var_subtype) :: data(1)  !< Holds pointers to contiguous data.
+     integer           :: axes  !< Rank of data (2D or 3D).
+     logical           :: diag  !< True for diagnostic field.
+     logical           :: reset !< If true, zero out diagnostic field.
+     character(len=32) :: name  !< variable name as it will appear in the restart file.
+     type(var_subtype) :: data  !< Holds pointers to contiguous data.
   end type GFS_restart_type
 
   public GFS_restart_type, GFS_restart_populate
@@ -39,8 +39,8 @@ module GFS_restart
 !     Restart%diag           [logical]  Flag to indicate diagnostic variable             !
 !     Restart%reset          [logical]  Flag to indicate diagnostics need to be reset    !
 !     Restart%name           [char=32]  Variable name in restart file                    !
-!     Restart%data(1)%var2(:)   [real*8 ]  pointer to 2D data (im)                       !
-!     Restart%data(1)%var3(:,:) [real*8 ]  pointer to 3D data (im,levs)                  !
+!     Restart%data%var2(:)   [real*8 ]  pointer to 2D data (im)                          !
+!     Restart%data%var3(:,:) [real*8 ]  pointer to 3D data (im,levs)                     !
 !----------------------------------------------------------------------------------------!
     type(GFS_restart_type),     intent(inout), allocatable :: Restart(:)
     type(GFS_control_type),     intent(in)    :: Model
@@ -97,7 +97,7 @@ module GFS_restart
         endif
       endif
     enddo
-
+  
     ! Number of required 2D restart variables.
     num2d = 3 + Model%ntot2d + Model%nctp + ndiag_rst
 
@@ -152,7 +152,7 @@ module GFS_restart
 
     ! Number of required 3D restart variables.
     num3d = Model%ntot3d
-
+    
     ! Do we have any 3D restart varaibles dependent on physics scheme?
     if (Model%num_dfi_radar>0) then
        num3d = num3d + Model%num_dfi_radar
@@ -191,432 +191,434 @@ module GFS_restart
         endif
       enddo
     endif
-    print*,'SWALES GFS_restart_populate num2d+num3d = ',num2d+num3d
+
     !--- Allocate Restart data type.
     allocate (Restart(num2d+num3d))
     Restart(:)%diag  = .false.
     Restart(:)%reset = .false.
+    idx = 0
 
     !--- Cldprop variables
-    Restart(1)%name = 'cv'
-    Restart(1)%axes = 2
-    Restart(1)%data(1)%var2 => Cldprop%cv(:)
-    Restart(2)%name = 'cvt'
-    Restart(2)%axes = 2
-    Restart(2)%data(1)%var2 => Cldprop%cvt(:)
-    Restart(3)%name = 'cvb'
-    Restart(3)%axes = 2
-    Restart(3)%data(1)%var2 => Cldprop%cvb(:)
+    idx = idx + 1
+    Restart(idx)%name = 'cv'
+    Restart(idx)%axes = 2
+    Restart(idx)%data%var2 => Cldprop%cv(:)
+    
+    idx = idx + 1
+    Restart(idx)%name = 'cvt'
+    Restart(idx)%axes = 2
+    Restart(idx)%data%var2 => Cldprop%cvt(:)
+
+    idx = idx + 1
+    Restart(idx)%name = 'cvb'
+    Restart(idx)%axes = 2
+    Restart(idx)%data%var2 => Cldprop%cvb(:)
 
     !--- phy_f2d variables
-    offset = 3
     do num = 1,Model%ntot2d
+      idx = idx + 1
        !--- set the variable name
       write(c2,'(i2.2)') num
-      Restart(num+offset)%name = 'phy_f2d_'//c2
-      Restart(num+offset)%axes = 2
-      Restart(num+offset)%data(1)%var2 => Tbd%phy_f2d(:,num)
+      Restart(idx)%name = 'phy_f2d_'//c2
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Tbd%phy_f2d(:,num)
     enddo
-    offset = offset + Model%ntot2d
 
     !--- phy_fctd variables
     if (Model%nctp > 0) then
       do num = 1, Model%nctp
-       !--- set the variable name
+        idx = idx + 1
+        !--- set the variable name
         write(c2,'(i2.2)') num
-        Restart(num+offset)%name = 'phy_fctd_'//c2
-        Restart(num+offset)%axes = 2
-        Restart(num+offset)%data(1)%var2 => Tbd%phy_fctd(:,num)
+        Restart(idx)%name = 'phy_fctd_'//c2
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Tbd%phy_fctd(:,num)
       enddo
-      offset = offset + Model%nctp
     endif
 
     !--- Diagnostic variables
-    do idx = 1,ndiag_rst
-      if( ndiag_idx(idx) > 0 ) then
-        Restart(offset+idx)%name  = trim(ExtDiag(ndiag_idx(idx))%name)
-        Restart(offset+idx)%axes  = 2
-        Restart(offset+idx)%diag  = .true.
-        Restart(offset+idx)%reset = .true.
-        Restart(offset+idx)%data(1)%var2 => ExtDiag(ndiag_idx(idx))%data(1)%var2(:)
+    do num = 1,ndiag_rst
+      if( ndiag_idx(num) > 0 ) then
+        idx = idx + 1
+        Restart(idx)%name  = trim(ExtDiag(ndiag_idx(num))%name)
+        Restart(idx)%axes  = 2
+        Restart(idx)%diag  = .true.
+        Restart(idx)%reset = .true.
+        Restart(idx)%data%var2 => ExtDiag(ndiag_idx(num))%data(1)%var2(:)
       endif
     enddo
 
-    num = offset + ndiag_rst
     !--- Celluluar Automaton, 2D
     !CA
     if (Model%imfdeepcnv == 2 .and. Model%do_ca) then
-      num = num + 1
-      Restart(num)%name = 'ca_condition'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Coupling%condition(:)
+      idx = idx + 1
+      Restart(idx)%name = 'ca_condition'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Coupling%condition(:)
     endif
     ! Unified convection
     if (Model%imfdeepcnv == Model%imfdeepcnv_c3) then
-      num = num + 1
-      Restart(num)%name = 'gf_2d_conv_act'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%conv_act(:)
-      num = num + 1
-      Restart(num)%name = 'gf_2d_conv_act_m'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%conv_act_m(:)
-      num = num + 1
-      Restart(num)%name = 'aod_gf'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Tbd%aod_gf(:)
+      idx = idx + 1
+      Restart(idx)%name = 'gf_2d_conv_act'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%conv_act(:)
+      idx = idx + 1
+      Restart(idx)%name = 'gf_2d_conv_act_m'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%conv_act_m(:)
+      idx = idx + 1
+      Restart(idx)%name = 'aod_gf'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Tbd%aod_gf(:)
     endif
     !--- RAP/HRRR-specific variables, 2D
     ! GF
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
-      num = num + 1
-      Restart(num)%name = 'gf_2d_conv_act'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%conv_act(:)
-      num = num + 1
-      Restart(num)%name = 'gf_2d_conv_act_m'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%conv_act_m(:)
-      num = num + 1
-      Restart(num)%name = 'aod_gf'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Tbd%aod_gf(:)
+      idx = idx + 1
+      Restart(idx)%name = 'gf_2d_conv_act'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%conv_act(:)
+      idx = idx + 1
+      Restart(idx)%name = 'gf_2d_conv_act_m'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%conv_act_m(:)
+      idx = idx + 1
+      Restart(idx)%name = 'aod_gf'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Tbd%aod_gf(:)
     endif
     ! NoahMP
     if (Model%lsm == Model%lsm_noahmp) then
-      num = num + 1
-      Restart(num)%name = 'noahmp_2d_raincprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%raincprv(:)
-      num = num + 1
-      Restart(num)%name = 'noahmp_2d_rainncprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%rainncprv(:)
-      num = num + 1
-      Restart(num)%name = 'noahmp_2d_iceprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%iceprv(:)
-      num = num + 1
-      Restart(num)%name = 'noahmp_2d_snowprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%snowprv(:)
-      num = num + 1
-      Restart(num)%name = 'noahmp_2d_graupelprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%graupelprv(:)
-      num = num + 1
-      Restart(num)%name = 'noahmp_2d_draincprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%draincprv(:)
-      num = num + 1
-      Restart(num)%name = 'noahmp_2d_drainncprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%drainncprv(:)
-      num = num + 1
-      Restart(num)%name = 'noahmp_2d_diceprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%diceprv(:)
-      num = num + 1
-      Restart(num)%name = 'noahmp_2d_dsnowprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%dsnowprv(:)
-      num = num + 1
-      Restart(num)%name = 'noahmp_2d_dgraupelprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%dgraupelprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'noahmp_2d_raincprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%raincprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'noahmp_2d_rainncprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%rainncprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'noahmp_2d_iceprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%iceprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'noahmp_2d_snowprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%snowprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'noahmp_2d_graupelprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%graupelprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'noahmp_2d_draincprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%draincprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'noahmp_2d_drainncprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%drainncprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'noahmp_2d_diceprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%diceprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'noahmp_2d_dsnowprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%dsnowprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'noahmp_2d_dgraupelprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%dgraupelprv(:)
     endif
     ! RUC 
     if (Model%lsm == Model%lsm_ruc) then
-      num = num + 1
-      Restart(num)%name = 'ruc_2d_raincprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%raincprv(:)
-      num = num + 1
-      Restart(num)%name = 'ruc_2d_rainncprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%rainncprv(:)
-      num = num + 1
-      Restart(num)%name = 'ruc_2d_iceprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%iceprv(:)
-      num = num + 1
-      Restart(num)%name = 'ruc_2d_snowprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%snowprv(:)
-      num = num + 1
-      Restart(num)%name = 'ruc_2d_graupelprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%graupelprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'ruc_2d_raincprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%raincprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'ruc_2d_rainncprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%rainncprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'ruc_2d_iceprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%iceprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'ruc_2d_snowprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%snowprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'ruc_2d_graupelprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%graupelprv(:)
     endif
     ! MYNN SFC
     if (Model%do_mynnsfclay) then
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_uustar'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%uustar(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_hpbl'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Tbd%hpbl(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_ustm'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%ustm(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_zol'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%zol(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_mol'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%mol(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_flhc'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%flhc(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_flqc'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%flqc(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_chs2'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%chs2(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_cqs2'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%cqs2(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_lh'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%lh(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_hflx'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%hflx(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_evap'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%evap(:)
-        num = num + 1
-        Restart(num)%name = 'mynn_2d_qss'
-        Restart(num)%axes = 2
-        Restart(num)%data(1)%var2 => Sfcprop%qss(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_uustar'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%uustar(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_hpbl'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Tbd%hpbl(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_ustm'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%ustm(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_zol'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%zol(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_mol'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%mol(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_flhc'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%flhc(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_flqc'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%flqc(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_chs2'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%chs2(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_cqs2'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%cqs2(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_lh'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%lh(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_hflx'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%hflx(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_evap'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%evap(:)
+        idx = idx + 1
+        Restart(idx)%name = 'mynn_2d_qss'
+        Restart(idx)%axes = 2
+        Restart(idx)%data%var2 => Sfcprop%qss(:)
     endif
     ! Save rain prev for lake if surface layer doesn't.
     if (Model%lkm>0 .and. Model%iopt_lake==Model%iopt_lake_clm .and. &
          .not.surface_layer_saves_rainprev) then
-      num = num + 1
-      Restart(num)%name = 'raincprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%raincprv(:)
-      num = num + 1
-      Restart(num)%name = 'rainncprv'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Sfcprop%rainncprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'raincprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%raincprv(:)
+      idx = idx + 1
+      Restart(idx)%name = 'rainncprv'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Sfcprop%rainncprv(:)
     endif
     ! Thompson aerosol-aware
     if (Model%imp_physics == Model%imp_physics_thompson .and. Model%ltaerosol) then
-      num = num + 1
-      Restart(num)%name = 'thompson_2d_nwfa2d'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Coupling%nwfa2d(:)
-      num = num + 1
-      Restart(num)%name = 'thompson_2d_nifa2d'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Coupling%nifa2d(:)
+      idx = idx + 1
+      Restart(idx)%name = 'thompson_2d_nwfa2d'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Coupling%nwfa2d(:)
+      idx = idx + 1
+      Restart(idx)%name = 'thompson_2d_nifa2d'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Coupling%nifa2d(:)
     endif
 
     ! Convection suppression
     if (Model%do_cap_suppress .and. Model%num_dfi_radar > 0) then
       do itime=1,Model%dfi_radar_max_intervals
         if(Model%ix_dfi_radar(itime)>0) then
-          num = num + 1
+          idx = idx + 1
           if(itime==1) then
-            Restart(num)%name = 'cap_suppress'
+            Restart(idx)%name = 'cap_suppress'
           else
-            write(Restart(num)%name,'("cap_suppress_",I0)') itime
+            write(Restart(idx)%name,'("cap_suppress_",I0)') itime
           endif
-          Restart(num)%axes = 2
-          Restart(num)%data(1)%var2 => Tbd%cap_suppress(:,Model%ix_dfi_radar(itime))
+          Restart(idx)%axes = 2
+          Restart(idx)%data%var2 => Tbd%cap_suppress(:,Model%ix_dfi_radar(itime))
         endif
       enddo
     endif
 
     ! RRFS-SD
     if (Model%rrfs_sd) then
-      num = num + 1
-      Restart(num)%name = 'ddvel_1'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Coupling%ddvel(:,1)
-      num = num + 1
-      Restart(num)%name = 'ddvel_2'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Coupling%ddvel(:,2)
-      num = num + 1
-      Restart(num)%name = 'min_fplume'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Coupling%min_fplume(:)
-      num = num + 1
-      Restart(num)%name = 'max_fplume'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Coupling%max_fplume(:)
-      num = num + 1
-      Restart(num)%name = 'rrfs_hwp'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Coupling%rrfs_hwp(:)
-      num = num + 1
-      Restart(num)%name = 'rrfs_hwp_ave'
-      Restart(num)%axes = 2
-      Restart(num)%data(1)%var2 => Coupling%rrfs_hwp_ave(:)
+      idx = idx + 1
+      Restart(idx)%name = 'ddvel_1'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Coupling%ddvel(:,1)
+      idx = idx + 1
+      Restart(idx)%name = 'ddvel_2'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Coupling%ddvel(:,2)
+      idx = idx + 1
+      Restart(idx)%name = 'min_fplume'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Coupling%min_fplume(:)
+      idx = idx + 1
+      Restart(idx)%name = 'max_fplume'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Coupling%max_fplume(:)
+      idx = idx + 1
+      Restart(idx)%name = 'rrfs_hwp'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Coupling%rrfs_hwp(:)
+      idx = idx + 1
+      Restart(idx)%name = 'rrfs_hwp_ave'
+      Restart(idx)%axes = 2
+      Restart(idx)%data%var2 => Coupling%rrfs_hwp_ave(:)
     endif
 
     !--- phy_f3d variables
     do num = 1,Model%ntot3d
-       !--- set the variable name
+      idx = idx + 1
+      !--- set the variable name
       write(c2,'(i2.2)') num
-      Restart(num)%name = 'phy_f3d_'//c2
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%phy_f3d(:,:,num)
-    enddo
-    if (Model%lrefres) then
-      num = Model%ntot3d+1
-      Restart(num)%name = 'ref_f3d'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => IntDiag%refl_10cm(:,:)
-    endif
-    if (Model%lrefres) then
-       num = Model%ntot3d+1
-    else
-       num = Model%ntot3d
-    endif
+      Restart(idx)%name = 'phy_f3d_'//c2
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%phy_f3d(:,:,num)
+   enddo
+
+   if (Model%lrefres) then
+      idx = idx + 1
+      Restart(idx)%name = 'ref_f3d'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => IntDiag%refl_10cm(:,:)
+   endif
 
     !Prognostic closure
     if(Model%progsigma)then
-       num = num + 1
-       Restart(num)%name = 'sas_3d_qgrs_dsave'
-       Restart(num)%axes = 3
-       Restart(num)%data(1)%var3 => Tbd%prevsq(:,:)
-       num = num + 1
-       Restart(num)%name = 'sas_3d_dqdt_qmicro'
-       Restart(num)%axes = 3
-       Restart(num)%data(1)%var3 => Coupling%dqdt_qmicro(:,:)
+       idx = idx + 1
+       Restart(idx)%name = 'sas_3d_qgrs_dsave'
+       Restart(idx)%axes = 3
+       Restart(idx)%data%var3 => Tbd%prevsq(:,:)
+       idx = idx + 1
+       Restart(idx)%name = 'sas_3d_dqdt_qmicro'
+       Restart(idx)%axes = 3
+       Restart(idx)%data%var3 => Coupling%dqdt_qmicro(:,:)
     endif
 
     !--Convection variable used in CB cloud fraction. Presently this
     !--is only needed in sgscloud_radpre for imfdeepcnv == imfdeepcnv_gf.
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf .or. Model%imfdeepcnv == Model%imfdeepcnv_c3) then
-      num = num + 1
-      Restart(num)%name = 'cnv_3d_ud_mf'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%ud_mf(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'cnv_3d_ud_mf'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%ud_mf(:,:)
     endif
 
     !Unified convection scheme                                                                                                                                                                    
     if (Model%imfdeepcnv == Model%imfdeepcnv_c3) then
-      num = num + 1
-      Restart(num)%name = 'gf_3d_prevst'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%prevst(:,:)
-      num = num + 1
-      Restart(num)%name = 'gf_3d_prevsq'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%prevsq(:,:)
-      num = num + 1
-      Restart(num)%name = 'gf_3d_qci_conv'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Coupling%qci_conv(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'gf_3d_prevst'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%prevst(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'gf_3d_prevsq'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%prevsq(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'gf_3d_qci_conv'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Coupling%qci_conv(:,:)
     endif
 
     !--- RAP/HRRR-specific variables, 3D
     ! GF
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
-      num = num + 1
-      Restart(num)%name = 'gf_3d_prevst'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%prevst(:,:)
-      num = num + 1
-      Restart(num)%name = 'gf_3d_prevsq'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%prevsq(:,:)
-      num = num + 1
-      Restart(num)%name = 'gf_3d_qci_conv'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Coupling%qci_conv(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'gf_3d_prevst'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%prevst(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'gf_3d_prevsq'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%prevsq(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'gf_3d_qci_conv'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Coupling%qci_conv(:,:)
     endif
     ! MYNN PBL
     if (Model%do_mynnedmf) then
-      num = num + 1
-      Restart(num)%name = 'mynn_3d_cldfra_bl'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%cldfra_bl(:,:)
-      num = num + 1
-      Restart(num)%name = 'mynn_3d_qc_bl'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%qc_bl(:,:)
-      num = num + 1
-      Restart(num)%name = 'mynn_3d_qi_bl'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%qi_bl(:,:)
-      num = num + 1
-      Restart(num)%name = 'mynn_3d_el_pbl'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%el_pbl(:,:)
-      num = num + 1
-      Restart(num)%name = 'mynn_3d_sh3d'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%sh3d(:,:)
-      num = num + 1
-      Restart(num)%name = 'mynn_3d_qke'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%qke(:,:)
-      num = num + 1
-      Restart(num)%name = 'mynn_3d_tsq'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%tsq(:,:)
-      num = num + 1
-      Restart(num)%name = 'mynn_3d_qsq'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%qsq(:,:)
-      num = num + 1
-      Restart(num)%name = 'mynn_3d_cov'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Tbd%cov(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'mynn_3d_cldfra_bl'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%cldfra_bl(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'mynn_3d_qc_bl'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%qc_bl(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'mynn_3d_qi_bl'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%qi_bl(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'mynn_3d_el_pbl'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%el_pbl(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'mynn_3d_sh3d'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%sh3d(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'mynn_3d_qke'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%qke(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'mynn_3d_tsq'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%tsq(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'mynn_3d_qsq'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%qsq(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'mynn_3d_cov'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Tbd%cov(:,:)
     endif
 
     ! Radar-derived microphysics temperature tendencies
     if (Model%num_dfi_radar > 0) then
       do itime=1,Model%dfi_radar_max_intervals
         if(Model%ix_dfi_radar(itime)>0) then
-          num = num + 1
+          idx = idx + 1
           if(itime==1) then
-            Restart(num)%name = 'radar_tten'
+            Restart(idx)%name = 'radar_tten'
           else
-            write(Restart(num)%name,'("radar_tten_",I0)') itime
+            write(Restart(idx)%name,'("radar_tten_",I0)') itime
           endif
-          Restart(num)%axes = 3
-          Restart(num)%data(1)%var3 => Tbd%dfi_radar_tten(:,:,Model%ix_dfi_radar(itime))
+          Restart(idx)%axes = 3
+          Restart(idx)%data%var3 => Tbd%dfi_radar_tten(:,:,Model%ix_dfi_radar(itime))
         endif
       enddo
     endif
 
     if(Model%rrfs_sd) then
-      num = num + 1
-      Restart(num)%name = 'chem3d_1'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Coupling%chem3d(:,:,1)
-      num = num + 1
-      Restart(num)%name = 'chem3d_2'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Coupling%chem3d(:,:,2)
-      num = num + 1
-      Restart(num)%name = 'chem3d_3'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Coupling%chem3d(:,:,3)
-      num = num + 1
-      Restart(num)%name = 'ext550'
-      Restart(num)%axes = 3
-      Restart(num)%data(1)%var3 => Radtend%ext550(:,:)
+      idx = idx + 1
+      Restart(idx)%name = 'chem3d_1'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Coupling%chem3d(:,:,1)
+      idx = idx + 1
+      Restart(idx)%name = 'chem3d_2'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Coupling%chem3d(:,:,2)
+      idx = idx + 1
+      Restart(idx)%name = 'chem3d_3'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Coupling%chem3d(:,:,3)
+      idx = idx + 1
+      Restart(idx)%name = 'ext550'
+      Restart(idx)%axes = 3
+      Restart(idx)%data%var3 => Radtend%ext550(:,:)
     endif
 
   end subroutine GFS_restart_populate

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,6 +65,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,6 +65,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_flake.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_flake.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -68,7 +68,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_flake.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_flake.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -66,6 +66,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_flake.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_flake.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -68,7 +68,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_flake.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_flake.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_ras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_ras.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_ras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_ras.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,6 +65,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_ras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_ras.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_ras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_ras.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,6 +62,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,6 +61,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,6 +62,10 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,6 +61,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,6 +62,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,6 +63,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,7 +65,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,7 +65,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmgp_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>GFS_rrtmgp_cloud_mp</scheme>
@@ -26,7 +25,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
@@ -24,7 +24,7 @@
       <scheme>GFS_rrtmgp_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
@@ -24,7 +24,7 @@
       <scheme>GFS_rrtmgp_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,6 +61,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
@@ -24,7 +24,7 @@
       <scheme>GFS_rrtmgp_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,6 +61,10 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,6 +65,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,7 +65,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,6 +63,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,7 +65,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_c3.xml
+++ b/ccpp/suites/suite_FV3_HRRR_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_c3.xml
+++ b/ccpp/suites/suite_FV3_HRRR_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_c3.xml
+++ b/ccpp/suites/suite_FV3_HRRR_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_c3.xml
+++ b/ccpp/suites/suite_FV3_HRRR_c3.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -55,6 +55,10 @@
       <scheme>mynnedmf_wrapper</scheme>
       <scheme>rrfs_smoke_postpbl</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -57,7 +57,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -57,7 +57,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP.xml
+++ b/ccpp/suites/suite_FV3_RAP.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP.xml
+++ b/ccpp/suites/suite_FV3_RAP.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP.xml
+++ b/ccpp/suites/suite_FV3_RAP.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP.xml
+++ b/ccpp/suites/suite_FV3_RAP.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_clm_lake.xml
+++ b/ccpp/suites/suite_FV3_RAP_clm_lake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_clm_lake.xml
+++ b/ccpp/suites/suite_FV3_RAP_clm_lake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_clm_lake.xml
+++ b/ccpp/suites/suite_FV3_RAP_clm_lake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_clm_lake.xml
+++ b/ccpp/suites/suite_FV3_RAP_clm_lake.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_flake.xml
+++ b/ccpp/suites/suite_FV3_RAP_flake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_flake.xml
+++ b/ccpp/suites/suite_FV3_RAP_flake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_flake.xml
+++ b/ccpp/suites/suite_FV3_RAP_flake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_flake.xml
+++ b/ccpp/suites/suite_FV3_RAP_flake.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
+++ b/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
+++ b/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
+++ b/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
+++ b/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1beta.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1beta.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1beta.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1beta.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_MP_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_WoFS_v0.xml
+++ b/ccpp/suites/suite_FV3_WoFS_v0.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_MP_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_WoFS_v0.xml
+++ b/ccpp/suites/suite_FV3_WoFS_v0.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_WoFS_v0.xml
+++ b/ccpp/suites/suite_FV3_WoFS_v0.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_WoFS_v0.xml
+++ b/ccpp/suites/suite_FV3_WoFS_v0.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_global_nest_v1.xml
+++ b/ccpp/suites/suite_FV3_global_nest_v1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_global_nest_v1.xml
+++ b/ccpp/suites/suite_FV3_global_nest_v1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_global_nest_v1.xml
+++ b/ccpp/suites/suite_FV3_global_nest_v1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_global_nest_v1.xml
+++ b/ccpp/suites/suite_FV3_global_nest_v1.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFS_sas.xml
+++ b/ccpp/suites/suite_RRFS_sas.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFS_sas.xml
+++ b/ccpp/suites/suite_RRFS_sas.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFS_sas.xml
+++ b/ccpp/suites/suite_RRFS_sas.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFS_sas.xml
+++ b/ccpp/suites/suite_RRFS_sas.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFS_sas_nogwd.xml
+++ b/ccpp/suites/suite_RRFS_sas_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -55,6 +55,10 @@
       <scheme>mynnedmf_wrapper</scheme>
       <scheme>rrfs_smoke_postpbl</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFS_sas_nogwd.xml
+++ b/ccpp/suites/suite_RRFS_sas_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -57,7 +57,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFS_sas_nogwd.xml
+++ b/ccpp/suites/suite_RRFS_sas_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -57,7 +57,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFS_sas_nogwd.xml
+++ b/ccpp/suites/suite_RRFS_sas_nogwd.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFSens_phy1.xml
+++ b/ccpp/suites/suite_RRFSens_phy1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy1.xml
+++ b/ccpp/suites/suite_RRFSens_phy1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy1.xml
+++ b/ccpp/suites/suite_RRFSens_phy1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy1.xml
+++ b/ccpp/suites/suite_RRFSens_phy1.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFSens_phy2.xml
+++ b/ccpp/suites/suite_RRFSens_phy2.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy2.xml
+++ b/ccpp/suites/suite_RRFSens_phy2.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -56,6 +56,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy2.xml
+++ b/ccpp/suites/suite_RRFSens_phy2.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy2.xml
+++ b/ccpp/suites/suite_RRFSens_phy2.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFSens_phy3.xml
+++ b/ccpp/suites/suite_RRFSens_phy3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy3.xml
+++ b/ccpp/suites/suite_RRFSens_phy3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -56,6 +56,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy3.xml
+++ b/ccpp/suites/suite_RRFSens_phy3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy3.xml
+++ b/ccpp/suites/suite_RRFSens_phy3.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFSens_phy4.xml
+++ b/ccpp/suites/suite_RRFSens_phy4.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy4.xml
+++ b/ccpp/suites/suite_RRFSens_phy4.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy4.xml
+++ b/ccpp/suites/suite_RRFSens_phy4.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy4.xml
+++ b/ccpp/suites/suite_RRFSens_phy4.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFSens_phy5.xml
+++ b/ccpp/suites/suite_RRFSens_phy5.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy5.xml
+++ b/ccpp/suites/suite_RRFSens_phy5.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -56,6 +56,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy5.xml
+++ b/ccpp/suites/suite_RRFSens_phy5.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy5.xml
+++ b/ccpp/suites/suite_RRFSens_phy5.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/io/fv3atm_history_io.F90
+++ b/io/fv3atm_history_io.F90
@@ -245,7 +245,7 @@ CONTAINS
             endif
           endif
         else if (diag(idx)%axes == 3) then
-          hist%levo(idx) = size(Diag(idx)%data(1)%var3, dim=2)
+          hist%levo(idx) = size(Diag(idx)%data%var3, dim=2)
           if( index(trim(diag(idx)%intpl_method),'bilinear') > 0 ) then
             hist%nstt(idx) = nrgst_bl + 1
             nrgst_bl  = nrgst_bl + hist%levo(idx)
@@ -337,7 +337,7 @@ CONTAINS
         endif
         if_2d: if (diag(idx)%axes == 2) then
           ! Integer data
-          int_or_real: if (associated(Diag(idx)%data(1)%int2)) then
+          int_or_real: if (associated(Diag(idx)%data%int2)) then
             if (trim(Diag(idx)%intpl_method) == 'nearest_stod') then
               var2(1:nx,1:ny) = 0._kind_phys
               do j = 1, ny
@@ -347,9 +347,9 @@ CONTAINS
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
                   im = Model%chunk_begin(nb)+ix-1
-                  var2(i,j) = real(Diag(idx)%data(1)%int2(im), kind=kind_phys)
+                  var2(i,j) = real(Diag(idx)%data%int2(im), kind=kind_phys)
                 enddo
-             enddo
+              enddo
               call hist%store_data(Diag(idx)%id, var2, Time, idx, Diag(idx)%intpl_method, Diag(idx)%name)
             else
               call mpp_error(FATAL, 'Interpolation method ' // trim(Diag(idx)%intpl_method) // ' for integer variable ' &
@@ -367,8 +367,8 @@ CONTAINS
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
                   im = Model%chunk_begin(nb)+ix-1
-                  if (Diag(idx)%data(1)%var21(im) > 0._kind_phys) &
-                       var2(i,j) = max(0._kind_phys,min(1._kind_phys,Diag(idx)%data(1)%var2(im)/Diag(idx)%data(1)%var21(im)))*lcnvfac
+                  if (Diag(idx)%data%var21(im) > 0._kind_phys) &
+                       var2(i,j) = max(0._kind_phys,min(1._kind_phys,Diag(idx)%data%var2(im)/Diag(idx)%data%var21(im)))*lcnvfac
                 enddo
               enddo
             elseif (trim(Diag(idx)%mask) == 'land_ice_only') then
@@ -381,7 +381,7 @@ CONTAINS
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
                   im = Model%chunk_begin(nb)+ix-1
-                  if (Diag(idx)%data(1)%var21(im) /= 0) var2(i,j) = Diag(idx)%data(1)%var2(im)*lcnvfac
+                  if (Diag(idx)%data%var21(im) /= 0) var2(i,j) = Diag(idx)%data%var2(im)*lcnvfac
                 enddo
               enddo
             elseif (trim(Diag(idx)%mask) == 'land_only') then
@@ -394,7 +394,7 @@ CONTAINS
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
                   im = Model%chunk_begin(nb)+ix-1
-                  if (Diag(idx)%data(1)%var21(im) == 1) var2(i,j) = Diag(idx)%data(1)%var2(im)*lcnvfac
+                  if (Diag(idx)%data%var21(im) == 1) var2(i,j) = Diag(idx)%data%var2(im)*lcnvfac
                 enddo
               enddo
             elseif (trim(Diag(idx)%mask) == 'cldmask') then
@@ -407,7 +407,7 @@ CONTAINS
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
                   im = Model%chunk_begin(nb)+ix-1
-                  if (Diag(idx)%data(1)%var21(im)*100. > 0.5) var2(i,j) = Diag(idx)%data(1)%var2(im)*lcnvfac
+                  if (Diag(idx)%data%var21(im)*100. > 0.5) var2(i,j) = Diag(idx)%data%var2(im)*lcnvfac
                 enddo
               enddo
             elseif (trim(Diag(idx)%mask) == 'cldmask_ratio') then
@@ -420,8 +420,8 @@ CONTAINS
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
                   im = Model%chunk_begin(nb)+ix-1
-                  if (Diag(idx)%data(1)%var21(im)*100.*lcnvfac > 0.5) var2(i,j) = Diag(idx)%data(1)%var2(im)/ &
-                       Diag(idx)%data(1)%var21(im)
+                  if (Diag(idx)%data%var21(im)*100.*lcnvfac > 0.5) var2(i,j) = Diag(idx)%data%var2(im)/ &
+                       Diag(idx)%data%var21(im)
                 enddo
               enddo
             elseif (trim(Diag(idx)%mask) == 'pseudo_ps') then
@@ -433,7 +433,7 @@ CONTAINS
                     nb = Atm_block%blkno(ii,jj)
                     ix = Atm_block%ixp(ii,jj)
                     im = Model%chunk_begin(nb)+ix-1
-                    var2(i,j) = (Diag(idx)%data(1)%var2(im)/stndrd_atmos_ps)**(rdgas/grav*stndrd_atmos_lapse)
+                    var2(i,j) = (Diag(idx)%data%var2(im)/stndrd_atmos_ps)**(rdgas/grav*stndrd_atmos_lapse)
                   enddo
                 enddo
               else
@@ -444,7 +444,7 @@ CONTAINS
                     nb = Atm_block%blkno(ii,jj)
                     ix = Atm_block%ixp(ii,jj)
                     im = Model%chunk_begin(nb)+ix-1
-                    var2(i,j) = Diag(idx)%data(1)%var2(im)
+                    var2(i,j) = Diag(idx)%data%var2(im)
                   enddo
                 enddo
               endif
@@ -456,7 +456,7 @@ CONTAINS
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
                   im = Model%chunk_begin(nb)+ix-1
-                  var2(i,j) = Diag(idx)%data(1)%var2(im)*lcnvfac
+                  var2(i,j) = Diag(idx)%data%var2(im)*lcnvfac
                 enddo
               enddo
            endif if_mask
@@ -482,9 +482,9 @@ CONTAINS
                 im = Model%chunk_begin(nb)+ix-1
                 ! flip only 3d variables with vertical dimension == levs (atm model levels)
                 if (levo_3d == levs) then
-                  var3(i,j,k) = Diag(idx)%data(1)%var3(im,levo_3d-k+1)*lcnvfac
+                  var3(i,j,k) = Diag(idx)%data%var3(im,levo_3d-k+1)*lcnvfac
                 else
-                  var3(i,j,k) = Diag(idx)%data(1)%var3(im,        k  )*lcnvfac
+                  var3(i,j,k) = Diag(idx)%data%var3(im,        k  )*lcnvfac
                 endif
               enddo
             enddo

--- a/io/fv3atm_history_io.F90
+++ b/io/fv3atm_history_io.F90
@@ -115,11 +115,12 @@ CONTAINS
   !! This routine transfers diagnostic data to the FMS diagnostic
   !!  manager for eventual output to the history files.
   subroutine fv3atm_diag_output(time, diag, atm_block, nx, ny, levs, ntcw, ntoz, &
-       dt, time_int, time_intfull, time_radsw, time_radlw)
+       dt, time_int, time_intfull, time_radsw, time_radlw, Model)
     !--- subroutine interface variable definitions
     type(time_type),           intent(in) :: time
     type(GFS_externaldiag_type),       intent(in) :: diag(:)
     type (block_control_type), intent(in) :: atm_block
+    type(GFS_control_type),    intent(in) :: Model
     integer,                   intent(in) :: nx, ny, levs, ntcw, ntoz
     real(kind=kind_phys),      intent(in) :: dt
     real(kind=kind_phys),      intent(in) :: time_int
@@ -128,7 +129,7 @@ CONTAINS
     real(kind=kind_phys),      intent(in) :: time_radlw
 
     call shared_history_data%output(time, diag, atm_block, nx, ny, levs, ntcw, ntoz, &
-         dt, time_int, time_intfull, time_radsw, time_radlw)
+         dt, time_int, time_intfull, time_radsw, time_radlw, Model)
 
   end subroutine fv3atm_diag_output
 
@@ -282,12 +283,13 @@ CONTAINS
   !! implementation of the public fv3atm_diag_output routine. Never
   !! call this directly.
   subroutine history_type_output(hist, time, diag, atm_block, nx, ny, levs, ntcw, ntoz, &
-       dt, time_int, time_intfull, time_radsw, time_radlw)
+       dt, time_int, time_intfull, time_radsw, time_radlw, Model)
     !--- subroutine interface variable definitions
     class(history_type)                   :: hist
     type(time_type),           intent(in) :: time
     type(GFS_externaldiag_type),       intent(in) :: diag(:)
     type (block_control_type), intent(in) :: atm_block
+    type(GFS_control_type),    intent(in) :: Model
     integer,                   intent(in) :: nx, ny, levs, ntcw, ntoz
     real(kind=kind_phys),      intent(in) :: dt
     real(kind=kind_phys),      intent(in) :: time_int
@@ -295,7 +297,7 @@ CONTAINS
     real(kind=kind_phys),      intent(in) :: time_radsw
     real(kind=kind_phys),      intent(in) :: time_radlw
     !--- local variables
-    integer :: i, j, k, idx, nb, ix, ii, jj, levo_3d
+    integer :: i, j, k, idx, nb, ix, ii, jj, levo_3d, im
     character(len=2) :: xtra
 #ifdef CCPP_32BIT
     real, dimension(nx,ny)      :: var2
@@ -344,9 +346,10 @@ CONTAINS
                   ii = i + Atm_block%isc -1
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
-                  var2(i,j) = real(Diag(idx)%data(nb)%int2(ix), kind=kind_phys)
+                  im = Model%chunk_begin(nb)+ix-1
+                  var2(i,j) = real(Diag(idx)%data(1)%int2(im), kind=kind_phys)
                 enddo
-              enddo
+             enddo
               call hist%store_data(Diag(idx)%id, var2, Time, idx, Diag(idx)%intpl_method, Diag(idx)%name)
             else
               call mpp_error(FATAL, 'Interpolation method ' // trim(Diag(idx)%intpl_method) // ' for integer variable ' &
@@ -363,8 +366,9 @@ CONTAINS
                   ii = i + Atm_block%isc -1
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
-                  if (Diag(idx)%data(nb)%var21(ix) > 0._kind_phys) &
-                       var2(i,j) = max(0._kind_phys,min(1._kind_phys,Diag(idx)%data(nb)%var2(ix)/Diag(idx)%data(nb)%var21(ix)))*lcnvfac
+                  im = Model%chunk_begin(nb)+ix-1
+                  if (Diag(idx)%data(1)%var21(im) > 0._kind_phys) &
+                       var2(i,j) = max(0._kind_phys,min(1._kind_phys,Diag(idx)%data(1)%var2(im)/Diag(idx)%data(1)%var21(im)))*lcnvfac
                 enddo
               enddo
             elseif (trim(Diag(idx)%mask) == 'land_ice_only') then
@@ -376,7 +380,8 @@ CONTAINS
                   ii = i + Atm_block%isc -1
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
-                  if (Diag(idx)%data(nb)%var21(ix) /= 0) var2(i,j) = Diag(idx)%data(nb)%var2(ix)*lcnvfac
+                  im = Model%chunk_begin(nb)+ix-1
+                  if (Diag(idx)%data(1)%var21(im) /= 0) var2(i,j) = Diag(idx)%data(1)%var2(im)*lcnvfac
                 enddo
               enddo
             elseif (trim(Diag(idx)%mask) == 'land_only') then
@@ -388,7 +393,8 @@ CONTAINS
                   ii = i + Atm_block%isc -1
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
-                  if (Diag(idx)%data(nb)%var21(ix) == 1) var2(i,j) = Diag(idx)%data(nb)%var2(ix)*lcnvfac
+                  im = Model%chunk_begin(nb)+ix-1
+                  if (Diag(idx)%data(1)%var21(im) == 1) var2(i,j) = Diag(idx)%data(1)%var2(im)*lcnvfac
                 enddo
               enddo
             elseif (trim(Diag(idx)%mask) == 'cldmask') then
@@ -400,7 +406,8 @@ CONTAINS
                   ii = i + Atm_block%isc -1
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
-                  if (Diag(idx)%data(nb)%var21(ix)*100. > 0.5) var2(i,j) = Diag(idx)%data(nb)%var2(ix)*lcnvfac
+                  im = Model%chunk_begin(nb)+ix-1
+                  if (Diag(idx)%data(1)%var21(im)*100. > 0.5) var2(i,j) = Diag(idx)%data(1)%var2(im)*lcnvfac
                 enddo
               enddo
             elseif (trim(Diag(idx)%mask) == 'cldmask_ratio') then
@@ -412,8 +419,9 @@ CONTAINS
                   ii = i + Atm_block%isc -1
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
-                  if (Diag(idx)%data(nb)%var21(ix)*100.*lcnvfac > 0.5) var2(i,j) = Diag(idx)%data(nb)%var2(ix)/ &
-                       Diag(idx)%data(nb)%var21(ix)
+                  im = Model%chunk_begin(nb)+ix-1
+                  if (Diag(idx)%data(1)%var21(im)*100.*lcnvfac > 0.5) var2(i,j) = Diag(idx)%data(1)%var2(im)/ &
+                       Diag(idx)%data(1)%var21(im)
                 enddo
               enddo
             elseif (trim(Diag(idx)%mask) == 'pseudo_ps') then
@@ -424,7 +432,8 @@ CONTAINS
                     ii = i + Atm_block%isc -1
                     nb = Atm_block%blkno(ii,jj)
                     ix = Atm_block%ixp(ii,jj)
-                    var2(i,j) = (Diag(idx)%data(nb)%var2(ix)/stndrd_atmos_ps)**(rdgas/grav*stndrd_atmos_lapse)
+                    im = Model%chunk_begin(nb)+ix-1
+                    var2(i,j) = (Diag(idx)%data(1)%var2(im)/stndrd_atmos_ps)**(rdgas/grav*stndrd_atmos_lapse)
                   enddo
                 enddo
               else
@@ -434,7 +443,8 @@ CONTAINS
                     ii = i + Atm_block%isc -1
                     nb = Atm_block%blkno(ii,jj)
                     ix = Atm_block%ixp(ii,jj)
-                    var2(i,j) = Diag(idx)%data(nb)%var2(ix)
+                    im = Model%chunk_begin(nb)+ix-1
+                    var2(i,j) = Diag(idx)%data(1)%var2(im)
                   enddo
                 enddo
               endif
@@ -445,10 +455,11 @@ CONTAINS
                   ii = i + Atm_block%isc -1
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
-                  var2(i,j) = Diag(idx)%data(nb)%var2(ix)*lcnvfac
+                  im = Model%chunk_begin(nb)+ix-1
+                  var2(i,j) = Diag(idx)%data(1)%var2(im)*lcnvfac
                 enddo
               enddo
-            endif if_mask
+           endif if_mask
           endif int_or_real
 
           call hist%store_data(Diag(idx)%id, var2, Time, idx, Diag(idx)%intpl_method, Diag(idx)%name)
@@ -468,11 +479,12 @@ CONTAINS
                 ii = i + Atm_block%isc -1
                 nb = Atm_block%blkno(ii,jj)
                 ix = Atm_block%ixp(ii,jj)
+                im = Model%chunk_begin(nb)+ix-1
                 ! flip only 3d variables with vertical dimension == levs (atm model levels)
                 if (levo_3d == levs) then
-                  var3(i,j,k) = Diag(idx)%data(nb)%var3(ix,levo_3d-k+1)*lcnvfac
+                  var3(i,j,k) = Diag(idx)%data(1)%var3(im,levo_3d-k+1)*lcnvfac
                 else
-                  var3(i,j,k) = Diag(idx)%data(nb)%var3(ix,        k  )*lcnvfac
+                  var3(i,j,k) = Diag(idx)%data(1)%var3(im,        k  )*lcnvfac
                 endif
               enddo
             enddo

--- a/io/fv3atm_restart_io.F90
+++ b/io/fv3atm_restart_io.F90
@@ -1293,7 +1293,7 @@ contains
        if(present(restart_output)) then
           if(Model%phour < 1.e-7) then
              do ivar = 1,size(GFS_restart(:)%axes)
-                if (GFS_restart(ivar)%reset == .true.) then
+                if (GFS_restart(ivar)%reset) then
                    !$omp parallel do default(shared) private(i, j, nb, ix, im)
                    do nb = 1,Atm_block%nblks
                       do ix = 1, Atm_block%blksz(nb)

--- a/io/fv3atm_restart_io.F90
+++ b/io/fv3atm_restart_io.F90
@@ -950,7 +950,7 @@ contains
     call read_restart(Phy_restart, ignore_checksum=ignore_rst_cksum)
     call close_file(Phy_restart)
 
-    call phy%transfer_data(.true., GFS_Restart, Atm_block, Model)
+    call phy%transfer_data(.true., GFS_Restart, Atm_block, Model, .true.)
 
   end subroutine phys_restart_read
 
@@ -963,10 +963,10 @@ contains
     implicit none
     !--- interface variable definitions
     type(GFS_restart_type),      intent(inout) :: GFS_Restart(:)
-    type(block_control_type),    intent(in) :: Atm_block
-    type(GFS_control_type),      intent(in) :: Model
-    type(domain2d),              intent(in) :: fv_domain
-    character(len=32), optional, intent(in) :: timestamp
+    type(block_control_type),    intent(in   ) :: Atm_block
+    type(GFS_control_type),      intent(in   ) :: Model
+    type(domain2d),              intent(in   ) :: fv_domain
+    character(len=32), optional, intent(in   ) :: timestamp
     !--- local variables
     integer :: i, j, k, nb, ix, num2, num3
     integer :: isc, iec, jsc, jec, nx, ny
@@ -1054,7 +1054,7 @@ contains
     nullify(var2_p)
     nullify(var3_p)
 
-    call phy%transfer_data(.false., GFS_Restart, Atm_block, Model)
+    call phy%transfer_data(.false., GFS_Restart, Atm_block, Model, .false.)
 
     call write_restart(Phy_restart)
     call close_file(Phy_restart)
@@ -1100,10 +1100,10 @@ contains
     implicit none
 
     type(GFS_restart_type),   intent(inout) :: GFS_Restart(:)
-    type(block_control_type), intent(in)    :: Atm_block
-    type(GFS_control_type),   intent(in)    :: Model
+    type(block_control_type), intent(in   ) :: Atm_block
+    type(GFS_control_type),   intent(in   ) :: Model
 
-    call phy_quilt%transfer_data(.false., GFS_Restart, Atm_block, Model, restart_output=.true.)
+    call phy_quilt%transfer_data(.false., GFS_Restart, Atm_block, Model, .false.)
 
   end subroutine fv_phy_restart_output
 
@@ -1273,7 +1273,7 @@ contains
   !! direction of the copy. For reading=.true., data is copied from the temporary arrays to the
   !! model grid (during restart read). For reading=.false., data is copied from the model grid to
   !! temporary arrays (for writing the restart).
-  subroutine phy_data_transfer_data(phy, reading, GFS_Restart, Atm_block, Model, restart_output)
+  subroutine phy_data_transfer_data(phy, reading, GFS_Restart, Atm_block, Model, reset_diag)
     use mpp_mod,            only: FATAL, mpp_error
     implicit none
     class(phy_data_type) :: phy
@@ -1281,7 +1281,7 @@ contains
     type(GFS_restart_type), intent(inout) :: GFS_Restart(:)
     type(block_control_type) :: Atm_block
     type(GFS_control_type), intent(in) :: Model
-    logical, optional, intent(in) :: restart_output
+    logical, intent(in) :: reset_diag
 
     integer :: i, j, k, ivar, nb, ix, im, num2, num3
 
@@ -1311,8 +1311,10 @@ contains
                    j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
                    GFS_Restart(ivar)%data%var2(im) = phy%var2(i,j,num2)
                    !--- if restart from init time, reset accumulated diag fields
-                   if (GFS_restart(ivar)%reset .and. (present(restart_output)) .and. Model%phour < 1.e-7) then
-                      GFS_Restart(ivar)%data%var2(im) = zero
+                   if (reset_diag) then
+                      if (GFS_restart(ivar)%reset .and. Model%phour < 1.e-7) then
+                         GFS_Restart(ivar)%data%var2(im) = zero
+                      endif
                    endif
                 enddo
              enddo

--- a/io/fv3atm_restart_io.F90
+++ b/io/fv3atm_restart_io.F90
@@ -842,13 +842,13 @@ contains
   subroutine phys_restart_read (GFS_Restart, Atm_block, Model, fv_domain, ignore_rst_cksum)
     implicit none
     !--- interface variable definitions
-    type(GFS_restart_type),      intent(in) :: GFS_Restart(:)
+    type(GFS_restart_type),      intent(inout) :: GFS_Restart(:)
     type(block_control_type),    intent(in) :: Atm_block
     type(GFS_control_type),      intent(in) :: Model
     type(domain2d),              intent(in) :: fv_domain
     logical,                     intent(in) :: ignore_rst_cksum
     !--- local variables
-    integer :: i, j, k, nb, ix, num, nvar
+    integer :: i, j, k, nb, ix, num2, num3, ivar
     integer :: isc, iec, jsc, jec, nx, ny
     character(len=64) :: fname
     real(kind=kind_phys), pointer, dimension(:,:)   :: var2_p => NULL()
@@ -884,17 +884,19 @@ contains
 
     !--- register the restart fields
     if(was_allocated) then
-
-      nvar = size(GFS_Restart(:)%axes)
-      do num = 1,nvar
-         if (GFS_Restart(num)%axes == 2) then
-            var2_p => phy%var2(:,:,num)
-            call register_restart_field(Phy_restart, trim(GFS_Restart(num)%name), var2_p, &
+       num2 = 0
+       num3 = 0
+       do ivar = 1,size(GFS_Restart(:)%axes)
+          num2 = num2 + 1
+          if (GFS_Restart(ivar)%axes == 2) then
+            var2_p => phy%var2(:,:,num2)
+            call register_restart_field(Phy_restart, trim(GFS_Restart(ivar)%name), var2_p, &
                  dimensions=(/'xaxis_1','yaxis_1','Time   '/), is_optional=.true.)
          end if
-         if (GFS_Restart(num)%axes == 3) then
-            var3_p => phy%var3(:,:,:,num)
-            call register_restart_field(Phy_restart, trim(GFS_restart(num)%name), var3_p, &
+         if (GFS_Restart(ivar)%axes == 3) then
+            num3 = num3 + 1
+            var3_p => phy%var3(:,:,:,num3)
+            call register_restart_field(Phy_restart, trim(GFS_restart(ivar)%name), var3_p, &
                  dimensions=(/'xaxis_1','yaxis_1','zaxis_1','Time   '/), is_optional=.true.)
          end if
       enddo
@@ -919,18 +921,18 @@ contains
   subroutine phys_restart_write (GFS_Restart, Atm_block, Model, fv_domain, timestamp)
     implicit none
     !--- interface variable definitions
-    type(GFS_restart_type),      intent(in) :: GFS_Restart(:)
+    type(GFS_restart_type),      intent(inout) :: GFS_Restart(:)
     type(block_control_type),    intent(in) :: Atm_block
     type(GFS_control_type),      intent(in) :: Model
     type(domain2d),              intent(in) :: fv_domain
     character(len=32), optional, intent(in) :: timestamp
     !--- local variables
-    integer :: i, j, k, nb, ix, num
+    integer :: i, j, k, nb, ix, num2, num3
     integer :: isc, iec, jsc, jec, nx, ny
     real(kind=kind_phys), pointer, dimension(:,:)   :: var2_p => NULL()
     real(kind=kind_phys), pointer, dimension(:,:,:) :: var3_p => NULL()
     !--- used for axis data for fms2_io
-    integer :: is, ie, nvar
+    integer :: is, ie, ivar
     integer, allocatable, dimension(:) :: buffer
     character(7) :: indir='RESTART'
     character(72) :: infile
@@ -990,17 +992,20 @@ contains
       call mpp_error(FATAL, 'Error opening file '//trim(infile))
     end if
 
-    nvar = size(GFS_restart(:)%axes)
-    do num = 1,nvar
-       if (GFS_Restart(num)%axes == 2) then
-          var2_p => phy%var2(:,:,num)
-          call register_restart_field(Phy_restart, trim(GFS_Restart(num)%name), var2_p, &
+    num2 = 0
+    num3 = 0
+    do ivar = 1,size(GFS_restart(:)%axes)
+       if (GFS_Restart(ivar)%axes == 2) then
+          num2 = num2 + 1
+          var2_p => phy%var2(:,:,num2)
+          call register_restart_field(Phy_restart, trim(GFS_Restart(ivar)%name), var2_p, &
                dimensions=(/'xaxis_1','yaxis_1','Time   '/),&
                chunksizes=(/xaxis_1_chunk,yaxis_1_chunk,1/), is_optional=.true.)
        endif
-       if (GFS_Restart(num)%axes == 3) then
-          var3_p => phy%var3(:,:,:,num)
-          call register_restart_field(Phy_restart, trim(GFS_Restart(num)%name), var3_p,&
+       if (GFS_Restart(ivar)%axes == 3) then
+          num3 = num3 + 1
+          var3_p => phy%var3(:,:,:,num3)
+          call register_restart_field(Phy_restart, trim(GFS_Restart(ivar)%name), var3_p,&
                dimensions=(/'xaxis_1','yaxis_1','zaxis_1','Time   '/),&
                chunksizes=(/xaxis_1_chunk,yaxis_1_chunk,1,1/), is_optional=.true.)
        endif
@@ -1049,14 +1054,15 @@ contains
   end subroutine fv3atm_restart_register
 
   !>@Copies physics restart fields from write component data structures to the model grid.
-  subroutine fv_phy_restart_output(GFS_Restart, Atm_block)
+  subroutine fv_phy_restart_output(GFS_Restart, Atm_block, Model)
 
     implicit none
 
-    type(GFS_restart_type),      intent(in) :: GFS_Restart(:)
-    type(block_control_type),    intent(in) :: Atm_block
+    type(GFS_restart_type),   intent(inout) :: GFS_Restart(:)
+    type(block_control_type), intent(in)    :: Atm_block
+    type(GFS_control_type),   intent(in)    :: Model
 
-    call phy_quilt%transfer_data(.false., GFS_Restart, Atm_block)
+    call phy_quilt%transfer_data(.false., GFS_Restart, Atm_block, Model, restart_output=.true.)
 
   end subroutine fv_phy_restart_output
 
@@ -1181,7 +1187,7 @@ contains
     type(GFS_restart_type),      intent(in) :: GFS_Restart(:)
     type(block_control_type),    intent(in) :: Atm_block
 
-    integer :: nx, ny, ivar, num1, num2
+    integer :: nx, ny, ivar, num2, num3
 
     phy_data_alloc = .false.
 
@@ -1200,21 +1206,20 @@ contains
        if (GFS_restart(ivar)%axes == 2) phy%nvar2d = phy%nvar2d + 1
        if (GFS_restart(ivar)%axes == 3) phy%nvar3d = phy%nvar3d + 1
     enddo
-
     allocate (phy%var2(nx,ny,phy%nvar2d), phy%var2_names(phy%nvar2d))
     allocate (phy%var3(nx,ny,phy%npz,phy%nvar3d), phy%var3_names(phy%nvar3d))
     phy%var2 = zero
     phy%var3 = zero
-    num1 = 0
     num2 = 0
+    num3 = 0
     do ivar = 1,size(GFS_restart(:)%axes)
        if (GFS_restart(ivar)%axes == 2) then
-          num1 = num1 + 1
-          phy%var2_names(num1) = trim(GFS_Restart(ivar)%name)
+          num2 = num2 + 1
+          phy%var2_names(num2) = trim(GFS_Restart(ivar)%name)
        end if
        if (GFS_restart(ivar)%axes == 3)	then
-          num2 = num2 + 1
-          phy%var3_names(num2) = trim(GFS_Restart(ivar)%name)
+          num3 = num3 + 1
+          phy%var3_names(num3) = trim(GFS_Restart(ivar)%name)
        endif
     enddo
     phy_data_alloc = .true.
@@ -1227,14 +1232,15 @@ contains
   !! direction of the copy. For reading=.true., data is copied from the temporary arrays to the
   !! model grid (during restart read). For reading=.false., data is copied from the model grid to
   !! temporary arrays (for writing the restart).
-  subroutine phy_data_transfer_data(phy, reading, GFS_Restart, Atm_block, Model)
+  subroutine phy_data_transfer_data(phy, reading, GFS_Restart, Atm_block, Model, restart_output)
     use mpp_mod,            only: FATAL, mpp_error
     implicit none
     class(phy_data_type) :: phy
     logical, intent(in) :: reading
-    type(GFS_restart_type) :: GFS_Restart(:)
+    type(GFS_restart_type), intent(inout) :: GFS_Restart(:)
     type(block_control_type) :: Atm_block
-    type(GFS_control_type), optional, intent(in) :: Model
+    type(GFS_control_type), intent(in) :: Model
+    logical, optional, intent(in) :: restart_output
 
     integer :: i, j, k, ivar, nb, ix, im, num2, num3
 
@@ -1248,7 +1254,7 @@ contains
       return ! should never get here
     endif
 
-    !--- place the data into the contiguous GFS containers
+    !--- place the data into the contiguous GFS containers.
     if(reading) then
        ! 2D
        num2 = 0
@@ -1256,29 +1262,27 @@ contains
        do ivar = 1,size(GFS_restart(:)%axes)
           if (GFS_restart(ivar)%axes == 2) then
              num2 = num2 + 1
-             print*,'SWALES Reading 2D variable: ',trim(GFS_restart(ivar)%name)
-             !$omp parallel do default(shared) private(i, j, nb, ix, im, ivar, num2)
+             !$omp parallel do default(shared) private(i, j, nb, ix, im)
              do nb = 1,Atm_block%nblks
                 do ix = 1, Atm_block%blksz(nb)
                    im = Model%chunk_begin(nb)+ix-1
                    i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
                    j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-                   GFS_Restart(ivar)%data(1)%var2(im) = phy%var2(i,j,num2)
+                   GFS_Restart(ivar)%data%var2(im) = phy%var2(i,j,num2)
                 enddo
              enddo
           endif
           ! 3D
           if (GFS_restart(ivar)%axes == 3) then
              num3 = num3 + 1
-             print*,'SWALES Reading 3D variable: ',trim(GFS_restart(ivar)%name)
-             !$omp parallel do default(shared) private(i, j, k, nb, ix, im, ivar, num3)
+             !$omp parallel do default(shared) private(i, j, k, nb, ix, im)
              do nb = 1,Atm_block%nblks
                 do k=1,phy%npz
                    do ix = 1, Atm_block%blksz(nb)
                       im = Model%chunk_begin(nb)+ix-1
                       i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
                       j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-                      GFS_Restart(ivar)%data(1)%var3(im,k) = phy%var3(i,j,k,num3)
+                      GFS_Restart(ivar)%data%var3(im,k) = phy%var3(i,j,k,num3)
                    enddo
                 enddo
              enddo
@@ -1292,29 +1296,27 @@ contains
           ! 2D
           if (GFS_restart(ivar)%axes == 2) then
              num2 = num2 + 1
-             print*,'SWALES Writing 2D variable: ',trim(GFS_restart(ivar)%name)
-             !$omp parallel do default(shared) private(i, j, nb, ix, im, ivar, num2)
+             !$omp parallel do default(shared) private(i, j, nb, ix, im)
              do nb = 1,Atm_block%nblks
                 do ix = 1, Atm_block%blksz(nb)
                    im = Model%chunk_begin(nb)+ix-1
                    i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
                    j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-                   phy%var2(i,j,num2) = GFS_Restart(ivar)%data(1)%var2(im)
+                   phy%var2(i,j,num2) = GFS_Restart(ivar)%data%var2(im)
                 enddo
              enddo
           endif
           ! 3D
           if (GFS_restart(ivar)%axes == 3) then
              num3 = num3 + 1
-             print*,'SWALES Writing 3D variable: ',trim(GFS_restart(ivar)%name)
-             !$omp parallel do default(shared) private(i, j, k, nb, ix, im, ivar, num3)
+             !$omp parallel do default(shared) private(i, j, k, nb, ix, im)
              do nb = 1,Atm_block%nblks
                 do k=1,phy%npz
                    do ix = 1, Atm_block%blksz(nb)
                       im = Model%chunk_begin(nb)+ix-1
                       i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
                       j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-                      phy%var3(i,j,k,num3) = GFS_Restart(ivar)%data(1)%var3(im,k)
+                      phy%var3(i,j,k,num3) = GFS_Restart(ivar)%data%var3(im,k)
                    enddo
                 enddo
              enddo
@@ -1323,7 +1325,7 @@ contains
     endif
 
     !--- if restart from init time, reset accumulated diag fields
-    if(reading .and. present(Model)) then
+    if(reading .and. present(restart_output)) then
        if(Model%phour < 1.e-7) then
           do ivar = 1,size(GFS_restart(:)%axes)
              if (GFS_restart(ivar)%reset == .true.) then
@@ -1333,7 +1335,7 @@ contains
                       im = Model%chunk_begin(nb)+ix-1
                       i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
                       j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-                      GFS_Restart(ivar)%data(1)%var2(im) = zero
+                      GFS_Restart(ivar)%data%var2(im) = zero
                    enddo
                 enddo
              endif

--- a/io/fv3atm_restart_io.F90
+++ b/io/fv3atm_restart_io.F90
@@ -1269,6 +1269,10 @@ contains
                    i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
                    j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
                    GFS_Restart(ivar)%data%var2(im) = phy%var2(i,j,num2)
+                   !--- if restart from init time, reset accumulated diag fields
+                   if (GFS_restart(ivar)%reset .and. (present(restart_output)) .and. Model%phour < 1.e-7) then
+                      GFS_Restart(ivar)%data%var2(im) = zero
+                   endif
                 enddo
              enddo
           endif
@@ -1288,25 +1292,6 @@ contains
              enddo
           endif
        enddo
-
-       !--- if restart from init time, reset accumulated diag fields
-       if(present(restart_output)) then
-          if(Model%phour < 1.e-7) then
-             do ivar = 1,size(GFS_restart(:)%axes)
-                if (GFS_restart(ivar)%reset) then
-                   !$omp parallel do default(shared) private(i, j, nb, ix, im)
-                   do nb = 1,Atm_block%nblks
-                      do ix = 1, Atm_block%blksz(nb)
-                         im = Model%chunk_begin(nb)+ix-1
-                         i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
-                         j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-                         GFS_Restart(ivar)%data%var2(im) = zero
-                      enddo
-                   enddo
-                endif
-             enddo
-          endif
-       endif
        
     !--- place the data into the phy%var* variables.
     else

--- a/io/fv3atm_restart_io.F90
+++ b/io/fv3atm_restart_io.F90
@@ -1288,6 +1288,26 @@ contains
              enddo
           endif
        enddo
+
+       !--- if restart from init time, reset accumulated diag fields
+       if(present(restart_output)) then
+          if(Model%phour < 1.e-7) then
+             do ivar = 1,size(GFS_restart(:)%axes)
+                if (GFS_restart(ivar)%reset == .true.) then
+                   !$omp parallel do default(shared) private(i, j, nb, ix, im)
+                   do nb = 1,Atm_block%nblks
+                      do ix = 1, Atm_block%blksz(nb)
+                         im = Model%chunk_begin(nb)+ix-1
+                         i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
+                         j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
+                         GFS_Restart(ivar)%data%var2(im) = zero
+                      enddo
+                   enddo
+                endif
+             enddo
+          endif
+       endif
+       
     !--- place the data into the phy%var* variables.
     else
        num2 = 0
@@ -1322,25 +1342,6 @@ contains
              enddo
           endif
        enddo
-    endif
-
-    !--- if restart from init time, reset accumulated diag fields
-    if(reading .and. present(restart_output)) then
-       if(Model%phour < 1.e-7) then
-          do ivar = 1,size(GFS_restart(:)%axes)
-             if (GFS_restart(ivar)%reset == .true.) then
-                !$omp parallel do default(shared) private(i, j, nb, ix, im)
-                do nb = 1,Atm_block%nblks
-                   do ix = 1, Atm_block%blksz(nb)
-                      im = Model%chunk_begin(nb)+ix-1
-                      i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
-                      j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-                      GFS_Restart(ivar)%data%var2(im) = zero
-                   enddo
-                enddo
-             endif
-          enddo
-       endif
     endif
 
   end subroutine phy_data_transfer_data

--- a/io/fv3atm_restart_io.F90
+++ b/io/fv3atm_restart_io.F90
@@ -103,7 +103,7 @@ contains
   subroutine fv3atm_restart_read (GFS_Sfcprop, GFS_Restart, Atm_block, Model, fv_domain, warm_start, ignore_rst_cksum)
     implicit none
     type(GFS_sfcprop_type),   intent(inout) :: GFS_Sfcprop
-    type(GFS_restart_type),   intent(inout) :: GFS_Restart
+    type(GFS_restart_type),   intent(inout) :: GFS_Restart(:)
     type(block_control_type), intent(in)    :: Atm_block
     type(GFS_control_type),   intent(inout) :: Model
     type(domain2d),           intent(in)    :: fv_domain
@@ -126,7 +126,7 @@ contains
   subroutine fv3atm_restart_write (GFS_Sfcprop, GFS_Restart, Atm_block, Model, fv_domain, timestamp)
     implicit none
     type(GFS_sfcprop_type),      intent(inout) :: GFS_Sfcprop
-    type(GFS_restart_type),      intent(inout) :: GFS_Restart
+    type(GFS_restart_type),      intent(inout) :: GFS_Restart(:)
     type(block_control_type),    intent(in)    :: Atm_block
     type(GFS_control_type),      intent(in)    :: Model
     type(domain2d),              intent(in)    :: fv_domain
@@ -842,13 +842,13 @@ contains
   subroutine phys_restart_read (GFS_Restart, Atm_block, Model, fv_domain, ignore_rst_cksum)
     implicit none
     !--- interface variable definitions
-    type(GFS_restart_type),      intent(in) :: GFS_Restart
+    type(GFS_restart_type),      intent(in) :: GFS_Restart(:)
     type(block_control_type),    intent(in) :: Atm_block
     type(GFS_control_type),      intent(in) :: Model
     type(domain2d),              intent(in) :: fv_domain
     logical,                     intent(in) :: ignore_rst_cksum
     !--- local variables
-    integer :: i, j, k, nb, ix, num
+    integer :: i, j, k, nb, ix, num, nvar
     integer :: isc, iec, jsc, jec, nx, ny
     character(len=64) :: fname
     real(kind=kind_phys), pointer, dimension(:,:)   :: var2_p => NULL()
@@ -885,14 +885,18 @@ contains
     !--- register the restart fields
     if(was_allocated) then
 
-      do num = 1,phy%nvar2d
-        var2_p => phy%var2(:,:,num)
-        call register_restart_field(Phy_restart, trim(GFS_Restart%name2d(num)), var2_p, dimensions=(/'xaxis_1','yaxis_1','Time   '/),&
-             &is_optional=.true.)
-      enddo
-      do num = 1,phy%nvar3d
-        var3_p => phy%var3(:,:,:,num)
-        call register_restart_field(Phy_restart, trim(GFS_restart%name3d(num)), var3_p, dimensions=(/'xaxis_1','yaxis_1','zaxis_1','Time   '/), is_optional=.true.)
+      nvar = size(GFS_Restart(:)%axes)
+      do num = 1,nvar
+         if (GFS_Restart(num)%axes == 2) then
+            var2_p => phy%var2(:,:,num)
+            call register_restart_field(Phy_restart, trim(GFS_Restart(num)%name), var2_p, &
+                 dimensions=(/'xaxis_1','yaxis_1','Time   '/), is_optional=.true.)
+         end if
+         if (GFS_Restart(num)%axes == 3) then
+            var3_p => phy%var3(:,:,:,num)
+            call register_restart_field(Phy_restart, trim(GFS_restart(num)%name), var3_p, &
+                 dimensions=(/'xaxis_1','yaxis_1','zaxis_1','Time   '/), is_optional=.true.)
+         end if
       enddo
       nullify(var2_p)
       nullify(var3_p)
@@ -915,7 +919,7 @@ contains
   subroutine phys_restart_write (GFS_Restart, Atm_block, Model, fv_domain, timestamp)
     implicit none
     !--- interface variable definitions
-    type(GFS_restart_type),      intent(in) :: GFS_Restart
+    type(GFS_restart_type),      intent(in) :: GFS_Restart(:)
     type(block_control_type),    intent(in) :: Atm_block
     type(GFS_control_type),      intent(in) :: Model
     type(domain2d),              intent(in) :: fv_domain
@@ -926,7 +930,7 @@ contains
     real(kind=kind_phys), pointer, dimension(:,:)   :: var2_p => NULL()
     real(kind=kind_phys), pointer, dimension(:,:,:) :: var3_p => NULL()
     !--- used for axis data for fms2_io
-    integer :: is, ie
+    integer :: is, ie, nvar
     integer, allocatable, dimension(:) :: buffer
     character(7) :: indir='RESTART'
     character(72) :: infile
@@ -986,15 +990,20 @@ contains
       call mpp_error(FATAL, 'Error opening file '//trim(infile))
     end if
 
-    do num = 1,phy%nvar2d
-      var2_p => phy%var2(:,:,num)
-      call register_restart_field(Phy_restart, trim(GFS_Restart%name2d(num)), var2_p, dimensions=(/'xaxis_1','yaxis_1','Time   '/),&
-           & chunksizes=(/xaxis_1_chunk,yaxis_1_chunk,1/), is_optional=.true.)
-    enddo
-    do num = 1,phy%nvar3d
-      var3_p => phy%var3(:,:,:,num)
-      call register_restart_field(Phy_restart, trim(GFS_Restart%name3d(num)), var3_p, dimensions=(/'xaxis_1','yaxis_1','zaxis_1','Time   '/),&
-           & chunksizes=(/xaxis_1_chunk,yaxis_1_chunk,1,1/), is_optional=.true.)
+    nvar = size(GFS_restart(:)%axes)
+    do num = 1,nvar
+       if (GFS_Restart(num)%axes == 2) then
+          var2_p => phy%var2(:,:,num)
+          call register_restart_field(Phy_restart, trim(GFS_Restart(num)%name), var2_p, &
+               dimensions=(/'xaxis_1','yaxis_1','Time   '/),&
+               chunksizes=(/xaxis_1_chunk,yaxis_1_chunk,1/), is_optional=.true.)
+       endif
+       if (GFS_Restart(num)%axes == 3) then
+          var3_p => phy%var3(:,:,:,num)
+          call register_restart_field(Phy_restart, trim(GFS_Restart(num)%name), var3_p,&
+               dimensions=(/'xaxis_1','yaxis_1','zaxis_1','Time   '/),&
+               chunksizes=(/xaxis_1_chunk,yaxis_1_chunk,1,1/), is_optional=.true.)
+       endif
     enddo
     nullify(var2_p)
     nullify(var3_p)
@@ -1013,7 +1022,7 @@ contains
     implicit none
 
     type(GFS_sfcprop_type),      intent(in) :: Sfcprop
-    type(GFS_restart_type),      intent(in) :: GFS_Restart
+    type(GFS_restart_type),      intent(in) :: GFS_Restart(:)
     type(block_control_type),    intent(in) :: Atm_block
     type(GFS_control_type),      intent(in) :: Model
 
@@ -1044,7 +1053,7 @@ contains
 
     implicit none
 
-    type(GFS_restart_type),      intent(in) :: GFS_Restart
+    type(GFS_restart_type),      intent(in) :: GFS_Restart(:)
     type(block_control_type),    intent(in) :: Atm_block
 
     call phy_quilt%transfer_data(.false., GFS_Restart, Atm_block)
@@ -1169,32 +1178,45 @@ contains
     use fv3atm_common_io, only: get_nx_ny_from_atm
     implicit none
     class(phy_data_type) :: phy
-    type(GFS_restart_type),      intent(in) :: GFS_Restart
+    type(GFS_restart_type),      intent(in) :: GFS_Restart(:)
     type(block_control_type),    intent(in) :: Atm_block
 
-    integer :: nx, ny, num
+    integer :: nx, ny, ivar, num1, num2
 
     phy_data_alloc = .false.
 
     if(associated(phy%var2)) return
 
     call get_nx_ny_from_atm(Atm_block, nx, ny)
-
     phy%npz = Atm_block%npz
-    phy%nvar2d = GFS_Restart%num2d
-    phy%nvar3d = GFS_Restart%num3d
+
+    !
+    ! Count the number of 2D and 3D restart fields, allocate space for physics data,
+    ! and gather metadata (e.g. names) for each field.
+    !
+    phy%nvar2d = 0
+    phy%nvar3d = 0
+    do ivar = 1,size(GFS_restart(:)%axes)
+       if (GFS_restart(ivar)%axes == 2) phy%nvar2d = phy%nvar2d + 1
+       if (GFS_restart(ivar)%axes == 3) phy%nvar3d = phy%nvar3d + 1
+    enddo
 
     allocate (phy%var2(nx,ny,phy%nvar2d), phy%var2_names(phy%nvar2d))
     allocate (phy%var3(nx,ny,phy%npz,phy%nvar3d), phy%var3_names(phy%nvar3d))
     phy%var2 = zero
     phy%var3 = zero
-    do num = 1,phy%nvar2d
-      phy%var2_names(num) = trim(GFS_Restart%name2d(num))
+    num1 = 0
+    num2 = 0
+    do ivar = 1,size(GFS_restart(:)%axes)
+       if (GFS_restart(ivar)%axes == 2) then
+          num1 = num1 + 1
+          phy%var2_names(num1) = trim(GFS_Restart(ivar)%name)
+       end if
+       if (GFS_restart(ivar)%axes == 3)	then
+          num2 = num2 + 1
+          phy%var3_names(num2) = trim(GFS_Restart(ivar)%name)
+       endif
     enddo
-    do num = 1,phy%nvar3d
-      phy%var3_names(num) = trim(GFS_Restart%name3d(num))
-    enddo
-
     phy_data_alloc = .true.
   end function phy_data_alloc
 
@@ -1210,11 +1232,11 @@ contains
     implicit none
     class(phy_data_type) :: phy
     logical, intent(in) :: reading
-    type(GFS_restart_type) :: GFS_Restart
+    type(GFS_restart_type) :: GFS_Restart(:)
     type(block_control_type) :: Atm_block
     type(GFS_control_type), optional, intent(in) :: Model
 
-    integer :: i, j, k, num, nb, ix
+    integer :: i, j, k, ivar, nb, ix, im, num2, num3
 
     !--- register the restart fields
     if (.not. associated(phy%var2)) then
@@ -1226,81 +1248,97 @@ contains
       return ! should never get here
     endif
 
-    ! Copy 2D Vars
-
+    !--- place the data into the contiguous GFS containers
     if(reading) then
-      !--- place the data into the block GFS containers
-      !--- phy%var* variables
-      do num = 1,phy%nvar2d
-        !$omp parallel do default(shared) private(i, j, nb, ix)
-        do nb = 1,Atm_block%nblks
-          do ix = 1, Atm_block%blksz(nb)
-            i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
-            j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-            GFS_Restart%data(nb,num)%var2p(ix) = phy%var2(i,j,num)
-          enddo
-        enddo
-      enddo
+       ! 2D
+       num2 = 0
+       num3 = 0
+       do ivar = 1,size(GFS_restart(:)%axes)
+          if (GFS_restart(ivar)%axes == 2) then
+             num2 = num2 + 1
+             print*,'SWALES Reading 2D variable: ',trim(GFS_restart(ivar)%name)
+             !$omp parallel do default(shared) private(i, j, nb, ix, im, ivar, num2)
+             do nb = 1,Atm_block%nblks
+                do ix = 1, Atm_block%blksz(nb)
+                   im = Model%chunk_begin(nb)+ix-1
+                   i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
+                   j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
+                   GFS_Restart(ivar)%data(1)%var2(im) = phy%var2(i,j,num2)
+                enddo
+             enddo
+          endif
+          ! 3D
+          if (GFS_restart(ivar)%axes == 3) then
+             num3 = num3 + 1
+             print*,'SWALES Reading 3D variable: ',trim(GFS_restart(ivar)%name)
+             !$omp parallel do default(shared) private(i, j, k, nb, ix, im, ivar, num3)
+             do nb = 1,Atm_block%nblks
+                do k=1,phy%npz
+                   do ix = 1, Atm_block%blksz(nb)
+                      im = Model%chunk_begin(nb)+ix-1
+                      i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
+                      j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
+                      GFS_Restart(ivar)%data(1)%var3(im,k) = phy%var3(i,j,k,num3)
+                   enddo
+                enddo
+             enddo
+          endif
+       enddo
+    !--- place the data into the phy%var* variables.
     else
-      !--- 2D variables
-      do num = 1,phy%nvar2d
-        !$omp parallel do default(shared) private(i, j, nb, ix)
-        do nb = 1,Atm_block%nblks
-          do ix = 1, Atm_block%blksz(nb)
-            i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
-            j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-            phy%var2(i,j,num) = GFS_Restart%data(nb,num)%var2p(ix)
-          enddo
-        enddo
-      enddo
+       num2 = 0
+       num3 = 0
+       do ivar = 1,size(GFS_restart(:)%axes)
+          ! 2D
+          if (GFS_restart(ivar)%axes == 2) then
+             num2 = num2 + 1
+             print*,'SWALES Writing 2D variable: ',trim(GFS_restart(ivar)%name)
+             !$omp parallel do default(shared) private(i, j, nb, ix, im, ivar, num2)
+             do nb = 1,Atm_block%nblks
+                do ix = 1, Atm_block%blksz(nb)
+                   im = Model%chunk_begin(nb)+ix-1
+                   i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
+                   j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
+                   phy%var2(i,j,num2) = GFS_Restart(ivar)%data(1)%var2(im)
+                enddo
+             enddo
+          endif
+          ! 3D
+          if (GFS_restart(ivar)%axes == 3) then
+             num3 = num3 + 1
+             print*,'SWALES Writing 3D variable: ',trim(GFS_restart(ivar)%name)
+             !$omp parallel do default(shared) private(i, j, k, nb, ix, im, ivar, num3)
+             do nb = 1,Atm_block%nblks
+                do k=1,phy%npz
+                   do ix = 1, Atm_block%blksz(nb)
+                      im = Model%chunk_begin(nb)+ix-1
+                      i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
+                      j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
+                      phy%var3(i,j,k,num3) = GFS_Restart(ivar)%data(1)%var3(im,k)
+                   enddo
+                enddo
+             enddo
+          endif
+       enddo
     endif
 
-    !-- if restart from init time, reset accumulated diag fields
-
+    !--- if restart from init time, reset accumulated diag fields
     if(reading .and. present(Model)) then
-      if(Model%phour < 1.e-7) then
-        do num = GFS_Restart%fdiag,GFS_Restart%ldiag
-          !$omp parallel do default(shared) private(i, j, nb, ix)
-          do nb = 1,Atm_block%nblks
-            do ix = 1, Atm_block%blksz(nb)
-              i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
-              j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-              GFS_Restart%data(nb,num)%var2p(ix) = zero
-            enddo
+       if(Model%phour < 1.e-7) then
+          do ivar = 1,size(GFS_restart(:)%axes)
+             if (GFS_restart(ivar)%reset == .true.) then
+                !$omp parallel do default(shared) private(i, j, nb, ix, im)
+                do nb = 1,Atm_block%nblks
+                   do ix = 1, Atm_block%blksz(nb)
+                      im = Model%chunk_begin(nb)+ix-1
+                      i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
+                      j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
+                      GFS_Restart(ivar)%data(1)%var2(im) = zero
+                   enddo
+                enddo
+             endif
           enddo
-        enddo
-      endif
-    endif
-
-    ! Copy 3D Vars
-
-    if(reading) then
-      do num = 1,phy%nvar3d
-        !$omp parallel do default(shared) private(i, j, k, nb, ix)
-        do nb = 1,Atm_block%nblks
-          do k=1,phy%npz
-            do ix = 1, Atm_block%blksz(nb)
-              i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
-              j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-              GFS_Restart%data(nb,num)%var3p(ix,k) = phy%var3(i,j,k,num)
-            enddo
-          enddo
-        enddo
-      enddo
-    else
-      !--- 3D variables
-      do num = 1,phy%nvar3d
-        !$omp parallel do default(shared) private(i, j, k, nb, ix)
-        do nb = 1,Atm_block%nblks
-          do k=1,phy%npz
-            do ix = 1, Atm_block%blksz(nb)
-              i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
-              j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
-              phy%var3(i,j,k,num) = GFS_Restart%data(nb,num)%var3p(ix,k)
-            enddo
-          enddo
-        enddo
-      enddo
+       endif
     endif
 
   end subroutine phy_data_transfer_data


### PR DESCRIPTION
## Description
This PR replaces using blocked data structures with contiguous data structures for external data types (GFS_diagnostics and GFS_restart). This work is a continuation of #798 and is described in [UWM #2294](https://github.com/ufs-community/ufs-weather-model/issues/2294).

Also, GFS_restart_type was refactored to be consistent with GFS_diagnostics_type. This simplifies the code and opens the possibility to unify some of the fv3 io modules.

### Issue(s) addressed
[UWM #2521](https://github.com/ufs-community/ufs-weather-model/issues/2521)

## Testing
All UWM RTs pass on Hera and WCOSS.
