### PR TITLE
Fix restart-reproduce if using a restart from 15th of month using MERRA2 climatology

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/AnningCheng-NOAA/ccpp-physics
-  branch = mr2_rst
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev  
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
+  url = https://github.com/AnningCheng-NOAA/ccpp-physics
   branch = mr2_rst
 [submodule "upp"]
   path = upp

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  branch = mr2_rst
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev  
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Provide a detailed description of what this PR does.  
What bug does it fix, or what feature does it add?  fixed restart non reproducing issue 2588 from MERRA2 climatology
Is a change of answers expected from this PR?  
No


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<2588> https://github.com/ufs-community/ufs-weather-model/issues/2588#issuecomment-2682166742
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?   hera
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)   yes, no new tests is needed
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
 No
- Please commit the regression test log files in your ufs-weather-model branch
I have only tested two tests related to restart because ecflow cannot connect the server

## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on [noaa-emc/nems/pull/<pr_number>](https://github.com/NCAR/ccpp-physics/pull/1115
- waiting on noaa-emc/fv3atm/pull/<pr_number>https://github.com/ufs-community/ufs-weather-model/pull/2625

