### PR TITLE
Update the upp submodule for GFS v17 and GEFS v13

### DIFF
--- a/ccpp/data/CCPP_typedefs.F90
+++ b/ccpp/data/CCPP_typedefs.F90
@@ -285,6 +285,7 @@ module CCPP_typedefs
     real (kind=kind_phys), pointer      :: t2mmp(:)           => null()  !<
     real (kind=kind_phys), pointer      :: theta(:)           => null()  !<
     real (kind=kind_phys), pointer      :: tlvl(:,:)          => null()  !<
+    real (kind=kind_phys), pointer      :: tkeh(:,:)          => null()  !< vertical turbulent kinetic energy (m2/s2) at the model layer interfaces
     real (kind=kind_phys), pointer      :: tlyr(:,:)          => null()  !<
     real (kind=kind_phys), pointer      :: tprcp_ice(:)       => null()  !<
     real (kind=kind_phys), pointer      :: tprcp_land(:)      => null()  !<
@@ -696,6 +697,7 @@ contains
     allocate (Interstitial%stress_land     (IM))
     allocate (Interstitial%stress_water    (IM))
     allocate (Interstitial%theta           (IM))
+    allocate (Interstitial%tkeh            (IM,Model%levs+1)) !Vertical turbulent kinetic energy at model layer interfaces
     allocate (Interstitial%tlvl            (IM,Model%levr+1+LTP))
     allocate (Interstitial%tlyr            (IM,Model%levr+LTP))
     allocate (Interstitial%tprcp_ice       (IM))
@@ -1039,6 +1041,7 @@ contains
       do n=2,Model%ntrac
         ltest = ( n /= Model%ntcw  .and. n /= Model%ntiw  .and. n /= Model%ntclamt .and. &
                   n /= Model%ntrw  .and. n /= Model%ntsw  .and. n /= Model%ntrnc   .and. &
+                  n /= Model%ntlnc .and. n /= Model%ntinc                          .and. &
                   n /= Model%ntsnc .and. n /= Model%ntgl  .and. n /= Model%ntgnc   .and. &
                   n /= Model%nthl  .and. n /= Model%nthnc .and. n /= Model%ntgv    .and. &
                   n /= Model%nthv  .and. n /= Model%ntccn .and. n /= Model%ntccna  .and. &
@@ -1346,6 +1349,7 @@ contains
     Interstitial%stress_land     = Model%huge
     Interstitial%stress_water    = Model%huge
     Interstitial%theta           = clear_val
+    Interstitial%tkeh            = 0
     Interstitial%tprcp_ice       = Model%huge
     Interstitial%tprcp_land      = Model%huge
     Interstitial%tprcp_water     = Model%huge

--- a/ccpp/data/CCPP_typedefs.meta
+++ b/ccpp/data/CCPP_typedefs.meta
@@ -2836,6 +2836,13 @@
   units = count
   dimensions = ()
   type = integer
+[tkeh]
+   standard_name = vertical_turbulent_kinetic_energy_at_interface
+   long_name = vertical turbulent kinetic energy at model layer interfaces
+   units = m2 s-2
+   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
+   type = real
+   kind = kind_phys
 
 ########################################################################
 [ccpp-table-properties]


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Provide a detailed description of what this PR does.  
What bug does it fix, or what feature does it add?  
Update the upp submodule to incorporate the UPP changes for GFS v17 and GEFS v13 
Is a change of answers expected from this PR?  Yes.



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes noaa-emc/fv3atm/issues #934



## Testing

How were these changes tested?  Yes
What compilers / HPCs was it tested with?  Intel 
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  Yes
Have the ufs-weather-model regression test been run? On what platform?  Yes, WCOSS2
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch
the ufs-wearther-model RTs will have baseline changes in the following tests due to inline post generating new variables in grib2 data files:
cpld_control_gefs intel
cpld_restart_gefs intel

## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
None.

