### PR TITLE
CCPP updates in fv3atm/ccpp-physics: split physics in two groups, reset GFS_interstitial DDT in CCPP_driver.F90

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = ufs/dev
+  url = https://github.com/climbfuji/ccpp-physics
+  branch = feature/remove_gfs_int_radphys_reset
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -109,8 +109,6 @@ SCHEME_FILES = [
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_overlap.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_post.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_stochastics.F90',
-    'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_rad_reset.F90',
-    'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_phys_reset.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_1.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_2.F90',
     'physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_stateout_reset.F90',

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -132,18 +132,18 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_init for "phys-ps"---required for Land IAU
-      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys-ps", ierr=ierr)
+      ! call timestep_init for "phys_ps"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys_ps", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys-ps"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys_ps"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
 
-      ! call timestep_init for "phys-ts"---required for Land IAU
-      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys-ts", ierr=ierr)
+      ! call timestep_init for "phys_ts"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys_ts", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys-ts"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys_ts"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
@@ -204,17 +204,17 @@ module CCPP_driver
         !--- Call CCPP radiation/physics/stochastics group
         if (trim(step)=="physics") then
           ! Process-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys-ps", ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys_ps", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys-ps", &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys_ps", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2
           endif
           ! Time-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys-ts", ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys_ts", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys-ts", &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys_ts", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2
@@ -249,18 +249,18 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_finalize for "phys-ps"---required for Land IAU
-      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys-ps", ierr=ierr)
+      ! call timestep_finalize for "phys_ps"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys_ps", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys-ps"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys_ps"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
 
-      ! call timestep_finalize for "phys-ts"---required for Land IAU
-      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys-ts", ierr=ierr)
+      ! call timestep_finalize for "phys_ts"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys_ts", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys-ts"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys_ts"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -204,17 +204,17 @@ module CCPP_driver
         !--- Call CCPP radiation/physics/stochastics group
         if (trim(step)=="physics") then
           ! Process-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_process_split"), ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_process_split", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_process_split"), &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_process_split", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2
           endif
           ! Time-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_time_split"), ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_time_split", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_time_split"), &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_time_split", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -186,7 +186,7 @@ module CCPP_driver
 !$OMP          default (none)                              &
 !$OMP          shared (nblks, nthrdsX, non_uniform_blocks, &
 !$OMP                  cdata_block, ccpp_suite, step,      &
-!$OMP                  GFS_Interstitial)                   &
+!$OMP                  GFS_Control, GFS_Interstitial)      &
 !$OMP          private (nb, nt, ntX, ierr2)                &
 !$OMP          reduction (+:ierr)
 #ifdef _OPENMP

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -13,7 +13,8 @@ module CCPP_driver
                                 cdata_block,                         &
                                 ccpp_suite,                          &
                                 GFS_control,                         &
-                                GFS_Intdiag
+                                GFS_Intdiag,                         &
+                                GFS_Interstitial
 
   implicit none
 
@@ -184,8 +185,9 @@ module CCPP_driver
 !$OMP parallel num_threads (nthrds)                        &
 !$OMP          default (none)                              &
 !$OMP          shared (nblks, nthrdsX, non_uniform_blocks, &
-!$OMP                  cdata_block,ccpp_suite, step)       &
-!$OMP          private (nb,nt,ntX,ierr2)                   &
+!$OMP                  cdata_block, ccpp_suite, step,      &
+!$OMP                  GFS_Interstitial)                   &
+!$OMP          private (nb, nt, ntX, ierr2)                &
 !$OMP          reduction (+:ierr)
 #ifdef _OPENMP
       nt = omp_get_thread_num()+1
@@ -203,6 +205,8 @@ module CCPP_driver
         end if
         !--- Call CCPP radiation/physics/stochastics group
         if (trim(step)=="physics") then
+          ! Reset GFS_Interstitial DDT physics fields for this thread
+          call GFS_Interstitial(ntX)%phys_reset(GFS_control)
           ! Process-split physics
           call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys_ps", ierr=ierr2)
           if (ierr2/=0) then
@@ -220,6 +224,11 @@ module CCPP_driver
             ierr = ierr + ierr2
           endif
         else
+          if (trim(step)=="radiation") then
+            ! Reset GFS_Interstitial DDT radiation fields for this thread
+            call GFS_Interstitial(ntX)%rad_reset(GFS_control)
+          end if
+          ! Radiation
           call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name=trim(step), ierr=ierr2)
           if (ierr2/=0) then
             write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", trim(step), &

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -132,18 +132,18 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_init for "physics_process_split"---required for Land IAU
-      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="physics_process_split", ierr=ierr)
+      ! call timestep_init for "phys-ps"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys-ps", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group physics_process_split"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys-ps"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
 
-      ! call timestep_init for "physics_time_split"---required for Land IAU
-      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="physics_time_split", ierr=ierr)
+      ! call timestep_init for "phys-ts"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="phys-ts", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group physics_time_split"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group phys-ts"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
@@ -204,17 +204,17 @@ module CCPP_driver
         !--- Call CCPP radiation/physics/stochastics group
         if (trim(step)=="physics") then
           ! Process-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_process_split", ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys-ps", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_process_split", &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys-ps", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2
           endif
           ! Time-split physics
-          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_time_split", ierr=ierr2)
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="phys-ts", ierr=ierr2)
           if (ierr2/=0) then
-            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_time_split", &
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "phys-ts", &
                                       ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
             write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
             ierr = ierr + ierr2
@@ -249,18 +249,18 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_finalize for "physics_process_split"---required for Land IAU
-      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="physics_process_split", ierr=ierr)
+      ! call timestep_finalize for "phys-ps"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys-ps", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group physics_process_split"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys-ps"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if
 
-      ! call timestep_finalize for "physics_time_split"---required for Land IAU
-      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="physics_time_split", ierr=ierr)
+      ! call timestep_finalize for "phys-ts"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="phys-ts", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group physics_time_split"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group phys-ts"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
       end if

--- a/ccpp/driver/CCPP_driver.F90
+++ b/ccpp/driver/CCPP_driver.F90
@@ -132,14 +132,22 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_init for "physics"---required for Land IAU
-      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="physics", ierr=ierr)
+      ! call timestep_init for "physics_process_split"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="physics_process_split", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group physics"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group physics_process_split"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
-      end if      
-            
+      end if
+
+      ! call timestep_init for "physics_time_split"---required for Land IAU
+      call ccpp_physics_timestep_init(cdata_domain, suite_name=trim(ccpp_suite),group_name="physics_time_split", ierr=ierr)
+      if (ierr/=0) then
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_init for group physics_time_split"
+        write(0,'(a)') trim(cdata_domain%errmsg)
+        return
+      end if
+
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       ! DH* 20210104 - this block of code will be removed once the CCPP framework    !
       ! fully supports handling diagnostics through its metadata, work in progress   !
@@ -194,12 +202,31 @@ module CCPP_driver
             ntX = nt
         end if
         !--- Call CCPP radiation/physics/stochastics group
-        call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name=trim(step), ierr=ierr2)
-        if (ierr2/=0) then
-           write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", trim(step), &
-                                     ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
-           write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
-           ierr = ierr + ierr2
+        if (trim(step)=="physics") then
+          ! Process-split physics
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_process_split"), ierr=ierr2)
+          if (ierr2/=0) then
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_process_split"), &
+                                      ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
+            write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
+            ierr = ierr + ierr2
+          endif
+          ! Time-split physics
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name="physics_time_split"), ierr=ierr2)
+          if (ierr2/=0) then
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", "physics_time_split"), &
+                                      ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
+            write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
+            ierr = ierr + ierr2
+          endif
+        else
+          call ccpp_physics_run(cdata_block(nb,ntX), suite_name=trim(ccpp_suite), group_name=trim(step), ierr=ierr2)
+          if (ierr2/=0) then
+            write(0,'(2a,3(a,i4),a)') "An error occurred in ccpp_physics_run for group ", trim(step), &
+                                      ", block/chunk ", nb, " and thread ", nt, " (ntX=", ntX, "):"
+            write(0,'(a)') trim(cdata_block(nb,ntX)%errmsg)
+            ierr = ierr + ierr2
+          endif
         end if
       end do
 !$OMP end do
@@ -222,13 +249,21 @@ module CCPP_driver
         return
       end if
 
-      ! call timestep_finalize for "physics"---required for Land IAU
-      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="physics", ierr=ierr)
+      ! call timestep_finalize for "physics_process_split"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="physics_process_split", ierr=ierr)
       if (ierr/=0) then
-        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group physics"
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group physics_process_split"
         write(0,'(a)') trim(cdata_domain%errmsg)
         return
-      end if      
+      end if
+
+      ! call timestep_finalize for "physics_time_split"---required for Land IAU
+      call ccpp_physics_timestep_finalize(cdata_domain, suite_name=trim(ccpp_suite), group_name="physics_time_split", ierr=ierr)
+      if (ierr/=0) then
+        write(0,'(a)') "An error occurred in ccpp_physics_timestep_finalize for group physics_time_split"
+        write(0,'(a)') trim(cdata_domain%errmsg)
+        return
+      end if
 
     ! Physics finalize
     else if (trim(step)=="physics_finalize") then

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn_lam3km.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,6 +65,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,6 +65,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_flake.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_flake.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -68,7 +68,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_flake.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_flake.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -66,6 +66,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_flake.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_flake.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -68,7 +68,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_flake.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_flake.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_fv3wam.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_ras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_ras.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_ras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_ras.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,6 +65,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_ras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_ras.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v16_ras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_ras.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,6 +62,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,6 +61,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_c3.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_sfcocn.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_coupled_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,6 +62,10 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,6 +61,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -64,7 +64,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,6 +62,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,6 +63,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,7 +65,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,7 +65,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmgp_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>GFS_rrtmgp_cloud_mp</scheme>
@@ -26,7 +25,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
@@ -24,7 +24,7 @@
       <scheme>GFS_rrtmgp_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
@@ -24,7 +24,7 @@
       <scheme>GFS_rrtmgp_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,6 +61,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_rrtmgp.xml
@@ -24,7 +24,7 @@
       <scheme>GFS_rrtmgp_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,6 +61,10 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_ugwpv1.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,7 +63,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,6 +65,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -67,7 +67,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,7 +65,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -63,6 +63,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
@@ -17,7 +17,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -30,7 +29,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_gfdlmp_tedmf_nonsst.xml
@@ -28,7 +28,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -65,7 +65,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_nonsst.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -25,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
+++ b/ccpp/suites/suite_FV3_HAFS_v1_thompson_tedmf_gfdlsf.xml
@@ -23,7 +23,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_c3.xml
+++ b/ccpp/suites/suite_FV3_HRRR_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_c3.xml
+++ b/ccpp/suites/suite_FV3_HRRR_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_c3.xml
+++ b/ccpp/suites/suite_FV3_HRRR_c3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_c3.xml
+++ b/ccpp/suites/suite_FV3_HRRR_c3.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -55,6 +55,10 @@
       <scheme>mynnedmf_wrapper</scheme>
       <scheme>rrfs_smoke_postpbl</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -57,7 +57,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -57,7 +57,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
+++ b/ccpp/suites/suite_FV3_HRRR_gf_nogwd.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP.xml
+++ b/ccpp/suites/suite_FV3_RAP.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP.xml
+++ b/ccpp/suites/suite_FV3_RAP.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP.xml
+++ b/ccpp/suites/suite_FV3_RAP.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP.xml
+++ b/ccpp/suites/suite_FV3_RAP.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_cires_ugwp.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_clm_lake.xml
+++ b/ccpp/suites/suite_FV3_RAP_clm_lake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_clm_lake.xml
+++ b/ccpp/suites/suite_FV3_RAP_clm_lake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_clm_lake.xml
+++ b/ccpp/suites/suite_FV3_RAP_clm_lake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_clm_lake.xml
+++ b/ccpp/suites/suite_FV3_RAP_clm_lake.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_flake.xml
+++ b/ccpp/suites/suite_FV3_RAP_flake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_flake.xml
+++ b/ccpp/suites/suite_FV3_RAP_flake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_flake.xml
+++ b/ccpp/suites/suite_FV3_RAP_flake.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_flake.xml
+++ b/ccpp/suites/suite_FV3_RAP_flake.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_noah_sfcdiff_cires_ugwp.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
+++ b/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
+++ b/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
+++ b/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
+++ b/ccpp/suites/suite_FV3_RAP_sfcdiff.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
+++ b/ccpp/suites/suite_FV3_RAP_unified_ugwp.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1beta.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1beta.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1beta.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1beta.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_MP_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
+++ b/ccpp/suites/suite_FV3_RRFS_v1nssl.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_WoFS_v0.xml
+++ b/ccpp/suites/suite_FV3_WoFS_v0.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_MP_generic_pre</scheme>

--- a/ccpp/suites/suite_FV3_WoFS_v0.xml
+++ b/ccpp/suites/suite_FV3_WoFS_v0.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_WoFS_v0.xml
+++ b/ccpp/suites/suite_FV3_WoFS_v0.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_WoFS_v0.xml
+++ b/ccpp/suites/suite_FV3_WoFS_v0.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_FV3_global_nest_v1.xml
+++ b/ccpp/suites/suite_FV3_global_nest_v1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,6 +60,10 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_FV3_global_nest_v1.xml
+++ b/ccpp/suites/suite_FV3_global_nest_v1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_global_nest_v1.xml
+++ b/ccpp/suites/suite_FV3_global_nest_v1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -62,7 +62,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_FV3_global_nest_v1.xml
+++ b/ccpp/suites/suite_FV3_global_nest_v1.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFS_sas.xml
+++ b/ccpp/suites/suite_RRFS_sas.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFS_sas.xml
+++ b/ccpp/suites/suite_RRFS_sas.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -60,7 +60,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFS_sas.xml
+++ b/ccpp/suites/suite_RRFS_sas.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,6 +58,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFS_sas.xml
+++ b/ccpp/suites/suite_RRFS_sas.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFS_sas_nogwd.xml
+++ b/ccpp/suites/suite_RRFS_sas_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -55,6 +55,10 @@
       <scheme>mynnedmf_wrapper</scheme>
       <scheme>rrfs_smoke_postpbl</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFS_sas_nogwd.xml
+++ b/ccpp/suites/suite_RRFS_sas_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -57,7 +57,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFS_sas_nogwd.xml
+++ b/ccpp/suites/suite_RRFS_sas_nogwd.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -57,7 +57,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFS_sas_nogwd.xml
+++ b/ccpp/suites/suite_RRFS_sas_nogwd.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFSens_phy1.xml
+++ b/ccpp/suites/suite_RRFSens_phy1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy1.xml
+++ b/ccpp/suites/suite_RRFSens_phy1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy1.xml
+++ b/ccpp/suites/suite_RRFSens_phy1.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy1.xml
+++ b/ccpp/suites/suite_RRFSens_phy1.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFSens_phy2.xml
+++ b/ccpp/suites/suite_RRFSens_phy2.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy2.xml
+++ b/ccpp/suites/suite_RRFSens_phy2.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -56,6 +56,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy2.xml
+++ b/ccpp/suites/suite_RRFSens_phy2.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy2.xml
+++ b/ccpp/suites/suite_RRFSens_phy2.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFSens_phy3.xml
+++ b/ccpp/suites/suite_RRFSens_phy3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy3.xml
+++ b/ccpp/suites/suite_RRFSens_phy3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -56,6 +56,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy3.xml
+++ b/ccpp/suites/suite_RRFSens_phy3.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy3.xml
+++ b/ccpp/suites/suite_RRFSens_phy3.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFSens_phy4.xml
+++ b/ccpp/suites/suite_RRFSens_phy4.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -59,6 +59,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy4.xml
+++ b/ccpp/suites/suite_RRFSens_phy4.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy4.xml
+++ b/ccpp/suites/suite_RRFSens_phy4.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -61,7 +61,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy4.xml
+++ b/ccpp/suites/suite_RRFSens_phy4.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_RRFSens_phy5.xml
+++ b/ccpp/suites/suite_RRFSens_phy5.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="phys-ps">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="phys-ts">
+  <group name="phys_ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy5.xml
+++ b/ccpp/suites/suite_RRFSens_phy5.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_process_split">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -56,6 +56,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="physics_time_split">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy5.xml
+++ b/ccpp/suites/suite_RRFSens_phy5.xml
@@ -25,7 +25,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics_process_split">
+  <group name="phys-ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -58,7 +58,7 @@
       <scheme>GFS_suite_stateout_update</scheme>
     </subcycle>
   </group>
-  <group name="physics_time_split">
+  <group name="phys-ts">
     <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_RRFSens_phy5.xml
+++ b/ccpp/suites/suite_RRFSens_phy5.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -27,7 +26,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>


### PR DESCRIPTION
## Description

1. Split the CCPP "physics" group in the suite definition files into two groups (process-split and time-split). This is in preparation for a more systematic, and in further down the road automatic, handling of updating the output state from the input state and the tendencies (with the next-generation code generator `capgen.py`).
2. Reset the `GFS_interstitial` DDT in `CCPP_driver.F90` instead of in the CCPP suites. This follows precedence of resetting the diagnostics (buckets) and removes the need to pass host-model DDTs into the physics (which breaks the paradigm of CCPP physics being host-model independent).

### Issue(s) addressed

This PR is part of the larger project of transitioning to the next-generation code generator `capgen.py`.

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/2651

## Dependencies

- [ ] Waiting on https://github.com/ufs-community/ccpp-physics/pull/258