### PR TITLE
Add a new parameter to control cutoff level for implicit RF

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "fv3/atmos_cubed_sphere"]
   path = fv3/atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  url = https://github.com/XiaqiongZhou-NOAA/GFDL_atmos_cubed_sphere
+  branch = rf_fast_w
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "fv3/atmos_cubed_sphere"]
   path = fv3/atmos_cubed_sphere
-  url =  https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "fv3/atmos_cubed_sphere"]
   path = fv3/atmos_cubed_sphere
-  url = https://github.com/XiaqiongZhou-NOAA/GFDL_atmos_cubed_sphere
-  branch = rf_fast_w
+  url =  https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description


A new parameter rf_cutoff_fast is introduced in dynamics to independently control the cutoff level for implicit Rayleigh damping when fast_tau_w_sec>0, decoupling it from the cutoff level (rf_cutoff) used for explicit damping when tau>0. 
The default value of rf_cutoff_fast=100. (1hPa). It changes the results in RTs with fast_tau_w_sec>0  with rt_cutoff is not equal to 100.


## Testing
Tested on Hera with intel compiler. It will change the regression tests with fast_tau_w_sec>0  and rt_cutoff is not equal to 100.
How were these changes tested?  

## Dependencies

- waiting on https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/381
- waiting on https://github.com/ufs-community/ufs-weather-model/pull/2730

