### PR TITLE
Bug fix for surface roughness calculation over lakes and sea ice points when wave model is turned on

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = ufs/dev
-  url = https://github.com/ChristianBoyer-NOAA/ccpp-physics
-  branch = lakefrac_ice_sfcr
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = ufs/dev
+  url = https://github.com/ChristianBoyer-NOAA/ccpp-physics
+  branch = lakefrac_ice_sfcr
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This PR is a bug fix so that the wave model only updates surface roughness over open ocean, and not over lakes and sea ice. It also avoids using unrealistic surface roughness values from the wave model, such as values greater than 0.1 m. 



### Issue(s) addressed

- fixes https://github.com/ufs-community/ufs-weather-model/issues/2702


## Testing
 
Simulations were conducted on Hercules at C1152 resolution.
Regressions tests were performed on Hercules and the log files are committed in the ufs-weather-model branch. 
Additionally, a new baseline was created and the results were reproduced when compared to its new baseline.

## Dependencies

- waiting on https://github.com/ufs-community/ccpp-physics/pull/281
- related to https://github.com/ufs-community/ufs-weather-model/pull/2739

