### PR TITLE
Bug fix to maxMF check: only access when do_mynnedmf=.true.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/SamuelTrahanNOAA/ccpp-physics
+  branch = bugfix/maxmf-check
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

Bug fix to https://github.com/ufs-community/ccpp-physics/issues/282 to guard against accessing maxMF in `cu_c3_driver.F90` when that array is not allocated.

See issue for full explanation.

### Issue(s) addressed

- fixes https://github.com/ufs-community/ccpp-physics/issues/282

## Testing

#### How were these changes tested?  

Experimental physics suite that uses C3 but not mynn edmf crashed without these changes but ran with the changes. See issue for full description.

#### What compilers / HPCs was it tested with?  

Hera and Hercules with the Intel compiler..

#### Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  

The experimental physics suite that triggers these bugs doesn't self-reproduce, so I cannot make a regression test for it yet. The reproducibility bug is unrelated and will be the subject of another Issue shortly.

#### Have the ufs-weather-model regression test been run? On what platform?  

Yes. Hera.

#### Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.

No. Either it crashes or it doesn't.

#### Please commit the regression test log files in your ufs-weather-model branch

Done.

## Dependencies

- waiting on ccpp-physics https://github.com/ufs-community/ccpp-physics/pull/283
