### PR TITLE
gcycle update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,11 +4,12 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  url = https://github.com/RuiyuSun/ccpp-physics.git
+  url = https://github.com/NCAR/ccpp-framework
   branch = gcycleupdate 
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
+  #url = https://github.com/ufs-community/ccpp-physics
+  url = https://github.com/RuiyuSun/ccpp-physics.git 
   branch = ufs/dev
 [submodule "upp"]
   path = upp

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,8 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  #url = https://github.com/NCAR/ccpp-framework
   url = https://github.com/RuiyuSun/ccpp-physics.git
-  branch = main
+  branch = gcycleupdate 
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "ccpp/physics"]
   path = ccpp/physics
   url = https://github.com/ufs-community/ccpp-physics
-  branch = gcycleupdate
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,8 @@
   branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
-  url = https://github.com/NCAR/ccpp-framework
+  #url = https://github.com/NCAR/ccpp-framework
+  url = https://github.com/RuiyuSun/ccpp-physics.git
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,12 +5,12 @@
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework
-  branch = gcycleupdate 
+  branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
   #url = https://github.com/ufs-community/ccpp-physics
   url = https://github.com/RuiyuSun/ccpp-physics.git 
-  branch = ufs/dev
+  branch = gcycleupdate
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,7 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  url = https://github.com/RuiyuSun/ccpp-physics.git 
+  url = https://github.com/ufs-community/ccpp-physics
   branch = gcycleupdate
 [submodule "upp"]
   path = upp


### PR DESCRIPTION
## Description

The following description is written by @XuLi-NOAA  

Background
In the uncoupled GFS , a utility, called Gcycle (Global Cycle), is required to apply some constraints or adjustments, such as relaxation to climatology or threshold check, to some surface variables.
Gcycle is still on in GFSv17, even if it has become a coupled system. However, in the transition from the uncoupled to coupled mode, two subtle issues in gcycle application have not been considered carefully enough and are addressed here.

Problem
The lack of two logics, (1) ocean or lake, to distinguish the way to apply the gcycle adjustment to water surface variables, specifically, temperature, sea ice and snow over sea ice and related variables; (2) coupled or uncoupled, to distinguish the way to apply the gcycle adjustment to water surface temperature

Root cause of the problem
The water surface is treated differently (1) over ocean or lake; (2) in coupled or unclouped mode.
Concretely, (1) in a coupled mode, the ocean, and sea ice, is simulated by an oceanic model (MOM6) and an ice model (ICE6) and therefore the sea surface temperature and sea ice adjustment by gcycle is not needed anymore; but the lake still evolves with the NSST model and gcycle, and therefore gcycle is still needed. (2) It is necessary to make it work in uncoupled mode, in which the gcycle is applied to both ocean and lake, therefore, an indicator of the couple mode is needed.
One argument (True or False): Turning off gcycle adjustments over ocean area is unnecessary since the oceanic surface temperature will be over written later on at the NSST run step.
With comprehensive understanding of CCPP sequential execution steps, it has been found out that there are some steps, such as radiation and some interstitial processing, between gcycle and NSST model run, therefore, the turning off of the gcycle adjustments in the coupled mode is absolutely necessary.
It is fair to say this argument is partially true since there is indeed an overwrite of the sea surface temperature. However, the key is that there are steps between gcycle call and the overwrite step.

Solution
To add two logics to determine if the water surface is ocean or lake, and if it is coupled or uncouple, to UFS.
The ocean mask, oceanfrac(1=ocean, 0=non-ocean) is available in ccpp physics can be used to tell if a grid is over ocean or not. Another logical variable, cplflx is available in ccpp code can be used to tell if the system is in coupled or uncoupled mode.

tref(:) = foundation temperature over water surface
tisfc(:) = surface skin temperature over (sea or lake) ice
hice(:) = (sih) sea or lake ice thickness
fice(:) = (sic) sea or lake ice fraction/concentration
weasd(:) = water equiv of acc snow depth over land and (sea or lake) ice
snowd(:) = water equivalent snow depth
snoalb(:) = maximum snow albedo

At present, the code modification is to let the current sfccycle subroutine does what it does (as is), but update the related variables (listed above) at Lake grids only and when the system is in a coupled model. Concretely, this requires to save the listed variables before the call of sfccycle in gcycle.F90, then update them as above after the call of sfccycle.

Only three files need to be modified:

Interstitials/UFS_SCM_NEPTUNE/gcycle.F90
Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.F90
Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.meta

The code has been done and tested and the impacts are as expeted. See result figures at https://docs.google.com/presentation/d/1sDo1rXrq32Fn9g-R2sWYtNx_Qi_0MKDLf0A-PuLaAJs/edit?slide=id.p1#slide=id.p1

Notes for future:

a. This project focuses on GFSv17, in which NSST is on. The work and test when NSST is off needs to be done for HAFS where NSST is off
b. Stand-alone Gcyele enhancement for sfcanl generation 

This PR will change results. 



### Issue(s) addressed

- fixes (ufs-community/ccpp-physics/pull/270)
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  Regression tests and a fully coupled gfsv17 HR retro test 
What compilers / HPCs was it tested with? intel compiler on hera 
Are the changes covered by regression tests? YES and no new test needs to be added.   
Have the ufs-weather-model regression test been run? YES On what platform?  Hera 
- Will the code updates change regression test baseline? If yes, why? YES. Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
https://github.com/RuiyuSun/ccpp-physics.git

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on (https://github.com/ufs-community/ccpp-physics/pull/285)


