### PR TITLE
Slight modification in orographic gravity wave drag (OGWD) scheme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = ufs/dev
-  url = https://github.com/rhaesung/ccpp-physics
-  branch = ogwd
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/rhaesung/ccpp-physics
+  branch = ogwd
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
This modification is from @JongilHan66 

## Description

1. The reference height (href) in the OGWD (Orographic Gravity Wave Drag) scheme is a critical parameter that significantly influences the strength of OGWD. Currently, href is defined as the maximum of the maximum subgrid orographic elevation (Omax) and twice the standard deviation of subgrid orography (sigma), i.e.,
href = max(Omax, 2*sigma).

   In the proposed modification, this is changed to:
   href = max(Omax, 2*sigma, hpbl),
   where hpbl is the planetary boundary layer height.

   The inclusion of hpbl in determining href is informed by prior studies on the OGWD scheme:

   href = hpbl (Kim and Arakawa, 1995)
   href = 2* sigma (Kim and Doyle, 2005)
   href = max(2*sigma, hpbl) (Hong et al., 2005)

2. This updated formulation of href not only [improves the 500 hPa height anomaly correlation](https://www.emc.ncep.noaa.gov/gmb/jhan/vsdbw/hr5c01/allmodel/daily/dieoff/cordieoff_HGT_P500_G2NHX.png), but also [helps to reduce too strong wintertime polar vortex in the upper stratosphere](https://www.emc.ncep.noaa.gov/gmb/jhan/vsdbw/hr5c03a/2D/d3/UGRDprs_zmean.png), where hr4a11 is the control run and hr5c01 is same as the control run but with the modified href.

## Testing

UFS-RTs on Hera


## Dependencies

https://github.com/ufs-community/ccpp-physics/pull/287