### PR TITLE
Fix upp calling frequency when restart freq and history freq are not …

### DIFF
--- a/fv3/io/module_wrt_grid_comp.F90
+++ b/fv3/io/module_wrt_grid_comp.F90
@@ -2105,7 +2105,7 @@
 ! ** now loop through output field bundle
 !-----------------------------------------------------------------------
 
-      if ( wrt_int_state%output_history .and. (lupp_history .or. lrestart) ) then
+      if ( (wrt_int_state%output_history .and. lupp_history) .or. lrestart ) then
 
         two_phase_loop: do out_phase = 1, 2
 

--- a/fv3/io/module_wrt_grid_comp.F90
+++ b/fv3/io/module_wrt_grid_comp.F90
@@ -1818,7 +1818,7 @@
       endif
 !
       if(lprnt) print *,'in wrt run, cdate=',cdate(1:4),'fcst_seconds=',fcst_seconds/3600.,'nfhour=',nfhour,&
-       'lupp_history=', lupp_history, 'lrestart=',lrestart,'write grid comp not return',cfhour=',trim(cfhour)
+       'lupp_history=', lupp_history, 'lrestart=',lrestart,'write grid comp not return,cfhour=',trim(cfhour)
 !
 !-----------------------------------------------------------------------
 !*** loop on the "output_" FieldBundles, i.e. files that need to write out

--- a/fv3/io/module_wrt_grid_comp.F90
+++ b/fv3/io/module_wrt_grid_comp.F90
@@ -1796,18 +1796,14 @@
       if (iau_offset > 0) then
         fcst_seconds = fcst_seconds + iau_offset*3600
       endif
-
-      if(lprnt) print *,'in wrt run, fcst_seconds=',fcst_seconds/3600.,'output_fh=',output_fh(1:10), 'frestart(:)=',frestart(1:10)/3600.
 !
 !--- set up logic variable to run upp/history and restart
 !
       lupp_history = .false.
       lrestart = .false.
-      if ( ANY(nint(output_fh(:)*3600) == nint(nfhour*3600)) ) lupp_history = .true.
+      if ( ANY(nint(output_fh(:)*3600) == fcst_seconds) ) lupp_history = .true.
       if ( ANY(frestart(:) == fcst_seconds) ) lrestart = .true.
       if ( .not. (lupp_history .or. lrestart ) ) return
-      if(lprnt) print *,'in wrt run, fcst_seconds=',fcst_seconds/3600.,'nfhour=',nfhour,'lupp_history=', lupp_history, &
-         'lrestart=',lrestart, 'write grid comp not return'
 !
 !--- set up current forecast hours
 !
@@ -1821,7 +1817,8 @@
         write(cfhour, cform) nf_hours
       endif
 !
-       if(lprnt) print *,'in wrt run, nfhour=',nfhour,' cfhour=',trim(cfhour)
+      if(lprnt) print *,'in wrt run, cdate=',cdate(1:4),'fcst_seconds=',fcst_seconds/3600.,'nfhour=',nfhour,&
+       'lupp_history=', lupp_history, 'lrestart=',lrestart,'write grid comp not return',cfhour=',trim(cfhour)
 !
 !-----------------------------------------------------------------------
 !*** loop on the "output_" FieldBundles, i.e. files that need to write out
@@ -2124,9 +2121,9 @@
             is_restart_bundle = .false.
             if (wrtFBName(1:8) == 'restart_') then
               is_restart_bundle = .true.
-              if (.not.(ANY(frestart(:) == fcst_seconds))) cycle
+              if (.not.lrestart) cycle
             else
-              if (.not.(wrt_int_state%output_history .and. ANY(nint(output_fh(:)*3600.0) == fcst_seconds))) cycle
+              if (.not.(wrt_int_state%output_history .and. lupp_history)) cycle
             endif
 
             if (out_phase == 1 .and. is_restart_bundle) cycle

--- a/fv3/io/module_wrt_grid_comp.F90
+++ b/fv3/io/module_wrt_grid_comp.F90
@@ -1722,6 +1722,7 @@
       logical                               :: use_parallel_netcdf
       real, allocatable                     :: output_fh(:)
       logical                               :: is_restart_bundle, restart_written
+      logical                               :: lupp_history, lrestart
       integer                               :: tileCount
       type(ESMF_Info)                       :: fcstInfo, wrtInfo
       character(len=ESMF_MAXSTR)            :: output_grid_name
@@ -1782,7 +1783,34 @@
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
       if (nf_hours < 0) return
+!
+!*** set up output time on write grid comp:
+!
+      call ESMF_TimeIntervalGet(timeinterval=io_currtimediff, s=fcst_seconds, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
+      ! fcst_seconds is number of seconds in io_currtimediff, which is time interval between currenttime and io_basetime.
+      ! io_basetime has been adjusted by iau_offset in initialize phase.
+      ! Since output_fh and frestart and NOT adjusted by iau_offset, in order to compare
+      ! them with fcst_seconds, we must also adjust fcst_seconds by iau_offset
+      if (iau_offset > 0) then
+        fcst_seconds = fcst_seconds + iau_offset*3600
+      endif
+
+      if(lprnt) print *,'in wrt run, fcst_seconds=',fcst_seconds/3600.,'output_fh=',output_fh(1:10), 'frestart(:)=',frestart(1:10)/3600.
+!
+!--- set up logic variable to run upp/history and restart
+!
+      lupp_history = .false.
+      lrestart = .false.
+      if ( ANY(nint(output_fh(:)*3600) == nint(nfhour*3600)) ) lupp_history = .true.
+      if ( ANY(frestart(:) == fcst_seconds) ) lrestart = .true.
+      if ( .not. (lupp_history .or. lrestart ) ) return
+      if(lprnt) print *,'in wrt run, fcst_seconds=',fcst_seconds/3600.,'nfhour=',nfhour,'lupp_history=', lupp_history, &
+         'lrestart=',lrestart, 'write grid comp not return'
+!
+!--- set up current forecast hours
+!
       if (lflname_fulltime) then
         ndig = max(log10(nf_hours+0.5)+1., 3.)
         write(cform, '("(I",I1,".",I1,",A1,I2.2,A1,I2.2)")') ndig, ndig
@@ -2019,7 +2047,7 @@
 !*** do post
 !-----------------------------------------------------------------------
       lmask_fields = .false.
-      if( wrt_int_state%write_dopost ) then
+      if( wrt_int_state%write_dopost .and. lupp_history ) then
 #ifdef INLINE_POST
         wbeg = MPI_Wtime()
         do n=1,ngrids
@@ -2080,20 +2108,11 @@
 ! ** now loop through output field bundle
 !-----------------------------------------------------------------------
 
-      call ESMF_TimeIntervalGet(timeinterval=io_currtimediff, s=fcst_seconds, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+      if ( wrt_int_state%output_history .and. (lupp_history .or. lrestart) ) then
 
-      ! fcst_seconds is number of seconds in io_currtimediff, which is time interval between currenttime and io_basetime.
-      ! io_basetime has been adjusted by iau_offset in initialize phase.
-      ! Since output_fh and frestart and NOT adjusted by iau_offset, in order to compare
-      ! them with fcst_seconds, we must also adjust fcst_seconds by iau_offset
-      if (iau_offset > 0) then
-        fcst_seconds = fcst_seconds + iau_offset*3600
-      endif
+        if (lprnt) write(0,*)'wrt_run: loop over wrt_int_state%FBCount ',wrt_int_state%FBCount, ' nfhour ',  nfhour, &
+          ' cdate ', cdate(1:6), 'lupp_histor',lupp_history,'lrestart=',lrestart
 
-      if ( (wrt_int_state%output_history .and. ANY(nint(output_fh(:)*3600.0) == fcst_seconds)) .or. ANY(frestart(:) == fcst_seconds) ) then
-
-        ! if (lprnt) write(0,*)'wrt_run: loop over wrt_int_state%FBCount ',wrt_int_state%FBCount, ' nfhour ',  nfhour, ' cdate ', cdate(1:6)
         two_phase_loop: do out_phase = 1, 2
 
           restart_written = .false.

--- a/fv3/io/module_wrt_grid_comp.F90
+++ b/fv3/io/module_wrt_grid_comp.F90
@@ -2107,9 +2107,6 @@
 
       if ( wrt_int_state%output_history .and. (lupp_history .or. lrestart) ) then
 
-        if (lprnt) write(0,*)'wrt_run: loop over wrt_int_state%FBCount ',wrt_int_state%FBCount, ' nfhour ',  nfhour, &
-          ' cdate ', cdate(1:6), 'lupp_histor',lupp_history,'lrestart=',lrestart
-
         two_phase_loop: do out_phase = 1, 2
 
           restart_written = .false.

--- a/fv3/module_fcst_grid_comp.F90
+++ b/fv3/module_fcst_grid_comp.F90
@@ -594,8 +594,8 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     logical               :: top_parent_is_global
     logical               :: history_file_on_native_grid
 
-    integer                       :: num_restart_interval, restart_starttime
-    real,dimension(:),allocatable :: restart_interval
+    integer                       :: num_restart_fh, restart_starttime
+    real,dimension(:),allocatable :: restart_fh
 
     integer           :: urc
     type(ESMF_State)  :: tempState
@@ -633,16 +633,16 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     call ESMF_ConfigLoadFile(config=CF ,filename='model_configure' ,rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-    num_restart_interval = ESMF_ConfigGetLen(config=CF, label ='restart_interval:',rc=rc)
+    num_restart_fh = ESMF_ConfigGetLen(config=CF, label ='restart_fh:',rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-    if (mype == 0) print *,'af ufs config,num_restart_interval=',num_restart_interval
-    if (num_restart_interval<=0) num_restart_interval = 1
-    allocate(restart_interval(num_restart_interval))
-    restart_interval = 0
-    call ESMF_ConfigGetAttribute(CF,valueList=restart_interval,label='restart_interval:', &
-                                 count=num_restart_interval, rc=rc)
+    if (mype == 0) print *,'af ufs config,num_restart_fh=',num_restart_fh
+    if (num_restart_fh<=0) num_restart_fh = 1
+    allocate(restart_fh(num_restart_fh))
+    restart_fh = 0
+    call ESMF_ConfigGetAttribute(CF,valueList=restart_fh,label='restart_fh:', &
+                                 count=num_restart_fh, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-    if (mype == 0) print *,'af ufs config,restart_interval=',restart_interval
+    if (mype == 0) print *,'af ufs config,restart_fh=',restart_fh
 !
     call fms_init(fcst_mpi_comm%mpi_val)
     call mpp_init()
@@ -763,28 +763,18 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 ! set up forecast time array that controls when to write out restart files
     frestart = 0
     call get_time(Time_end - Time_init, total_inttime)
-! set iau offset time
-    Atmos%iau_offset    = iau_offset
-    if(iau_offset > 0 ) then
-      iautime =  set_time(iau_offset * 3600, 0)
-    endif
 ! if the second item is -1, the first number is frequency
     freq_restart = .false.
-    if(num_restart_interval == 2) then
-      if(restart_interval(2)== -1) freq_restart = .true.
+    if(num_restart_fh == 2) then
+      if(restart_fh(2)== -1) freq_restart = .true.
     endif
     if(freq_restart) then
-      if(restart_interval(1) >= 0) then
-        tmpvar = restart_interval(1) * 3600
+      if(restart_fh(1) >= 0) then
+        tmpvar = restart_fh(1) * 3600
         Time_step_restart = set_time (tmpvar, 0)
-        if(iau_offset > 0 ) then
-          Time_restart = Time_init + iautime + Time_step_restart
-          frestart(1) = tmpvar + iau_offset *3600
-        else
-          Time_restart = Time_init + Time_step_restart
-          frestart(1) = tmpvar
-        endif
-        if(restart_interval(1) > 0) then
+        Time_restart = Time_init + Time_step_restart
+        frestart(1) = tmpvar
+        if(restart_fh(1) > 0) then
           i = 2
           do while ( Time_restart < Time_end )
             frestart(i) = frestart(i-1) + tmpvar
@@ -794,17 +784,13 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
         endif
       endif
 ! otherwise it is an array with forecast time at which the restart files will be written out
-    else if(num_restart_interval >= 1) then
-      if(num_restart_interval == 1 .and. restart_interval(1) == 0 ) then
+    else if(num_restart_fh >= 1) then
+      if(num_restart_fh == 1 .and. restart_fh(1) == 0 ) then
         frestart(1) = total_inttime
       else
-        if(iau_offset > 0 ) then
-          restart_starttime = iau_offset *3600
-        else
-          restart_starttime = 0
-        endif
-        do i=1,num_restart_interval
-          frestart(i) = restart_interval(i) * 3600. + restart_starttime
+        restart_starttime = 0
+        do i=1,num_restart_fh
+          frestart(i) = restart_fh(i) * 3600. + restart_starttime
         enddo
       endif
     endif


### PR DESCRIPTION
…same

## Description

This PR is to fix the upp calling frequency when the restart output frequency and history file output frequency  are not same. One example is in cpld_control_gfsv17_iau test, where the restart frequency is 3 while the history output frequency is 6. The inline post should only be called at the history output frequency, even when history files are written out (controlled by output_history).    


(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Provide a detailed description of what this PR does.  
What bug does it fix, or what feature does it add?  
Is a change of answers expected from this PR?  



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #969
- fixed #978 



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>

