### PR TITLE
Fix CI/CD workflow

### DIFF
--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -120,7 +120,7 @@ jobs:
         export CC=mpicc
         export CXX=mpicxx
         export FC=mpif90
-        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_CI_TESTING=ON ${{ matrix.cmake_opts }} ${{ env.gcov_cmake }}
+        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_CI_TESTING=ON -DFV3=ON ${{ matrix.cmake_opts }} ${{ env.gcov_cmake }}
         make -j2
 
     - name: run-tests

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -119,7 +119,7 @@ jobs:
         export CC=mpicc
         export CXX=mpicxx
         export FC=mpif90
-        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_CI_TESTING=ON ${{ matrix.cmake_opts }} -DENABLE_FV3ATM_DOCS=ON ${{ env.gcov_cmake }}
+        cmake ${GITHUB_WORKSPACE}/fv3atm -DBUILD_CI_TESTING=ON -DFV3=ON ${{ matrix.cmake_opts }} -DENABLE_FV3ATM_DOCS=ON ${{ env.gcov_cmake }}
         make doxygen_doc
 
     - name: upload-docs

--- a/ci/CMakeLists.txt
+++ b/ci/CMakeLists.txt
@@ -6,11 +6,13 @@
 # Alex Richert, 6 Dec 2023
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMakeModules/Modules)
-# Add ESMF's cmake files. They have been removed from EMC's module repo
+# Add ESMF's cmake files and library locations
 if(DEFINED ENV{ESMFMKFILE})
   get_filename_component(TEMP_DIR $ENV{ESMFMKFILE} DIRECTORY)
   get_filename_component(ESMF_ROOT ${TEMP_DIR} DIRECTORY)
-    list(APPEND CMAKE_MODULE_PATH ${ESMF_ROOT}/cmake)
+  list(APPEND CMAKE_MODULE_PATH ${ESMF_ROOT}/cmake)
+  include_directories(${ESMF_ROOT}/include)
+  link_directories(${TEMP_DIR})
 endif()
 
 if(${CMAKE_Fortran_COMPILER_ID} MATCHES "GNU")

--- a/ci/CMakeLists.txt
+++ b/ci/CMakeLists.txt
@@ -6,6 +6,12 @@
 # Alex Richert, 6 Dec 2023
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMakeModules/Modules)
+# Add ESMF's cmake files. They have been removed from EMC's module repo
+if(DEFINED ENV{ESMFMKFILE})
+  get_filename_component(TEMP_DIR $ENV{ESMFMKFILE} DIRECTORY)
+  get_filename_component(ESMF_ROOT ${TEMP_DIR} DIRECTORY)
+    list(APPEND CMAKE_MODULE_PATH ${ESMF_ROOT}/cmake)
+endif()
 
 if(${CMAKE_Fortran_COMPILER_ID} MATCHES "GNU")
   if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 9.0.0)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,13 +10,13 @@ execute_process(COMMAND cmake -E create_symlink
 
 function(add_fv3atm_mpi_test TESTNAME)
   add_executable(${TESTNAME} ${TESTNAME}.F90)
-  target_link_libraries(${TESTNAME} PRIVATE fv3atm MPI::MPI_Fortran PIO::PIO_Fortran)
+  target_link_libraries(${TESTNAME} PRIVATE ufsatm_fv3 MPI::MPI_Fortran PIO::PIO_Fortran)
   add_test(${TESTNAME} ${MPIEXEC_EXECUTABLE} -n 2 ${CMAKE_CURRENT_BINARY_DIR}/${TESTNAME})
 endfunction()
 
 function(add_fv3atm_serial_test TESTNAME)
   add_executable(${TESTNAME} ${TESTNAME}.F90)
-  target_link_libraries(${TESTNAME} PRIVATE fv3atm)
+  target_link_libraries(${TESTNAME} PRIVATE ufsatm_fv3)
   add_test(${TESTNAME} ${CMAKE_CURRENT_BINARY_DIR}/${TESTNAME})
 endfunction()
 


### PR DESCRIPTION
## Description
The GitHub CI/CD workflow was broken after a recent PR. This PR will update the workflows to allow the check to be run again. 

Two distinct issues were found so far:

1.  The addition of an FV3 option (in prep for MPAS) was not added to the CI workflow. That has now been added.
2.  A new path needed to be added because of the elimination of the FindESMF.cmake from the NOAA-EMC repo (https://github.com/NOAA-EMC/CMakeModules/pull/71)



## Issue(s) addressed
- Closes #959



## Testing
These changes were tested using the GitHub CI/CD workflow.

The changes were also tested on Hercules in UFS to make sure that there weren't any unexpected changes. 


## Dependencies
None 

