### PR TITLE
Fix zero out accumulated total precip

### DIFF
--- a/ccpp/CCPP_driver.F90
+++ b/ccpp/CCPP_driver.F90
@@ -173,11 +173,13 @@ module CCPP_driver
         kdt_iau = nint(GFS_control%iau_offset*3600./GFS_control%dtp)
         if (GFS_control%kdt-1 == kdt_iau) then
           iauwindow_center = .true.
+          if( GFS_control%me == 0)print *,'in ccpp step vary, iauwindow_center=',iauwindow_center,&
+            'kdt=',GFS_control%kdt,'dtp=',GFS_control%dtp,'iau_offset=',GFS_control%iau_offset
         else
           iauwindow_center = .false.
         endif
       endif
-      if ((mod(GFS_control%kdt-1,GFS_control%nszero)) == 0 .or. iauwindow_center) then
+      if ((mod(GFS_control%kdt-1,GFS_control%nszero)) == 0) then
         call GFS_Intdiag%phys_zero(GFS_control, iauwindow_center=iauwindow_center)
       endif
 

--- a/ccpp/CCPP_driver.F90
+++ b/ccpp/CCPP_driver.F90
@@ -169,14 +169,13 @@ module CCPP_driver
       endif
 
       !--- determine if physics diagnostics buckets need to be cleared
+      iauwindow_center = .false.
       if (GFS_control%iau_offset > 0) then
         kdt_iau = nint(GFS_control%iau_offset*3600./GFS_control%dtp)
         if (GFS_control%kdt-1 == kdt_iau) then
           iauwindow_center = .true.
           if( GFS_control%me == 0)print *,'in ccpp step vary, iauwindow_center=',iauwindow_center,&
             'kdt=',GFS_control%kdt,'dtp=',GFS_control%dtp,'iau_offset=',GFS_control%iau_offset
-        else
-          iauwindow_center = .false.
         endif
       endif
       if ((mod(GFS_control%kdt-1,GFS_control%nszero)) == 0) then

--- a/ccpp/CCPP_driver.F90
+++ b/ccpp/CCPP_driver.F90
@@ -59,6 +59,8 @@ module CCPP_driver
     ! Local variables
     integer :: nb, nt, ntX
     integer :: ierr2
+    integer :: kdt_iau
+    logical :: iauwindow_center
     ! DH* 20210104 - remove kdt_rad when code to clear diagnostic buckets is removed
     integer :: kdt_rad
 
@@ -167,8 +169,16 @@ module CCPP_driver
       endif
 
       !--- determine if physics diagnostics buckets need to be cleared
-      if ((mod(GFS_control%kdt-1,GFS_control%nszero)) == 0) then
-        call GFS_Intdiag%phys_zero(GFS_control)
+      if (GFS_control%iau_offset > 0) then
+        kdt_iau = nint(GFS_control%iau_offset*3600./GFS_control%dtp)
+        if (GFS_control%kdt-1 == kdt_iau) then
+          iauwindow_center = .true.
+        else
+          iauwindow_center = .false.
+        endif
+      endif
+      if ((mod(GFS_control%kdt-1,GFS_control%nszero)) == 0 .or. iauwindow_center) then
+        call GFS_Intdiag%phys_zero(GFS_control, iauwindow_center=iauwindow_center)
       endif
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/fv3/atmos_model.F90
+++ b/fv3/atmos_model.F90
@@ -1001,24 +1001,18 @@ subroutine update_atmos_model_state (Atmos, rc)
     call get_time (Atmos%Time - Atmos%Time_init, seconds)
     call atmosphere_nggps_diag(Atmos%Time,ltavg=.true.,avg_max_length=avg_max_length)
     if (ANY(nint(output_fh(:)*3600.0) == seconds) .or. (GFS_control%kdt == first_kdt)) then
-      if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds
       time_int = real(isec)
+      time_intfull = real(seconds)
       if(Atmos%iau_offset > zero) then
         if( time_int - Atmos%iau_offset*3600. > zero ) then
           time_int = time_int - Atmos%iau_offset*3600.
-        else if(seconds == Atmos%iau_offset*3600) then
-          call get_time (Atmos%Time - diag_time_fhzero, isec_fhzero)
-          time_int = real(isec_fhzero)
-          if (mpp_pe() == mpp_root_pe()) write(6,*) "---iseczero",isec_fhzero
         endif
-      endif
-      time_intfull = real(seconds)
-      if(Atmos%iau_offset > zero) then
         if( time_intfull - Atmos%iau_offset*3600. > zero) then
           time_intfull = time_intfull - Atmos%iau_offset*3600.
         endif
       endif
-      if (mpp_pe() == mpp_root_pe()) write(6,*) ' gfs diags time since last bucket empty: ',time_int/3600.,'hrs'
+      if (mpp_pe() == mpp_root_pe()) write(6,*) 'gfs diags time since last bucket empty: ',time_int,'hrs',' time_intfull=', &
+         time_intfull,' kdt=',GFS_control%kdt
       call atmosphere_nggps_diag(Atmos%Time)
       call fv3atm_diag_output(Atmos%Time, GFS_Diag, Atm_block, GFS_control%nx, GFS_control%ny, &
                             GFS_control%levs, 1, 1, 1.0_GFS_kind_phys, time_int, time_intfull, &

--- a/fv3/atmos_model.F90
+++ b/fv3/atmos_model.F90
@@ -1011,7 +1011,7 @@ subroutine update_atmos_model_state (Atmos, rc)
           time_intfull = time_intfull - Atmos%iau_offset*3600.
         endif
       endif
-      if (mpp_pe() == mpp_root_pe()) write(6,*) 'gfs diags time since last bucket empty: ',time_int,'hrs',' time_intfull=', &
+      if (mpp_pe() == mpp_root_pe()) write(6,*) 'gfs diags time since last bucket empty: ',time_int,' time_intfull=', &
          time_intfull,' kdt=',GFS_control%kdt
       call atmosphere_nggps_diag(Atmos%Time)
       call fv3atm_diag_output(Atmos%Time, GFS_Diag, Atm_block, GFS_control%nx, GFS_control%ny, &

--- a/fv3/fv3_cap.F90
+++ b/fv3/fv3_cap.F90
@@ -949,11 +949,7 @@ module fv3atm_cap_mod
             if( nfhmax>output_startfh) nfh = nint((nfhmax-output_startfh)/outputfh2(1)) + 1
             if( nfh > 0) then
               allocate(output_fh(nfh))
-              if( output_startfh == 0) then
-                output_fh(1) = dt_atmos/3600.
-              else
-                output_fh(1) = output_startfh + dt_atmos/3600.
-              endif
+              output_fh(1) = output_startfh + dt_atmos/3600.
               do i=2,nfh
                 output_fh(i) = (i-1)*outputfh2(1) + output_startfh
                 ! Except fh000, which is the first time output, if any other of the

--- a/fv3/fv3_cap.F90
+++ b/fv3/fv3_cap.F90
@@ -952,7 +952,7 @@ module fv3atm_cap_mod
               if( output_startfh == 0) then
                 output_fh(1) = dt_atmos/3600.
               else
-                output_fh(1) = output_startfh
+                output_fh(1) = output_startfh + dt_atmos/3600.
               endif
               do i=2,nfh
                 output_fh(i) = (i-1)*outputfh2(1) + output_startfh


### PR DESCRIPTION
## Description

This PR is to resolve the issue with [#976](https://github.com/NOAA-EMC/fv3atm/issues/976). The average total precipitation fields (accumulated from cycle starting time) are not correct in GFSv17 retro run. 

The following code changes in production/GFS.16 were lost in the current fv3atm ccpp driver code: https://github.com/NOAA-EMC/fv3atm/blob/production/GFS.v16/gfsphysics/GFS_layer/GFS_driver.F90#L643-L649

```
  if (Model%iau_offset > 0) then
      kdt_iau = nint(Model%iau_offset*con_hr/Model%dtp)
      if (Model%kdt == kdt_iau+1) then
        iauwindow_center = .true.
        do nb = 1,nblks
          call Diag(nb)%rad_zero  (Model)
          call Diag(nb)%phys_zero (Model,iauwindow_center=iauwindow_center)
```
ccpp_driver.F90 is updated with the code.


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #976
- fixes https://github.com/NOAA-EMC/GFS/issues/1



## Testing

How were these changes tested?  
The code has been tested on hera with cpld_control_gfsv17 and cpld_control_gfsv17_iau tests. There is no change in cpld_control_gfsv17 and the changes in sfc, pgrb and restart/phys files are what we expected. The rt log files are under:

/scratch1/NCEPDEV/nems/Jun.Wang/nems/vlab/20250523/totprep/ufs-weather-model/tests/logs/log_hera:
rt_cpld_control_gfsv17_intel.log
rt_cpld_control_gfsv17_iau_intel.log

For cpld_control_gfsv17_iau, the pgrb24 file shows field differences, with no impact on bucket precip related fields:
```
6874c6874
860:51710820:vt=2021032312:surface:0-1 day acc fcst:APCP Total Precipitation [kg/m^2]:
<     ndata=72960:undef=0:mean=2.20412:min=0:max=85.125
---
>     ndata=72960:undef=0:mean=2.74013:min=0:max=96.1875

< 862:51782808:vt=2021032312:surface:0-1 day acc fcst:ACPCP Convective Precipitation [kg/m^2]:
<     ndata=72960:undef=0:mean=1.19379:min=0:max=44.5625
---
> 862:51784880:vt=2021032312:surface:0-1 day acc fcst:ACPCP Convective Precipitation [kg/m^2]:
>     ndata=72960:undef=0:mean=1.48688:min=0:max=51.75
< 864:51839342:vt=2021032312:surface:0-1 day acc fcst:NCPCP Large-Scale Precipitation (non-convective) [kg/m^2]:
<     ndata=72960:undef=0:mean=1.00914:min=0:max=69.8125
---
> 864:51843137:vt=2021032312:surface:0-1 day acc fcst:NCPCP Large-Scale Precipitation (non-convective) [kg/m^2]:
>     ndata=72960:undef=0:mean=1.25191:min=0:max=87.5625
6913,6914c6913,6914
< 865:51870935:vt=2021032312:surface:0-1 day acc fcst:FROZR Frozen Rain [kg/m^2]:
<     ndata=72960:undef=0:mean=0.00337536:min=0:max=1.4826
---
> 865:51877684:vt=2021032312:surface:0-1 day acc fcst:FROZR Frozen Rain [kg/m^2]:
>     ndata=72960:undef=0:mean=0.00663582:min=0:max=1.95496
6921,6922c6921,6922
< 866:51892809:vt=2021032312:surface:0-1 day acc fcst:FRZR Freezing Rain [kg/m^2]:
<     ndata=72960:undef=0:mean=0.00102056:min=0:max=1.255
---
> 866:51907601:vt=2021032312:surface:0-1 day acc fcst:FRZR Freezing Rain [kg/m^2]:
>     ndata=72960:undef=0:mean=0.00111388:min=0:max=1.255
6929,6930c6929,6930
< 867:51898053:vt=2021032312:surface:0-1 day acc fcst:TSNOWP Total Snow Precipitation [kg/m^2]:
<     ndata=72960:undef=0:mean=0.3984:min=0:max=62.87
---
> 867:51913552:vt=2021032312:surface:0-1 day acc fcst:TSNOWP Total Snow Precipitation [kg/m^2]:
>     ndata=72960:undef=0:mean=0.492066:min=0:max=75.91
```

## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>

