### PR TITLE
Glacier modifications in NoahMP to address GFSv17 biases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/barlage/ccpp-physics
+  branch = glacier_mods
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/barlage/ccpp-physics
-  branch = glacier_mods
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

Testing for GFSv17 exposed temperature and albedo biases over glacier regions. There were also large differences when compared to GFSv16 (current operational) and ERA5. To address these biases, the following changes are added:

- removal of albedo aging (current approach is probably too aggressive for remote locations like Antarctica and Greenland)
-change snow thermal conductivity to be consistent with that used in non-glacier NoahMP model
- keep the snow depth and density fixed over glacier following a similar approach used in other NWP systems; this includes cold starting glaciers with 2m of snow

Answers using NoahMP LSM will change




## Testing

- C1152 simulation on 2025-12-02 to test performance over Antarctica
- Regression tests run on ursa

## Dependencies

- testing requires: [barlage/ccpp-physics/glacier_mods](https://github.com/barlage/ccpp-physics/tree/glacier_mods)

- waiting on ufs-community/ccpp-physics/pull/316

