### PR TITLE
Fix initialization of Atmos%iau_offset

### DIFF
--- a/fv3/module_fcst_grid_comp.F90
+++ b/fv3/module_fcst_grid_comp.F90
@@ -765,6 +765,9 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
                                    Time_restart, num_restart_fh, &
                                    restart_fh)
 
+    ! Set IAU offset time
+    Atmos%iau_offset = iau_offset
+
 !------ initialize component models ------
 
      call  atmos_model_init (Atmos, Time_init, Time, Time_step)


### PR DESCRIPTION
## Description

This PR fixes a bug where the iau_offest was not being saved to Atmos%iau_offest. This bug resulted in the fixes introduced in #996 to not work as intended as discussed in https://github.com/NOAA-EMC/GFS/issues/1 .

The change has been tested and seems to fix the issue with #996.



### Issue(s) addressed

- fixes #1014 

## Testing

How were these changes tested?  **The entire RT suite was tested on Ursa.**
What compilers / HPCs was it tested with?  **Both Intel and GNU**
Are the changes covered by regression tests? **Yes**
Have the ufs-weather-model regression test been run? On what platform?  
**Full RT suite was run on Ursa. This only changes baselines on the v17 and GDAS RTs as expected.**


## Dependencies
None

