### PR TITLE
[production/RRFS.v1] fix RRFS/REFS restart reproducibility issues 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,10 @@
   path = atmos_cubed_sphere
 #  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
 #  branch = production/RRFS.v1
-  url = https://github.com/DusanJovic-NOAA/GFDL_atmos_cubed_sphere
-  branch = rrfs_v1_conus13km_tests
+#  url = https://github.com/DusanJovic-NOAA/GFDL_atmos_cubed_sphere
+#  branch = rrfs_v1_conus13km_tests
+  url = https://github.com/JiliDong-NOAA/GFDL_atmos_cubed_sphere
+  branch = restart_fix
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/RRFS.v1
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = production/RRFS.v1
+  url = https://github.com/JiliDong-NOAA/ccpp-physics    
+  branch = sigmab_restart_fix
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,13 +8,11 @@
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework
   branch = production/RRFS.v1
-[submodule "ccpp/physics"]
-  path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = production/RRFS.v1
-  url = https://github.com/JiliDong-NOAA/ccpp-physics    
-  branch = sigmab_restart_fix
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP
   branch = develop
+[submodule "ccpp/physics"]
+  path = ccpp/physics
+  url = https://github.com/JiliDong-NOAA/ccpp-physics.git
+  branch = sigmab_restart_fix

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,13 +6,11 @@
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework
   branch = production/RRFS.v1
-[submodule "ccpp/physics"]
-  path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = production/RRFS.v1
-  url = https://github.com/JiliDong-NOAA/ccpp-physics    
-  branch = sigmab_restart_fix
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP
   branch = develop
+[submodule "ccpp/physics"]
+  path = ccpp/physics
+  url = https://github.com/JiliDong-NOAA/ccpp-physics.git
+  branch = sigmab_restart_fix

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,20 +1,16 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-#  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-#  branch = production/RRFS.v1
-#  url = https://github.com/DusanJovic-NOAA/GFDL_atmos_cubed_sphere
-#  branch = rrfs_v1_conus13km_tests
-  url = https://github.com/JiliDong-NOAA/GFDL_atmos_cubed_sphere
-  branch = restart_fix
+  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+  branch = production/RRFS.v1
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework
+  branch = production/RRFS.v1
+[submodule "ccpp/physics"]
+  path = ccpp/physics
+  url = https://github.com/ufs-community/ccpp-physics
   branch = production/RRFS.v1
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP
   branch = develop
-[submodule "ccpp/physics"]
-  path = ccpp/physics
-  url = https://github.com/JiliDong-NOAA/ccpp-physics.git
-  branch = sigmab_restart_fix

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-  branch = production/RRFS.v1
+#  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+#  branch = production/RRFS.v1
+  url = https://github.com/DusanJovic-NOAA/GFDL_atmos_cubed_sphere
+  branch = rrfs_v1_conus13km_tests
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -3849,6 +3849,18 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'qss'
+    ExtDiag(idx)%desc = 'surface specific humidity'
+    ExtDiag(idx)%unit = 'kg/kg'
+    ExtDiag(idx)%mod_name = 'gfs_sfc'
+    ExtDiag(idx)%intpl_method = 'bilinear'
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => Sfcprop(nb)%qss(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 't2m'
     ExtDiag(idx)%desc = '2m temperature'
     ExtDiag(idx)%unit = 'K'

--- a/ccpp/driver/GFS_restart.F90
+++ b/ccpp/driver/GFS_restart.F90
@@ -179,7 +179,7 @@ module GFS_restart
       Restart%num3d = Restart%num3d + 9
     endif
     if (Model%rrfs_sd) then
-      Restart%num3d = Restart%num3d + 4
+      Restart%num3d = Restart%num3d + 5
     endif
     !Prognostic area fraction
     if (Model%progsigma) then
@@ -688,6 +688,11 @@ module GFS_restart
       Restart%name3d(num) = 'chem3d_3'
       do nb = 1,nblks
         Restart%data(nb,num)%var3p => Coupling(nb)%chem3d(:,:,3)
+      enddo
+      num = num + 1
+      Restart%name3d(num) = 'ebu_smoke'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var3p => Coupling(nb)%ebu_smoke(:,:)
       enddo
       num = num + 1
       Restart%name3d(num) = 'ext550'

--- a/io/fv3atm_restart_io.F90
+++ b/io/fv3atm_restart_io.F90
@@ -405,6 +405,8 @@ contains
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%tsnow_ice)
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%snowfallac_land)
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%snowfallac_ice)
+        call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%acsnow_land)
+        call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%acsnow_ice)
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%sfalb_lnd)
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%sfalb_lnd_bck)
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%sfalb_ice)

--- a/io/fv3atm_sfc_io.F90
+++ b/io/fv3atm_sfc_io.F90
@@ -123,9 +123,9 @@ contains
     endif
     if (Model%lsm == Model%lsm_ruc .and. warm_start) then
       if (Model%rdlai) then
-        nvar2r = 13
+        nvar2r = 15
       else
-        nvar2r = 12
+        nvar2r = 14
       endif
       nvar3  = 5
     else
@@ -534,6 +534,8 @@ contains
       nt=nt+1 ; sfc%name2(nt) = 'tsnow_ice'
       nt=nt+1 ; sfc%name2(nt) = 'snowfall_acc_land'
       nt=nt+1 ; sfc%name2(nt) = 'snowfall_acc_ice'
+      nt=nt+1 ; sfc%name2(nt) = 'acsnow_land'
+      nt=nt+1 ; sfc%name2(nt) = 'acsnow_ice'
       nt=nt+1 ; sfc%name2(nt) = 'sfalb_lnd'
       nt=nt+1 ; sfc%name2(nt) = 'sfalb_lnd_bck'
       nt=nt+1 ; sfc%name2(nt) = 'sfalb_ice'
@@ -1051,6 +1053,8 @@ contains
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%tsnow_ice)
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%snowfallac_land)
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%snowfallac_ice)
+        call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%acsnow_land)
+        call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%acsnow_ice)
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%sfalb_lnd)
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%sfalb_lnd_bck)
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%sfalb_ice)

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -59,7 +59,9 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
   use fv3atm_restart_io_mod,  only: fv_phy_restart_bundle_setup, fv_sfc_restart_bundle_setup
   use fv_ufs_restart_io_mod,  only: fv_core_restart_bundle_setup, &
                                     fv_srf_wnd_restart_bundle_setup, &
-                                    fv_tracer_restart_bundle_setup
+                                    fv_tracer_restart_bundle_setup, &
+                                    fv_diag_restart_bundle_setup
+  use module_diag_hailcast,   only: do_hailcast
 
   use fms2_io_mod,        only: FmsNetcdfFile_t, open_file, close_file, variable_exists, read_data
 
@@ -361,6 +363,9 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     else if (fb_name(1:21) == 'restart_fv_tracer.res') then
       call fv_tracer_restart_bundle_setup(fbList(1), grid, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+    else if (fb_name(1:19) == 'restart_fv_diag.res') then
+      call fv_diag_restart_bundle_setup(fbList(1), grid, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
     else
       do i=1, itemCount
         call fv_dyn_bundle_setup(Atmos%axes, fbList(i), grid, quilting=.true., rc=rc)
@@ -580,6 +585,11 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     integer,allocatable           :: grid_number_on_all_pets(:)
     logical,allocatable           :: is_moving_on_all_pets(:), is_moving(:)
     character(len=7)              :: nest_suffix
+
+    integer, parameter            :: MAX_NUM_DYN_BUNDLES = 10
+    character(len=esmf_maxstr), dimension(MAX_NUM_DYN_BUNDLES) :: dyn_bundles_name
+
+    integer                       :: num_dyn_bundles = 0
 
     type(FmsNetcdfFile_t)         :: fileobj
 !
@@ -1055,21 +1065,24 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 
         if ( quilting_restart ) then
 
-          do i=1,3 ! 3 dynamics restart bundles
+          ! Number of non-optional dyn bundles (core, srf_wnd and tracer)
+          num_dyn_bundles = 3
+          dyn_bundles_name(1) = 'restart_fv_core.res'
+          dyn_bundles_name(2) = 'restart_fv_srf_wnd.res'
+          dyn_bundles_name(3) = 'restart_fv_tracer.res'
+
+          ! Optional dyn bundles
+          if (do_hailcast) then
+             num_dyn_bundles = num_dyn_bundles + 1
+             dyn_bundles_name(num_dyn_bundles) = 'restart_fv_diag.res'
+          end if
+
+          do i=1,num_dyn_bundles ! dynamics restart bundles
 
             tempState = ESMF_StateCreate(rc=rc)
             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-            if (i == 1) then
-              name_FB = 'restart_fv_core.res'
-            elseif (i == 2) then
-              name_FB = 'restart_fv_srf_wnd.res'
-            elseif (i == 3) then
-              name_FB = 'restart_fv_tracer.res'
-            else
-              write(0,*)' unknown name_dynamics restart bundle ', i
-              ESMF_ERR_ABORT(101)
-            endif
+            name_FB = dyn_bundles_name(i)
 
             if (n > 1) then
               write(nest_suffix,'(A5,I2.2)') '.nest', n


### PR DESCRIPTION
## Description

This PR fixes RRFS/REFS restart bitwise reproducibility issues caused by:

1. RRFS smoke/dust components
2. HAILCAST variables updraft duration and mask not written out and read in the restart runs
3. snow equivalent water accumulation not written out to the restart file
4. saSAS convection initialization logic (i.e. qadv) needs to be corrected
5. Grell-Freitas convection initialization logic needs to be corrected (i.e. cold starting T/q tendency only applied in the first timestep)

Big thanks to @DusanJovic-NOAA for all his help and work!

The forecast will only change when Grell-Freitas is turned on during warm start runs with gf_coldstart being explicitly set to T in the namelist

This PR also includes a hook to output surface specific humidity, which may be needed for RRFS post-processing. 

### Issue(s) addressed

https://github.com/NOAA-EMC/ufsatm/issues/1020

## Testing

How were these changes tested?  

The changes have been tested with RRFS real case from real-time runs over a large north America domain.

What compilers / HPCs was it tested with?  

WCOSS2 with intel compiler

Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  

The changes are partially covered by regression test. To fully include these changes in regression tests, we need cases with winter weather (snow accumulation) and strong convection cases (strong updraft). Regression tests covering all REFS ensemble members are also needed.

Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
    No for the current RTs.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/91
https://github.com/ufs-community/ccpp-physics/pull/315

