### PR TITLE
Cloud cover parameter changes for GFSv17

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  url = https://github.com/RuiyuSun/ccpp-physics.git
-  #branch = ufs/dev
-  branch = moorthi_cover
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  #url = https://github.com/ufs-community/ccpp-physics
+  url = https://github.com/RuiyuSun/ccpp-physics.git
+  #branch = ufs/dev
+  branch = moorthi_cover
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

There is a low cloud bias in the current version of the GFSv17. The formula used in the cloud cover calculation is based Xu/Randall (1996). To increase the cloud cover in the GFSv17, a different set of parameters is used in the formulation. The increase in the cloud cover will also help to reduce the downward SW at the surface.



### Issue(s) addressed

This PR 
- fixes noaa-emc/fv3atm/issues/[<1026>](https://github.com/NOAA-EMC/ufsatm/issues/1026)



## Testing

How were these changes tested?  
This change has been used in a GFSv17 RETRO-like experiment on WCOSS2. RT tests are being conducted on the URSA. 

What compilers / HPCs was it tested with? 
Intel   

Are the changes covered by regression tests? 
YES 

Have the ufs-weather-model regression test been run? On what platform?  
The RT tests were conducted on the URSA. 

- Will the code updates change regression test baseline?  - Please show the baseline directory below.
- 
 This change will change the baseline. 
BASELINE DIRECTORY: /scratch4/NAGAPE/epic/role-epic/UFS-WM_RT/NEMSfv3gfs/develop-20251007

- Please commit the regression test log files in your ufs-weather-model branch
DONE. 

## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)
https://github.com/RuiyuSun/ccpp-physics/tree/moorthi_cover
https://github.com/ufs-community/ccpp-physics/pull/325


