### PR TITLE
Noahmp no stcslcadj at0inc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/tsga/ccpp-physics  #https://github.com/ufs-community/ccpp-physics
+  branch = noahmp_no_stcslcadj_at0inc  #ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/tsga/ccpp-physics  #https://github.com/ufs-community/ccpp-physics
-  branch = noahmp_no_stcslcadj_at0inc  #ufs/dev
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

After adding soil moisture (SLC) and temperature (STC) increments in ccpp-physics/Noahmp driver, adjustments are made to ensure consistency between liquid/frozen soil moisture and temperature. Currently this is applied even when all the increments are (intentionally) 0. We do not want to change the physics model predicted states when no/zero increments are added to STC and SLC.

The changes introduced in this PR check and skip the adjustment section if the magnitude of an increment is zero (below threshold).



### Issue(s) addressed

- [fixes NOAA-EMC/ufsatm/issues/1024](https://github.com/NOAA-EMC/ufsatm/issues/1024)


## Testing

Tested by running a low-res (C384C192) global workflow case with Soil DA, and comparing it to previous outputs without the code changes here. The results outputs have the expected changes.

UFSWM RT tests are currently running.


## Dependencies

Needs to be merged at the same time as 
https://github.com/ufs-community/ccpp-physics/pull/326
https://github.com/ufs-community/ufs-weather-model/pull/2941
