### PR TITLE
Modules fix explicit interface compiler warnings for post to call UPP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,8 +12,8 @@
   branch = ufs/dev
 [submodule "upp"]
   path = upp
-  url = https://github.com/NickSzapiro-NOAA/UPP
-  branch = warnings_upp
+  url = https://github.com/NOAA-EMC/UPP
+  branch = develop
 [submodule "mpas/MPAS-Model"]
   path = mpas/MPAS-Model
   url = https://github.com/ufs-community/MPAS-Model.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,8 +12,8 @@
   branch = ufs/dev
 [submodule "upp"]
   path = upp
-  url = https://github.com/NOAA-EMC/UPP
-  branch = develop
+  url = https://github.com/NickSzapiro-NOAA/UPP
+  branch = warnings_upp
 [submodule "mpas/MPAS-Model"]
   path = mpas/MPAS-Model
   url = https://github.com/ufs-community/MPAS-Model.git

--- a/io/post_fv3.F90
+++ b/io/post_fv3.F90
@@ -46,6 +46,12 @@ module post_fv3
                                lonstart,lonlast
       use grib2_module, only : gribit2,num_pset,nrecout,first_grbtbl
       use xml_perl_data,only : paramset
+      use read_xml_upp_mod, only : read_xml
+      use set_outflds_upp_mod, only : set_outflds
+      use get_postfilename_mod, only : get_postfilename
+      use process_upp_mod, only : process
+      use post_nems_routines_mod, only : read_postnmlt, post_alctvars, &
+                                         post_finalize
 !
 !-----------------------------------------------------------------------
 !
@@ -565,6 +571,9 @@ module post_fv3
       use physcons,    only: grav => con_g, fv => con_fvirt, rgas => con_rd,    &
                              eps => con_eps, epsm1 => con_epsm1
       use rqstfld_mod
+      use exch_upp_mod, only : exch
+      use table_upp_mod,  only : table
+      use tableq_upp_mod, only : tableq
 !
 !      use write_internal_state, only: wrt_internal_state
 !

--- a/io/post_nems_routines.F90
+++ b/io/post_nems_routines.F90
@@ -1,3 +1,9 @@
+      MODULE post_nems_routines_mod
+      
+      implicit none
+
+      contains
+
 !-----------------------------------------------------------------------
 !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 !-----------------------------------------------------------------------
@@ -28,6 +34,7 @@
                             ileft,iright,ileftb,irightb, &
                             icnt2, idsp2,isxa,iexa,jsxa,jexa, &
                             num_procs
+      use allocate_all_upp_mod, only: allocate_all
 !
 !-----------------------------------------------------------------------
 !
@@ -346,6 +353,7 @@
 !    Jul 2019 Jun Wang: finalize post step
 !
       use grib2_module, only : grib_info_finalize
+      use DE_ALLOCATE_UPP_MOD , only : de_allocate
 !
       character(*),intent(in) :: post_gribversion
 !
@@ -356,4 +364,6 @@
       call de_allocate
 !
     end subroutine post_finalize
+    
+    END MODULE post_nems_routines_mod
 

--- a/tests/test_post_nems_routines.F90
+++ b/tests/test_post_nems_routines.F90
@@ -5,6 +5,7 @@ program test_post_nems_routines
 
   use ctlblk_mod, only : komax,hyb_sigp,d3d_on,gocart_on, &
    rdaod,nasa_on,gccpp_on,d2d_chem,modelname,submodelname, lsm
+  use post_nems_routines_mod, only : read_postnmlt
 
   implicit none
 


### PR DESCRIPTION
## Description

To address a compiler warning in UFSATM to have explicit interfaces to UPP subroutines (https://github.com/NOAA-EMC/ufsatm/issues/1008), those subroutines are added to modules on UPP side (https://github.com/NOAA-EMC/UPP/pull/1351) and used in post here. This is bit-for-bit


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #1008



## Testing

How were these changes tested?  ufs-weather-model RTs
What compilers / HPCs was it tested with?  Ursa
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? No
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on https://github.com/NOAA-EMC/UPP/pull/1351

