### PR TITLE
add method_blsn to the namelist

### DIFF
--- a/io/post_nems_routines.F90
+++ b/io/post_nems_routines.F90
@@ -231,7 +231,7 @@ module post_nems_routines
                              lsmdef,ALSL,me,d3d_on,gocart_on,hyb_sigp,&
                              pthresh,novegtype,ivegsrc,icu_physics,   &
                              isf_surface_physics,modelname,submodelname,&
-                             rdaod,d2d_chem,nasa_on,gccpp_on
+                             rdaod,d2d_chem,nasa_on,gccpp_on,method_blsn
       use upp_ifi_mod, only: write_ifi_debug_files
 !
 !    revision history:
@@ -249,7 +249,7 @@ module post_nems_routines
 
       namelist/nampgb/kpo,po,kth,th,kpv,pv,popascal,d3d_on,gocart_on,  &
                       hyb_sigp,write_ifi_debug_files,rdaod,nasa_on,gccpp_on, &
-                      d2d_chem
+                      method_blsn,d2d_chem
       namelist/model_inputs/modelname,submodelname
 !---------------------------------------------------------------------
 !

--- a/io/post_nems_routines.F90
+++ b/io/post_nems_routines.F90
@@ -270,6 +270,7 @@ module post_nems_routines
       nasa_on     = .false.
       gccpp_on    = .false.
       d2d_chem    = .false.
+      method_blsn = .true. 
 !
       if (me == 0) print *,'post_namelist=',post_namelist
 !jw post namelist is using the same file itag as standalone post


### PR DESCRIPTION
## Description
This PR is to fix a bug associated with the inline UPP when the method_blsn is used in the visibility calculation in the calvis_gsd routine. 

If this method is used in the inline UPP visibility calculation the results will be changed. 

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes noaa-emc/fv3atm/issues/<1035>



## Testing

How were these changes tested?  Full RT test on URSA 
What compilers / HPCs was it tested with?  Intel 
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  YES 
Have the ufs-weather-model regression test been run? On what platform?  Full RT tests were completed on URSA 
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below. 
- Please commit the regression test log files in your ufs-weather-model branch (Committed to the UFS weather model PR)


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)
https://github.com/NOAA-EMC/UPP/pull/1369

Do PRs in upstream repositories need to be merged first? NO


