### PR TITLE
Add snow temperature for all three snow layers in the history files

### DIFF
--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -3368,6 +3368,28 @@ module GFS_diagnostics
       ExtDiag(idx)%data%var3 => sfcprop%stc(:,:)
    endif
 
+   if (Model%lsm == Model%lsm_noahmp) then
+      do num = Model%lsnow_lsm_lbound, Model%lsnow_lsm_ubound
+         write (xtra,'(i1)') abs(num)+1
+         idx = idx + 1
+         ExtDiag(idx)%axes = 2
+         ExtDiag(idx)%name = 'snowt'//trim(xtra)
+         ExtDiag(idx)%desc = 'Snow temperature at layer ' // trim(xtra) // ' (from the bottom)'
+         ExtDiag(idx)%unit = 'K'
+         ExtDiag(idx)%mod_name = 'gfs_sfc'
+         ExtDiag(idx)%intpl_method = 'nearest_stod'
+         ExtDiag(idx)%data%var2 => sfcprop%tsnoxy(:,num)
+      enddo
+      idx = idx + 1
+      ExtDiag(idx)%axes = 3
+      ExtDiag(idx)%name = 'snowt'
+      ExtDiag(idx)%desc = 'Snow temperature'
+      ExtDiag(idx)%unit = 'K'
+      ExtDiag(idx)%mod_name = 'gfs_sfc'
+      ExtDiag(idx)%intpl_method = 'nearest_stod'
+      ExtDiag(idx)%data%var3 => sfcprop%tsnoxy(:,:)
+   endif
+
 !--------------------------nsst variables
   if (model%nstf_name(1) > 0) then
 !--------------------------nsst variables


### PR DESCRIPTION
## Description
This PR adds a small section of code in ccpp/driver/GFS_diagnostics.F90 to enable snow temperature output in the history files.

## Issue(s) addressed
https://github.com/NOAA-EMC/ufsatm/issues/1041

## Testing
- How were these changes tested?  
  We verified that snow temperature exists in the history file after adding the code and including the corresponding variables in parm/ufs/fv3/diag_table_da.

- What compilers / HPCs was it tested with?  
  These changes have been tested on RDHPCS such as Hera, Ursa, Gaea, and Orion. 

## Dependencies
To get the snow temperature in the history files, we need to add the corresponding variables to parm/ufs/fv3/diag_table_da as:
"gfs_sfc", "snowt1", "snowt1" "fv3_history2d", "all", .false., "none", 2
"gfs_sfc", "snowt2", "snowt2" "fv3_history2d", "all", .false., "none", 2
"gfs_sfc", "snowt3", "snowt3" "fv3_history2d", "all", .false., "none", 2