### PR TITLE
Replace 1038: Fix time-averaged radiation variables

### DIFF
--- a/fv3/atmos_model.F90
+++ b/fv3/atmos_model.F90
@@ -978,6 +978,7 @@ subroutine update_atmos_model_state (Atmos, rc)
 !--- local variables
   integer :: i, localrc, sec_lastfhzerofh
   integer :: isec, seconds, isec_fhzero
+  integer :: dtatm_temp
   logical :: tmpflag_fhzero
   real(kind=GFS_kind_phys) :: time_int, time_intfull
 !
@@ -1012,9 +1013,10 @@ subroutine update_atmos_model_state (Atmos, rc)
       if (mpp_pe() == mpp_root_pe()) write(6,*) 'gfs diags time since last bucket empty: ',time_int,' time_intfull=', &
          time_intfull,' kdt=',GFS_control%kdt
       call atmosphere_nggps_diag(Atmos%Time)
+      call get_time ( Atmos%Time_step, dtatm_temp)
       call fv3atm_diag_output(Atmos%Time, GFS_Diag, Atm_block, GFS_control%nx, GFS_control%ny, &
                             GFS_control%levs, 1, 1, 1.0_GFS_kind_phys, time_int, time_intfull, &
-                            GFS_control%fhswr, GFS_control%fhlwr, GFS_control)
+                            GFS_control%fhswr, GFS_control%fhlwr, GFS_control, dtatm_temp)
     endif
 
     !---  find current fhzero

--- a/io/fv3atm_history_io.F90
+++ b/io/fv3atm_history_io.F90
@@ -115,13 +115,13 @@ CONTAINS
   !! This routine transfers diagnostic data to the FMS diagnostic
   !!  manager for eventual output to the history files.
   subroutine fv3atm_diag_output(time, diag, atm_block, nx, ny, levs, ntcw, ntoz, &
-       dt, time_int, time_intfull, time_radsw, time_radlw, Model)
+       dt, time_int, time_intfull, time_radsw, time_radlw, Model, dt_atmos)
     !--- subroutine interface variable definitions
     type(time_type),           intent(in) :: time
     type(GFS_externaldiag_type),       intent(in) :: diag(:)
     type (block_control_type), intent(in) :: atm_block
     type(GFS_control_type),    intent(in) :: Model
-    integer,                   intent(in) :: nx, ny, levs, ntcw, ntoz
+    integer,                   intent(in) :: nx, ny, levs, ntcw, ntoz, dt_atmos
     real(kind=kind_phys),      intent(in) :: dt
     real(kind=kind_phys),      intent(in) :: time_int
     real(kind=kind_phys),      intent(in) :: time_intfull
@@ -129,7 +129,7 @@ CONTAINS
     real(kind=kind_phys),      intent(in) :: time_radlw
 
     call shared_history_data%output(time, diag, atm_block, nx, ny, levs, ntcw, ntoz, &
-         dt, time_int, time_intfull, time_radsw, time_radlw, Model)
+         dt, time_int, time_intfull, time_radsw, time_radlw, Model, dt_atmos)
 
   end subroutine fv3atm_diag_output
 
@@ -282,14 +282,14 @@ CONTAINS
   !! implementation of the public fv3atm_diag_output routine. Never
   !! call this directly.
   subroutine history_type_output(hist, time, diag, atm_block, nx, ny, levs, ntcw, ntoz, &
-       dt, time_int, time_intfull, time_radsw, time_radlw, Model)
+       dt, time_int, time_intfull, time_radsw, time_radlw, Model, dt_atmos)
     !--- subroutine interface variable definitions
     class(history_type)                   :: hist
     type(time_type),           intent(in) :: time
     type(GFS_externaldiag_type),       intent(in) :: diag(:)
     type (block_control_type), intent(in) :: atm_block
     type(GFS_control_type),    intent(in) :: Model
-    integer,                   intent(in) :: nx, ny, levs, ntcw, ntoz
+    integer,                   intent(in) :: nx, ny, levs, ntcw, ntoz, dt_atmos
     real(kind=kind_phys),      intent(in) :: dt
     real(kind=kind_phys),      intent(in) :: time_int
     real(kind=kind_phys),      intent(in) :: time_intfull
@@ -310,8 +310,8 @@ CONTAINS
 
     rtime_int     = one/time_int
     rtime_intfull = one/time_intfull
-    rtime_radsw   = one/time_radsw
-    rtime_radlw   = one/time_radlw
+    rtime_radsw   = one/(time_radsw * (int((time_int-dt_atmos)/time_radsw)+1))
+    rtime_radlw   = one/(time_radlw * (int((time_int-dt_atmos)/time_radlw)+1))
 
     !     if(mpp_pe()==mpp_root_pe())print *,'in,fv3atm_io. time avg, time_int=',time_int
     history_loop: do idx = 1,hist%tot_diag_idx
@@ -322,13 +322,13 @@ CONTAINS
             lcnvfac = lcnvfac*rtime_intfull
             !             if(mpp_pe()==mpp_root_pe())print *,'in,fv3atm_io. full time avg, field=',trim(Diag(idx)%name),' time=',time_intfull
           else if ( trim(diag(idx)%time_avg_kind) == 'rad_lw' ) then
-            lcnvfac = lcnvfac*min(rtime_radlw,rtime_int)
+            lcnvfac = lcnvfac*rtime_radlw
             !             if(mpp_pe()==mpp_root_pe())print *,'in,fv3atm_io. rad longwave avg, field=',trim(Diag(idx)%name),' time=',time_radlw
           else if ( trim(diag(idx)%time_avg_kind) == 'rad_sw' ) then
-            lcnvfac = lcnvfac*min(rtime_radsw,rtime_int)
+            lcnvfac = lcnvfac*rtime_radsw
             !             if(mpp_pe()==mpp_root_pe())print *,'in,fv3atm_io. rad shortwave avg, field=',trim(Diag(idx)%name),' time=',time_radsw
           else if ( trim(diag(idx)%time_avg_kind) == 'rad_swlw_min' ) then
-            lcnvfac = lcnvfac*min(max(rtime_radsw,rtime_radlw),rtime_int)
+            lcnvfac = lcnvfac*max(rtime_radsw,rtime_radlw)
             !             if(mpp_pe()==mpp_root_pe())print *,'in,fv3atm_io. rad swlw min avg, field=',trim(Diag(idx)%name),' time=',time_radlw,time_radsw,time_int
           else
             lcnvfac = lcnvfac*rtime_int


### PR DESCRIPTION
Information copied from #1038 

## Description

This PR fixes some of  the UFS-ATM issue discussed in ufs-weather-model issues #1767. 
https://github.com/ufs-community/ufs-weather-model/issues/1767
The problem in retro tests has been discussed in detail in GFS issues #43:
https://github.com/NOAA-EMC/GFS/issues/43#issuecomment-3457383271
@JongilHan66 noticed the time averaged cloud cover, which should range from 0-100%, only range across 0-4% in his experiment based on the retrotest16update branch . Abnormal ranges happen to all time averaged cloud cover, and related radiative fluxes. The instantaneous cloud covers and radiative fluxes are fine. The issue is from the UWM and exists in the sfc history files.
There are two different problems related to the radiation fields, one is the instantaneous values used for the coupling (the radiation time step is 3600s, and the physics time step or dynamic time steps are much smaller, for example 360s or 720s), so the coupling need to estimate the radiation flux at the coupling time step which needs to extrapolate the radiation fluxes from the earlier radiation calculation. This extrapolation is not a bug, but not accurate. The second problem is the time-averaged calculation which is a bug. The time-averaged quantities related to the radiation variables are wrong in current UFS community repository.
As Fanglin mentioned in his e-mail: 
"This outstanding issue has been affecting us for some time. A number of  people have been involved in the discussion or contributed code changes in the past few years.  Thank you, in particular, Denise for bringing the issue to everyone's attention in the first place, Grant, for taking this over after Larissa's departure, Dusan, for providing the working solution, and Qingfu, for the testing and confirmation."

The changes of answers are expected from this PR.

### Issue(s) addressed

- ufs-weather-model issues #1767
     https://github.com/ufs-community/ufs-weather-model/issues/1767
- fixes GFS issues #43
     https://github.com/NOAA-EMC/GFS/issues/43#issuecomment-3457383271


## Testing

The code changes have been tested in ufs-weather-model regression tests, and the results have been plotted/diagnosed for all the radiation related variables.
The code updates change the regression test baseline if the output interval is smaller than the averaging interval, otherwise, the code will not change the test baseline.
(no regression test log files since I have not run all the baseline tests. Hope someone can help to run the regression tests and provide the log files)

## Dependencies

No dependency
 