### PR TITLE
Allow ihr to be non-multiples of 6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = develop
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = ufs/dev
+  url = https://github.com/DavidHuber-NOAA/ccpp-physics
+  branch = feature/gcycle_non6
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = develop
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = ufs/dev
-  url = https://github.com/DavidHuber-NOAA/ccpp-physics
-  branch = feature/gcycle_non6
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description
This PR brings in changes to ccpp-physics that allow ihr to be non-mulitples of 6 fixing an issue found in testing for GFS V17.

This PR is high priority due to changes needed for GFS v17.

### Issue(s) addressed
- NOAA-EMC/global-workflow/issues/4364

## Testing
Will be tested with UFSWM RT system

## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
* ufs-community/ccpp-physics/pull/336

