### PR TITLE
[production/GFS.v17] Add CCPP Physics production branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = ufs/dev
-  url = https://github.com/XiaqiongZhou-NOAA/ccpp-physics
-  branch = dev_alt_dfac
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = production/GFS.v17
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = ufs/dev
+  url = https://github.com/XiaqiongZhou-NOAA/ccpp-physics
+  branch = dev_alt_dfac
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This PR updates the CCPP physics submodule to point to the `production/GFSv17` branch.
It will also bring in a hotfix for an issue in GFSv17 retro runs: https://github.com/ufs-community/ccpp-physics/pull/347

## Testing

How were these changes tested?  These changes were tested on Ursa using the UFSWM RTs 
Have the ufs-weather-model regression test been run? On what platform?  These changes were tested on Ursa using the UFSWM RTs 
- Will the code updates change regression test baseline? Baseline changes were expected and did change when tested with the RT suite.


## Dependencies
- None

