### PR TITLE
[production/RRFS.v1] UFSATM layer for RUC LSM speedup in CCPP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/RRFS.v1
+#   url = https://github.com/ufs-community/ccpp-physics
+#  branch = production/RRFS.v1
+  url = https://github.com/MatthewPyle-NOAA/ccpp-physics
+  branch = feature/smokefix
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/RRFS.v1
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = production/RRFS.v1
+  url = https://github.com/MatthewPyle-NOAA/ccpp-physics
+  branch = feature/rucspeedupredo
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = production/RRFS.v1
-  url = https://github.com/MatthewPyle-NOAA/ccpp-physics
-  branch = feature/rucspeedupredo
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = production/RRFS.v1
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-  branch = production/RRFS.v1
+#   url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+#   branch = production/RRFS.v1
+    url = https://github.com/JiliDong-NOAA/GFDL_atmos_cubed_sphere
+    branch = hailcast_bug_fix
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-#   url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-#   branch = production/RRFS.v1
-    url = https://github.com/JiliDong-NOAA/GFDL_atmos_cubed_sphere
-    branch = hailcast_bug_fix
+  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+  branch = production/RRFS.v1
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description

This PR points at a ccpp-physics PR that brings in a zero-difference speedup in the RUC LSM physics.

And now also points at a change impacting RRFS smoke (so the ccpp-physics feature branch no longer matches the umbrella branch names that reflect the original change of this PR)

### Issue(s) addressed

- partially addresses [ufs-community/ufs-weather-model/discussions/<3023>](https://github.com/ufs-community/ufs-weather-model/discussions/3023)



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch

These changes were tested with the RRFS subset of UFS WM regression tests on WCOSS2 so far.  Answers for two tests were updated due to expected changes to answers.  WCOSS regression test log file is updated in https://github.com/MatthewPyle-NOAA/ufs-weather-model/tree/feature/rucspeedupredo


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

https://github.com/MatthewPyle-NOAA/ccpp-physics/tree/feature/smokefix
https://github.com/MatthewPyle-NOAA/ufs-weather-model/tree/feature/rucspeedupredo

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>

