### PR TITLE
[production/GFS.v17] Add pointer to UPP prod/gfsv17 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP
-  branch = develop
+  branch = release/gfs_v17
 [submodule "mpas/MPAS-Model"]
   path = mpas/MPAS-Model
   url = https://github.com/ufs-community/MPAS-Model.git


### PR DESCRIPTION
## Description

This PR will bring in the UPP hash for the production/GFS.v17 branch (named release/gfs_v17) in the UFSATM production/GFS.v17 branch. Included is a fix to a race condition (https://github.com/NOAA-EMC/UPP/pull/1413) that is also now included at the head of UPP develop (https://github.com/NOAA-EMC/UPP/pull/1402) and will be added to the UFSWM develop branch.



### Issue(s) addressed

No issue in UFSATM


## Testing

For the production branch, this was tested against production baselines that were created and maintained by @dpsarmie .


## Dependencies

No dependencies

