### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 # ufsatm
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NOAA-EMC/ufsatm)
 
 This repository contains a driver and key subcomponents of the
 atmospheric component of the NOAA's [Unified Forecast System


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/NOAA-EMC/ufsatm) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.