### PR TITLE
[production/GFS.v17] Add option for zstandard restart files and update FV3 hash

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "fv3/atmos_cubed_sphere"]
   path = fv3/atmos_cubed_sphere
   url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  branch = production/GFS.v17
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/io/module_fv3_io_def.F90
+++ b/io/module_fv3_io_def.F90
@@ -100,13 +100,13 @@ module module_fv3_io_def
 
   !> Deflate level to use, 0 means no deflate.
   integer,dimension(:),allocatable  :: ideflate
-
+  integer,dimension(:),allocatable  :: ideflate_rst
   !> Number of significant digits for lossy compression.
   integer,dimension(:),allocatable  :: quantize_nsd
 
   !> Zstandard compression level, 0 means no zstandard compression.
   integer,dimension(:),allocatable  :: zstandard_level
-
+  integer,dimension(:),allocatable  :: zstandard_level_rst
   !> Quantize mode to use for lossy compression.
   character(len=esmf_maxstr),dimension(:),allocatable :: quantize_mode
 

--- a/io/module_write_restart_netcdf.F90
+++ b/io/module_write_restart_netcdf.F90
@@ -10,7 +10,7 @@ module module_write_restart_netcdf
   use mpi_f08
   use esmf
   use netcdf
-  use module_fv3_io_def,only : zstandard_level
+  use module_fv3_io_def,only : zstandard_level_rst
 
   implicit none
   private
@@ -417,8 +417,8 @@ module module_write_restart_netcdf
 
          ncerr = nf90_def_var_chunking(ncid, varids(i), NF90_CHUNKED, chunksizes) ; NC_ERR_STOP(ncerr)
 
-         if (zstandard_level(1) > 0) then
-            ncerr = nf90_def_var_zstandard(ncid, varids(i), zstandard_level(1))
+         if (zstandard_level_rst(1) > 0) then
+            ncerr = nf90_def_var_zstandard(ncid, varids(i), zstandard_level_rst(1))
             if (ncerr /= nf90_noerr) then
                if (ncerr == nf90_enofilter) then
                   if (mype == 0) write(0,*) 'Zstandard filter not found.'

--- a/io/module_wrt_grid_comp.F90
+++ b/io/module_wrt_grid_comp.F90
@@ -44,6 +44,7 @@
                                      cen_lon, cen_lat,                         &
                                      lon1, lat1, lon2, lat2, dlon, dlat,       &
                                      stdlat1, stdlat2, dx, dy, iau_offset,     &
+                                     ideflate_rst, zstandard_level_rst,        &
                                      ideflate, zstandard_level, lflname_fulltime
      use module_write_netcdf, only : write_netcdf
      use module_write_restart_netcdf, only : write_restart_netcdf
@@ -378,9 +379,11 @@
      allocate(jchunk3d(ngrids))
      allocate(kchunk3d(ngrids))
      allocate(ideflate(ngrids))
+     allocate(ideflate_rst(ngrids))
      allocate(quantize_mode(ngrids))
      allocate(quantize_nsd(ngrids))
      allocate(zstandard_level(ngrids))
+     allocate(zstandard_level_rst(ngrids))
 
      allocate(wrt_int_state%out_grid_info(ngrids))
 
@@ -494,11 +497,15 @@
 
        ! zstandard compression flag
        call ESMF_ConfigGetAttribute(config=CF,value=zstandard_level(n),default=0,label ='zstandard_level:',rc=rc)
+       call ESMF_ConfigGetAttribute(config=CF,value=zstandard_level_rst(n),default=0,label ='zstandard_level_rst:',rc=rc)
        if (zstandard_level(n) < 0) zstandard_level(n)=0
+       if (zstandard_level_rst(n) < 0) zstandard_level_rst(n)=0
 
        ! zlib compression flag
        call ESMF_ConfigGetAttribute(config=CF,value=ideflate(n),default=0,label ='ideflate:',rc=rc)
+       call ESMF_ConfigGetAttribute(config=CF,value=ideflate_rst(n),default=0,label ='ideflate_rst:',rc=rc)
        if (ideflate(n) < 0) ideflate(n)=0
+       if (ideflate_rst(n) < 0) ideflate_rst(n)=0
 
        if (ideflate(n) > 0 .and. zstandard_level(n) > 0) then
           write(0,*)"wrt_initialize_p1: zlib and zstd compression cannot be both enabled at the same time"


### PR DESCRIPTION
## Description

This PR will add a requested feature that is needed for GFS.v17.  The current compression options apply to both the ATM output and for the restart files. A request was made to allow for separate compression options to be applied to the output and the restart files. (In this case, deflate option to the output and zstandard compression to the restart files).

This PR will allow for the compression options to be set separately in the `model_configure` file in UFS. 

We will still need to discuss whether or not to also have this feature pushed to `develop`.

This PR will also change the `.gitmodule` files to point to the production branch made in the `atmos_cubed` repo.



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- Closes #1069



## Testing

How were these changes tested?  
A quick test was done to make sure that the files were being compressed with the appropriate algorithm option. A full RT test will be done soon.
What compilers / HPCs was it tested with?  This will be tested on WCOSS2, Gaea, and Ursa
Are the changes covered by regression tests? Yes
Have the ufs-weather-model regression test been run? On what platform?  This will be tested on WCOSS2, Gaea, and Ursa
- Will the code updates change regression test baseline? **Testing in progress**


## Dependencies

None

