### PR TITLE
Add Tiedtke CP related namelist options and introduce wind and PBLH dependent mixing length limits in GFS PBL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = develop
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/hafs-community/ccpp-physics
+  branch = feature/hafs_tiedtke_varml
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1368,6 +1368,8 @@ module GFS_typedefs
                                             !< Until a realistic Nccn is provided, Nccns are assumed
                                             !< as Nccn=100 for sea and Nccn=1000 for land
     real(kind=kind_phys) :: cat_adj_deep    !< adjustment for convective advection time for deep convection
+    integer              :: scale_fac_opt   !< control for Scale Awareness Options in the Tiedtke Convection Scheme
+    integer              :: icu_zoentr      !< options for using different entrainment for Tiedtke Convection Scheme
 
 !--- mass flux shallow convection
     real(kind=kind_phys) :: clam_shal       !< c_e for shallow convection (Han and Pan, 2011, eq(6))
@@ -3976,6 +3978,8 @@ module GFS_typedefs
                                                              !< Until a realistic Nccn is provided, Nccns are assumed
                                                              !< as Nccn=100 for sea and Nccn=1000 for land
     real(kind=kind_phys) :: cat_adj_deep   = 1.0             !< adjustment for convective advection time for deep convection
+    integer              :: scale_fac_opt  = 0               !< control for Scale Awareness Options in the Tiedtke Convection Scheme
+    integer              :: icu_zoentr     = 1               !< options for using different entrainment for Tiedtke Convection Scheme
 
 !--- mass flux shallow convection
     real(kind=kind_phys) :: clam_shal      = 0.3             !< c_e for shallow convection (Han and Pan, 2011, eq(6))
@@ -4305,7 +4309,7 @@ module GFS_typedefs
                           !--- mass flux deep convection
                                clam_deep, c0s_deep, c1_deep, betal_deep,                    &
                                betas_deep, evef, evfact_deep, evfactl_deep, pgcon_deep,     &
-                               asolfac_deep, cat_adj_deep,                                  &
+                               asolfac_deep, cat_adj_deep, scale_fac_opt, icu_zoentr,       &
                           !--- mass flux shallow convection
                                clam_shal, c0s_shal, c1_shal, pgcon_shal, asolfac_shal,      &
                                cat_adj_shal,                                                &
@@ -5332,6 +5336,8 @@ module GFS_typedefs
     Model%pgcon_deep       = pgcon_deep
     Model%asolfac_deep     = asolfac_deep
     Model%cat_adj_deep     = cat_adj_deep
+    Model%scale_fac_opt    = scale_fac_opt
+    Model%icu_zoentr       = icu_zoentr
 
 !--- mass flux shallow convection
     Model%clam_shal        = clam_shal
@@ -7272,6 +7278,8 @@ module GFS_typedefs
         print *, ' pgcon_deep        : ', Model%pgcon_deep
         print *, ' asolfac_deep      : ', Model%asolfac_deep
         print *, ' cat_adj_deep      : ', Model%cat_adj_deep
+        print *, ' scale_fac_opt     : ', Model%scale_fac_opt
+        print *, ' icu_zoentr        : ', Model%icu_zoentr
         print *, ' '
       endif
       if (Model%imfshalcnv >= 0) then

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -6220,6 +6220,18 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[scale_fac_opt]
+  standard_name = control_for_scale_awareness_options_in_Tiedtke
+  long_name = control for scale awareness options in the Tiedtke scheme
+  units = none
+  dimensions = ()
+  type = integer
+[icu_zoentr]
+  standard_name = option_for_different_entrainment_in_Tiedtke
+  long_name = option for different entrainment in Tiedtke
+  units = none
+  dimensions = ()
+  type = integer
 [clam_shal]
   standard_name = entrainment_rate_coefficient_for_shallow_convection
   long_name = entrainment rate coefficient for shallow convection


### PR DESCRIPTION
## Description

Add Tiedtke CP related namelist options and introduce wind and PBLH dependent mixing length scales in GFS PBL.
 - From @AndrewHazelton: Add a namelist option to control scale-awareness option in Tiedtke CP.
 - From @JunghoonShin-NOAA: Add a namelist variable, icu_zoentr, for using a different entrainment equation in Tiedtke CP.
 - From @WeiguoWang-NOAA: Introduce wind speed and PBLH dependent mixing length limits in GFS PBL scheme.

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes ufs-community/ccpp-physics/issues/357
- fixes ufs-community/ccpp-physics/issues/358
- fixes ufs-community/ccpp-physics/issues/356

## Testing

Development and testing were done with HAFS.

## Dependencies
Related PRs:
- waiting on ufs-community/ccpp-physics/pull/359
- needed by ufs-community/ufs-weather-model/pull/3104