### PR TITLE
[production/GFS.v17] CCPP warning reduction and FV3 warning range adjustment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = production/GFS.v17
-  url=https://github.com/NickSzapiro-NOAA/ccpp-physics
-  branch=ccpp_longComment_gfs
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = production/GFS.v17
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/GFS.v17
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = production/GFS.v17
+  url=https://github.com/NickSzapiro-NOAA/ccpp-physics
+  branch=ccpp_longComment_gfs
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description
This PR is for production only. It adds some changes that reduces remarks in CCPP physics (a more robust change to address this is currently bein worked on for develop) and a change to the temperature range that triggers a warning in FV3 (discussions are also underway to see if this should go into develop).


### Issue(s) addressed

No issue; just hash updates for GFS.v17



## Testing

How were these changes tested?  
These changes were tested using the regression tests in UFSWM to make sure that the baselines in the production/GFS.v17 branch were not changed.


## Dependencies

None. Submodule PRs were already merged into their respective production branches.

