### PR TITLE
[production/RRFS.v1] Hailcast bug fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-  branch = production/RRFS.v1
+#  url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+#  branch = production/RRFS.v1
+  url = https://github.com/JiliDong-NOAA/GFDL_atmos_cubed_sphere 
+  branch = hailcast_bug_fix 
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description

This PR is to fix RRFS crash related to hailcast under DEBUG compilation. When the hail embryo temperature falls outside the range of the vertical temperature column, which happens occasionally, NaNs are generated. The fix is to initialize several variables before the interpolation

This PR has been tested for RRFS and no changes are expected on the forecast when compiling without DEBUG.


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>

