### PR TITLE
Fix averaging for FH000 when using IAU

### DIFF
--- a/fv3/atmos_model.F90
+++ b/fv3/atmos_model.F90
@@ -956,7 +956,9 @@ subroutine update_atmos_model_state (Atmos, rc)
 
     call get_time (Atmos%Time - diag_time, isec)
     call get_time (Atmos%Time - Atmos%Time_init, seconds)
-    call get_time (Atmos%Time - diag_time_fhzero, isec_fhzero)
+    if(Atmos%iau_offset > zero) then
+      call get_time (Atmos%Time - diag_time_fhzero, isec_fhzero)
+    endif
     call atmosphere_nggps_diag(Atmos%Time,ltavg=.true.,avg_max_length=avg_max_length)
     if (ANY(nint(output_fh(:)*3600.0) == seconds) .or. (GFS_control%kdt == first_kdt)) then
       if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds

--- a/fv3/atmos_model.F90
+++ b/fv3/atmos_model.F90
@@ -741,6 +741,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
 
    !--- set the initial diagnostic timestamp
    diag_time = Time
+   diag_time_fhzero = Atmos%Time_init
    call get_time (Atmos%Time - Atmos%Time_init, sec)
    call set_fhzero_loop(sec, sec_lastfhzerofh)
    if (mpp_pe() == mpp_root_pe()) print *,'in atmos_model, fhzero=',GFS_Control%fhzero, 'fhour=',sec/3600.,sec_lastfhzerofh/3600
@@ -956,9 +957,7 @@ subroutine update_atmos_model_state (Atmos, rc)
 
     call get_time (Atmos%Time - diag_time, isec)
     call get_time (Atmos%Time - Atmos%Time_init, seconds)
-    if(Atmos%iau_offset > zero) then
-      call get_time (Atmos%Time - diag_time_fhzero, isec_fhzero)
-    endif
+    call get_time (Atmos%Time - diag_time_fhzero, isec_fhzero)
     call atmosphere_nggps_diag(Atmos%Time,ltavg=.true.,avg_max_length=avg_max_length)
     if (ANY(nint(output_fh(:)*3600.0) == seconds) .or. (GFS_control%kdt == first_kdt)) then
       if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds

--- a/fv3/atmos_model.F90
+++ b/fv3/atmos_model.F90
@@ -956,12 +956,13 @@ subroutine update_atmos_model_state (Atmos, rc)
 
     call get_time (Atmos%Time - diag_time, isec)
     call get_time (Atmos%Time - Atmos%Time_init, seconds)
+    call get_time (Atmos%Time - diag_time_fhzero, isec_fhzero)
     call atmosphere_nggps_diag(Atmos%Time,ltavg=.true.,avg_max_length=avg_max_length)
     if (ANY(nint(output_fh(:)*3600.0) == seconds) .or. (GFS_control%kdt == first_kdt)) then
       if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds
       time_int = real(isec)
       time_intfull = real(seconds)
-      call InitTimeFromIAUOffset(Atmos, time_int, time_intfull)
+      call InitTimeFromIAUOffset(Atmos, time_int, time_intfull, seconds, isec_fhzero)
       if (mpp_pe() == mpp_root_pe()) write(6,*) 'gfs diags time since last bucket empty: ',time_int,' time_intfull=', &
          time_intfull,' kdt=',GFS_control%kdt
       call atmosphere_nggps_diag(Atmos%Time)
@@ -1006,16 +1007,22 @@ subroutine update_atmos_model_state (Atmos, rc)
   !> @param[inout] atmos the main atmos model configurations 
   !> @param[inout] time_init model initialization time
   !> @param[inout] time_intfull model time remaining
+  !> @param[in]    seconds runtime from model initialization
+  !> @param[in]    isec_fhzero model time delta from init to forecast hour 00
   !>
   !> @author Daniel Sarmiento @date May 16, 2025
- subroutine InitTimeFromIAUOffset(Atmos, time_int, time_intfull)
+  !> @date Mar 24, 2026 :: Fix average fields at f000 when using IAU
+ subroutine InitTimeFromIAUOffset(Atmos, time_int, time_intfull, seconds, isec_fhzero)
 
    type (atmos_data_type),   intent(inout)  :: Atmos
    real(kind=GFS_kind_phys), intent(inout)  :: time_int, time_intfull
+   integer,                  intent(in)     :: seconds, isec_fhzero
 
    if(Atmos%iau_offset > zero) then
      if( time_int - Atmos%iau_offset*3600. > zero ) then
        time_int = time_int - Atmos%iau_offset*3600.
+     else if (seconds == nint(Atmos%iau_offset*3600.)) then
+       time_int = real(isec_fhzero)
      endif
      if( time_intfull - Atmos%iau_offset*3600. > zero) then
        time_intfull = time_intfull - Atmos%iau_offset*3600.


### PR DESCRIPTION
## Description

A bug was reported (https://github.com/NOAA-EMC/GFS/issues/53) where the averaged fields in `sfcf000.nc` were not being calculated correctly. This occurred when in IAU mode and only affected the sfc file at fh000. 

The fix involves adding a case for fh000 in the `InitTimeFromIAUOffset` subroutine in `./fv3/atmos_model.F90` where the correct averaging window is set. The functionality at other points in the model remains untouched. `diag_time_fhzero` was also initialized for non-IAU cases to prevent errors. This variable is not used in non-IAU cases so that functionality remains the same.

The variables that changed in sfcf000.nc in the GFSv17 tests were the following:
```
cduvb_ave
cpratb_ave
csdlf
csdsf
csulf
csulftoa
csusf
csusftoa
cwork_aveclm
dlwrf_ave
dswrf_ave
dswrf_avetoa
duvb_ave
evbs_ave
evcw_ave
gflux_ave
lhtfl_ave
nbdsf_ave
nddsf_ave
pah_ave
pevpr_ave
prateb_ave
pres_avehcb
pres_avehct
pres_avelcb
pres_avelct
pres_avemcb
pres_avemct
sbsno_ave
shtfl_ave
snohf
snowc_ave
tcdc_avebndcl
tcdc_aveclm
tcdc_avehcl
tcdc_avelcl
tcdc_avemcl
tmp_avehct
tmp_avelct
tmp_avemct
trans_ave
u-gwd_ave
uflx_ave
ulwrf_ave
ulwrf_avetoa
uswrf_ave
uswrf_avetoa
v-gwd_ave
vbdsf_ave
vddsf_ave
vflx_ave
```

No other variables or files at any other forecast hour were changed.

### Issue(s) addressed

Closes #1080 


## Testing

This fix was tested using the GFSv17 operational configuration on WCOSS2. The fix was also tested using the regression test suite of the UFSWM on Ursa.

