### PR TITLE
[production/GFS.v17] Update CCPP hash :: Remove goto statements and fix rrtmgp compile warning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  #url = https://github.com/ufs-community/ccpp-physics
-  #branch = production/GFS.v17
-  url = https://github.com/dpsarmie/ccpp-physics
-  branch = v17/radwarnfix_gotos
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = production/GFS.v17
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/GFS.v17
+  #url = https://github.com/ufs-community/ccpp-physics
+  #branch = production/GFS.v17
+  url = https://github.com/dpsarmie/ccpp-physics
+  branch = v17/radwarnfix_gotos
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description
This PR will update the CCPP physics hash to include changes made to the production/GFS.v17 CCPP branch. The changes are both part of EE2 compliance and include some removal of goto statements and updates the rte-rrtmgp hash to the production GFSv17 branch, which includes changes that remove a compiler warning.

Both of these changes are planned to be merged into develop:
https://github.com/ufs-community/ccpp-physics/issues/322  -- RRTMGP Compile warning
https://github.com/ufs-community/ufs-weather-model/pull/3167 -- Removal of goto statements from CCPP


### Issue(s) addressed
 No issue for this production only update


## Testing
This PR was tested on WCOSS2 and Ursa using the UFSWM regression test workflow and using a set of GFSv17 baselines that I've been maintaining.


## Dependencies
CCPP PR: https://github.com/ufs-community/ccpp-physics/pull/370

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on https://github.com/ufs-community/ccpp-physics/pull/370
