### PR TITLE
Bug Fix to Explicit In-Canopy Vertical Diffusion of Tracers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = develop
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/noaa-oar-arl/ccpp-physics
-  branch = fix_canopy_vdf
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = develop
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/noaa-oar-arl/ccpp-physics
+  branch = fix_canopy_vdf
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

Remove hpbl/kpbl update due to explicit in-canopy diffusion. This ensures no changes on the SRW-App AQM predictions of temperature, humidity, and winds in regions of contiguous canopies due to explicit in-canopy diffusion. The integrated-canopy vertical diffusion meteorology effects remains as before.

Using 10-interpolated winds in the initialization of the explicit canopy layers (instead of the 1 hydrid model layer winds) for the diffusion of tracers. This leads to further reductions in ozone biases (and it's precursors) in regions on contiguous canopies.

## Testing

Tests conducted on Gaea-C6 with the SRW-App AQM configuration/compilers. Tests conducted for GFS v16 and GFS v17_p8 physics.

Upcoming PR tests...
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on: https://github.com/ufs-community/ccpp-physics/pull/371
Upcoming full RT in UWM PR
