### PR TITLE
Update FV3 hash :: Removes all GNU compile warnings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "fv3/atmos_cubed_sphere"]
   path = fv3/atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  #url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  #branch = dev/emc
+  url = https://github.com/dpsarmie/GFDL_atmos_cubed_sphere
+  branch = fix/gnu_compiler_warnings
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "fv3/atmos_cubed_sphere"]
   path = fv3/atmos_cubed_sphere
-  #url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  #branch = dev/emc
-  url = https://github.com/dpsarmie/GFDL_atmos_cubed_sphere
-  branch = fix/gnu_compiler_warnings
+  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+  branch = dev/emc
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework


### PR DESCRIPTION
## Description
This PR will update the atmos_cubed model hash to bring in changes that resolve warnings that are triggered by the GNU compiler.  The warnings were a result from trailing text after a handful of `#if` and `#endif` statements.



### Issue(s) addressed

- closes #1094 



## Testing

These changes were tested on Ursa using the UFS WM regression test suite.


## Dependencies

- waiting on https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/412


