### PR TITLE
Add download of restart_fh to ci/CMakeLists.txt

### DIFF
--- a/ci/CMakeLists.txt
+++ b/ci/CMakeLists.txt
@@ -104,3 +104,18 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(stochastic_physics)
 
 message(STATUS "stochastic_physics downloaded successfully")
+
+# Download the standalone restart_fh module to satisfy UFSATM's hardcoded path
+set(RESTART_FH_URL "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/CDEPS-interface/ufs/cdeps_share/shr_is_restart_fh_mod.F90")
+set(RESTART_FH_DEST "${CMAKE_SOURCE_DIR}/CDEPS-interface/ufs/cdeps_share/shr_is_restart_fh_mod.F90")
+message(STATUS "Downloading shr_is_restart_fh_mod.F90 from ufs-weather-model...")
+
+file(DOWNLOAD "${RESTART_FH_URL}" "${RESTART_FH_DEST}" STATUS download_status)
+
+# Check if the download was successful to prevent silent CI failures
+list(GET download_status 0 status_code)
+list(GET download_status 1 status_msg)
+if(NOT status_code EQUAL 0)
+    message(FATAL_ERROR "Failed to download shr_is_restart_fh_mod.F90: ${status_msg}")
+endif()
+message(STATUS "restart_fh downloaded successfully")


### PR DESCRIPTION
## Description
Download restart_fh dependency from ufs-weather-model for UFSATM ci

### Issue(s) addressed

Fix https://github.com/NOAA-EMC/ufsatm/issues/1109

## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- None

