### PR TITLE
Update UPP version to 2026-05-15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ if (FV3)
 
   if(INLINE_POST)
     set(BUILD_POSTEXEC OFF)
+    set(BUILD_TESTING OFF)
     find_package(crtm REQUIRED)
     if (TARGET crtm)
       add_library(crtm::crtm ALIAS crtm)


### PR DESCRIPTION
## Description
Updated UPP version to develop as of 2026-05-15.

Also adds a `BUILD_TESTING=NO` flag to the UPP build to prevent build of UPP unit tests. UPP has added unit tests that assume the root CMAKE path is upp, which leads to errors during building as part of a larger package due to unfound fix files.

### Issue(s) addressed
Fixes #1113

## Testing
How were these changes tested?
- Tested within global workflow
- UFSWM RT on Ursa

What compilers / HPCs was it tested with?
- Native AWS/Intel
- Ursa (full RT)

Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
- Yes

Have the ufs-weather-model regression test been run? On what platform?
- On Ursa

Will the code updates change regression test baseline?
- No

Please commit the regression test log files in your ufs-weather-model branch
- ufs-community/ufs-weather-model#3244

## Dependencies
None (UPP changes being responded to are already in develop)

