### PR TITLE
The physics and dynamics coupling with tendencies dribbling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+  url = https://github.com/KevinViner-NOAA/GFDL_atmos_cubed_sphere
+  branch = gfs_pdc_2025
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "fv3/atmos_cubed_sphere"]
   path = fv3/atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+#  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+#  branch = dev/emc
+  url = https://github.com/WChen-NOAA/GFDL_atmos_cubed_sphere
+  branch = local-dev
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "atmos_cubed_sphere"]
   path = atmos_cubed_sphere
-  url = https://github.com/KevinViner-NOAA/GFDL_atmos_cubed_sphere
-  branch = gfs_pdc_2025
+  url = https://github.com/WChen-NOAA/GFDL_atmos_cubed_sphere
+  branch = gfs_pdc_2025k
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 #  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
 #  branch = dev/emc
   url = https://github.com/WChen-NOAA/GFDL_atmos_cubed_sphere
-  branch = local-dev
+  branch = pdc_full
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "fv3/atmos_cubed_sphere"]
   path = fv3/atmos_cubed_sphere
-  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-  branch = dev/emc
+#  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+#  branch = dev/emc
+  url = https://github.com/WChen-NOAA/GFDL_atmos_cubed_sphere
+  branch = pdc_full
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 #  url = https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
 #  branch = dev/emc
   url = https://github.com/WChen-NOAA/GFDL_atmos_cubed_sphere
-  branch = pdc_full
+  branch = pdc-dev
 [submodule "ccpp/framework"]
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -147,6 +147,7 @@ public setup_exportdata
      logical                       :: moving_nest_parent ! true if this grid has a moving nest child
      logical                       :: is_moving_nest     ! true if this is a moving nest grid
      logical                       :: isAtCapTime        ! true if currTime is at the cap driverClock's currTime
+     logical                       :: pdc                ! true for higher-order physics-dynamics coupling
      integer                       :: ngrids             !
      integer                       :: mygrid             !
      integer                       :: mlon, mlat
@@ -185,12 +186,13 @@ integer :: fv3Clock, getClock, updClock, setupClock, radClock, physClock
 integer :: blocksize    = 1
 logical :: chksum_debug = .false.
 logical :: dycore_only  = .false.
+logical :: pdc          = .false.
 logical :: debug        = .false.
 !logical :: debug        = .true.
 logical :: sync         = .false.
 real    :: avg_max_length=3600.
 logical :: ignore_rst_cksum = .false.
-namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, ccpp_suite, avg_max_length, &
+namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, pdc, debug, sync, ccpp_suite, avg_max_length, &
                            ignore_rst_cksum
 
 type (time_type) :: diag_time, diag_time_fhzero
@@ -622,6 +624,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
    if (file_exists('input.nml')) then
       read(input_nml_file, nml=atmos_model_nml, iostat=io)
       ierr = check_nml_error(io, 'atmos_model_nml')
+      Atmos%pdc = pdc
    endif
 
 !-----------------------------------------------------------------------
@@ -876,7 +879,7 @@ subroutine update_atmos_model_dynamics (Atmos)
     endif
 #endif
     call mpp_clock_begin(fv3Clock)
-    call atmosphere_dynamics (Atmos%Time)
+    call atmosphere_dynamics (Atmos%Time,Atmos%pdc)
 #ifdef MOVING_NEST
     ! W. Ramstrom, AOML/HRD -- June 9, 2021
     ! Debugging output of moving nest code.  Called from this level to access needed input variables.

--- a/fv3/atmos_model.F90
+++ b/fv3/atmos_model.F90
@@ -150,6 +150,7 @@ public get_atmos_tracer_types
      logical                       :: moving_nest_parent ! true if this grid has a moving nest child
      logical                       :: is_moving_nest     ! true if this is a moving nest grid
      logical                       :: isAtCapTime        ! true if currTime is at the cap driverClock's currTime
+     logical                       :: pdc                ! true for higher-order physics-dynamics coupling
      integer                       :: ngrids             !
      integer                       :: mygrid             !
      integer                       :: mlon, mlat
@@ -188,12 +189,13 @@ integer :: fv3Clock, getClock, updClock, setupClock, radClock, physClock
 integer :: blocksize    = 1
 logical :: chksum_debug = .false.
 logical :: dycore_only  = .false.
+logical :: pdc          = .false.
 logical :: debug        = .false.
 !logical :: debug        = .true.
 logical :: sync         = .false.
 real    :: avg_max_length=3600.
 logical :: ignore_rst_cksum = .false.
-namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, ccpp_suite, avg_max_length, &
+namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, pdc, debug, sync, ccpp_suite, avg_max_length, &
                            ignore_rst_cksum
 
 type (time_type) :: diag_time, diag_time_fhzero
@@ -626,6 +628,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
    if (file_exists('input.nml')) then
       read(input_nml_file, nml=atmos_model_nml, iostat=io)
       ierr = check_nml_error(io, 'atmos_model_nml')
+      Atmos%pdc = pdc
    endif
 
 !-----------------------------------------------------------------------
@@ -879,7 +882,7 @@ subroutine update_atmos_model_dynamics (Atmos)
     endif
 #endif
     call mpp_clock_begin(fv3Clock)
-    call atmosphere_dynamics (Atmos%Time)
+    call atmosphere_dynamics (Atmos%Time,Atmos%pdc)
 #ifdef MOVING_NEST
     ! W. Ramstrom, AOML/HRD -- June 9, 2021
     ! Debugging output of moving nest code.  Called from this level to access needed input variables.

--- a/fv3/atmos_model.F90
+++ b/fv3/atmos_model.F90
@@ -150,6 +150,7 @@ public get_atmos_tracer_types
      logical                       :: moving_nest_parent ! true if this grid has a moving nest child
      logical                       :: is_moving_nest     ! true if this is a moving nest grid
      logical                       :: isAtCapTime        ! true if currTime is at the cap driverClock's currTime
+     logical                       :: pdc                ! true for higher-order physics-dynamics coupling
      integer                       :: ngrids             !
      integer                       :: mygrid             !
      integer                       :: mlon, mlat
@@ -188,12 +189,13 @@ integer :: fv3Clock, getClock, updClock, setupClock, radClock, physClock
 integer :: blocksize    = 1
 logical :: chksum_debug = .false.
 logical :: dycore_only  = .false.
+logical :: pdc          = .false.
 logical :: debug        = .false.
 !logical :: debug        = .true.
 logical :: sync         = .false.
 real    :: avg_max_length=3600.
 logical :: ignore_rst_cksum = .false.
-namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, ccpp_suite, avg_max_length, &
+namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, pdc, debug, sync, ccpp_suite, avg_max_length, &
                            ignore_rst_cksum
 
 type (time_type) :: diag_time, diag_time_fhzero
@@ -626,6 +628,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
    if (file_exists('input.nml')) then
       read(input_nml_file, nml=atmos_model_nml, iostat=io)
       ierr = check_nml_error(io, 'atmos_model_nml')
+      Atmos%pdc = pdc
    endif
 
 !-----------------------------------------------------------------------
@@ -898,7 +901,7 @@ subroutine update_atmos_model_dynamics (Atmos)
     endif
 #endif
     call mpp_clock_begin(fv3Clock)
-    call atmosphere_dynamics (Atmos%Time)
+    call atmosphere_dynamics (Atmos%Time,Atmos%pdc)
 #ifdef MOVING_NEST
     ! W. Ramstrom, AOML/HRD -- June 9, 2021
     ! Debugging output of moving nest code.  Called from this level to access needed input variables.

--- a/fv3/atmos_model.F90
+++ b/fv3/atmos_model.F90
@@ -162,6 +162,7 @@ public merge_importfield
      integer                       :: mlon, mlat         !< longitude and latitude
      integer                       :: iau_offset         !< iau running window length
      logical                       :: pe                 !< current pe.
+     logical                       :: pdc                ! true for higher-order physics-dynamics coupling
      real(kind=GFS_kind_phys), pointer, dimension(:)     :: ak, bk
      real(kind=GFS_kind_phys), pointer, dimension(:,:)   :: lon_bnd  => null() !< local longitude axis grid box corners in radians.
      real(kind=GFS_kind_phys), pointer, dimension(:,:)   :: lat_bnd  => null() !< local latitude axis grid box corners in radians.
@@ -201,8 +202,9 @@ real    :: avg_max_length=3600.   !< Maximum length for time averaging
 logical :: ignore_rst_cksum = .false. !< Logical to ignore restart file checksum
 logical :: cpl_imp_mrg = .false. !< Logical to merge imported data
 logical :: cpl_imp_dbg = .false. !< Logical to debug imported data
+logical :: pdc          = .false. !<Logical to enable phy-dyn-cpl with time dribbling
 namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, ccpp_suite, avg_max_length, &
-                           ignore_rst_cksum, cpl_imp_mrg, cpl_imp_dbg
+                           ignore_rst_cksum, cpl_imp_mrg, cpl_imp_dbg,pdc
 
 type (time_type) :: diag_time, diag_time_fhzero !< Time diagnostic and forecast hour zero time diagnostic
 
@@ -610,6 +612,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step)
    if (file_exists('input.nml')) then
       read(input_nml_file, nml=atmos_model_nml, iostat=io)
       ierr = check_nml_error(io, 'atmos_model_nml')
+      Atmos%pdc = pdc
    endif
 
 !-----------------------------------------------------------------------
@@ -862,7 +865,7 @@ subroutine update_atmos_model_dynamics (Atmos)
     endif
 #endif
     call mpp_clock_begin(fv3Clock)
-    call atmosphere_dynamics (Atmos%Time)
+    call atmosphere_dynamics (Atmos%Time,Atmos%pdc)
 #ifdef MOVING_NEST
     ! W. Ramstrom, AOML/HRD -- June 9, 2021
     ! Debugging output of moving nest code.  Called from this level to access needed input variables.


### PR DESCRIPTION
## Description

An new methodology is implemented as an option (PDC=.T./.F.) to account for the lack of physics tendencies in the dynamics which could briefly be on the second time step, we use the physics/coupling tendencies from the previous step and then allocate the tendency containers at a time. Reset the state variables to the saved state from the end of the previous time step, add the new tendencies piecemeal on each acoustic step.



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<[1122](https://github.com/NOAA-EMC/ufsatm/issues/1122)>
- fixes NOAA-GFDL/GFDL_atmos_cubed_sphere/issues/[417](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/issues/417) 



## Testing

How were these changes tested?  
Ideal & Real Cases are tested.
SFS-PDC are tested and compared.
RES tested .le. C768

What compilers / HPCs was it tested with?  
Intel on Hera/Ursa/WCOSS2

Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
No new tests, this an option and be turned off as currently 

Have the ufs-weather-model regression test been run? On what platform? 
Run on Ursa
 
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
No new tests, this an option and be turned off as currently 

- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
- waiting on NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/[418](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/418)

