### PR TITLE
RRFS smoke fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = develop
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+  url = https://github.com/mkavulich/ccpp-physics
+  branch = rrfs_smoke_bugfix
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = develop
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/mkavulich/ccpp-physics
-  branch = rrfs_smoke_bugfix
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = ufs/dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -3605,7 +3605,7 @@ module GFS_diagnostics
       ExtDiag(idx)%desc = 'smoke concentration'
       ExtDiag(idx)%unit = 'kg kg-1'
       ExtDiag(idx)%mod_name = 'gfs_phys'
-      ExtDiag(idx)%data%var3 => Statein%qgrs(:,:,Model%ntfsmoke)
+      ExtDiag(idx)%data%var3 => Stateout%gq0(:,:,Model%ntfsmoke)
     endif
 
     if (Model%rrfs_sd .and. Model%ntsmoke>0) then


### PR DESCRIPTION
## Description
This PR fixes an issue in the current UFS code where the smoke emissions from the CFBM fire_behavior module do not persist in subsequent timesteps. Only a few instantaneous pixels of smoke can be seen in the first layer. This series of images shows smoke concentrations in the first layer at 3 h, 4 h, 5h and 6 h lead times using the current UFS weather model code:
<img width="468" height="127" alt="image" src="https://github.com/user-attachments/assets/ec4f9031-a7b2-4aae-b0db-bceebde0e17f" />

After the fix, smoke now accumulates properly in the atmosphere over time:
<img width="521" height="148" alt="image" src="https://github.com/user-attachments/assets/3d1808e5-718c-4d87-8aed-02a0baf97f24" />

### Issue(s) addressed
- fixes https://github.com/ufs-community/ufs-weather-model/issues/3266 (once updates merged into ufs-weather-model)

## Testing
UFS regression tests on Ursa successful.

## Dependencies
- waiting on https://github.com/ufs-community/ccpp-physics/pull/377

## Contributors:
Fixes from Maria Frediani and Pedro Jimenez
