### PR TITLE
[production/RRFS.v1] G-F and NSSL MP changes to reduce REFS instability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = production/RRFS.v1
-  url = https://github.com/JiliDong-NOAA/ccpp-physics 
-  branch = refs_stability 
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = production/RRFS.v1
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/RRFS.v1
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = production/RRFS.v1
+  url = https://github.com/JiliDong-NOAA/ccpp-physics 
+  branch = refs_stability 
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This PR includes two physics changes to reduce instability related to REFS members:

1. Changes on Grell-Freitas cumulus convection from @delippi and discussions with Georg Grell, @haiqinli @lisa-bengtsson and @yangfanglin:

- Disable the fct1d3 convective-subsidence transport of existing cloud condensate.
  - This transport pathway was found to be problematic in columns containing very thin model layers.
  - Other GF convective processes remain active.
- Add a mass-conserving correction for cloud liquid water and cloud ice.
  - Compute the candidate liquid, ice, and total condensate values before updating the model state.
  - When the temperature-based partition makes one species negative, place the remaining nonnegative total condensate in the other species.
  - When the updated total condensate itself is negative, set both species to zero.
  - Avoid independently clipping liquid and ice in a way that can artificially increase total condensate. 


2. Changes on NSSL microphysics from @MicroTed
- this change limit condensation in NSSL microphysics to avoid undersaturation (overprediction of condensation)


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

Tests on REFS members have been performed on WCOSS2 by @delippi and @JiliDong-NOAA

## Dependencies

https://github.com/ufs-community/ccpp-physics/pull/379

