### PR TITLE
[production/GEFS_v12] Update GFDL_atmos_cubed_sphere to include dz_min change

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/EricSinsky-NOAA/GFDL_atmos_cubed_sphere
-	branch = issue93
+	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+	branch = production/GEFS.v12

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "atmos_cubed_sphere"]
-       path = atmos_cubed_sphere
-       url = git@github.com:EricSinsky-NOAA/GFDL_atmos_cubed_sphere.git
-       branch = issue93
+	path = atmos_cubed_sphere
+	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
+	branch = dev/emc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-	branch = dev/emc
+	url = git@github.com:EricSinsky-NOAA/GFDL_atmos_cubed_sphere.git
+	branch = issue93

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "atmos_cubed_sphere"]
-	path = atmos_cubed_sphere
-	url = https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere
-	branch = dev/emc
+       path = atmos_cubed_sphere
+       url = git@github.com:EricSinsky-NOAA/GFDL_atmos_cubed_sphere.git
+       branch = issue93

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = git@github.com:EricSinsky-NOAA/GFDL_atmos_cubed_sphere.git
+	url = https://github.com/EricSinsky-NOAA/GFDL_atmos_cubed_sphere
 	branch = issue93


### PR DESCRIPTION
## Description

This PR updates the `GFDL_atmos_cubed_sphere` submodule for `production/GEFS_v12`. This update changes `dz_min` from `2` to `12` to improve model stability. 

This PR will be kept in draft until the subPR in `GFDL_atmos_cubed_sphere` is merged. After the subPR is merged, `.gitmodules` and the `GFDL_atmos_cubed_sphere` hash in this PR will need to be updated. 

### Issue(s) addressed

- fixes #1128 

## Testing

This change has been tested in the GEFSv12 package on WCOSS2 for the following cases:

1. 20260706 00Z p18
2. 20260704 00Z p08
3. 20260703 06Z p26
4. 20260630 00Z p08
5. 20260630 18Z p11

## Dependencies

- waiting on noaa-emc/GFDL_atmos_cubed_sphere/pull/94

