### PR TITLE
Add new compiler options to ThompsonMP for speed-up

### DIFF
--- a/ccpp/CMakeLists.txt
+++ b/ccpp/CMakeLists.txt
@@ -467,6 +467,17 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release" AND (${CMAKE_Fortran_COMPILER_ID} STREQU
 endif()
 
 #------------------------------------------------------------------------------
+# Thompson MP can be sped up with more aggresive compiler flags;
+# HAFS will have this in 2.2 production. This is Intel/IntelLLVM only.
+#------------------------------------------------------------------------------
+if (CMAKE_BUILD_TYPE STREQUAL "Release" AND (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel" OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL "IntelLLVM"))
+	message(STATUS "Add speed up flags to Thompson MP with Intel")
+  set_property(SOURCE
+    ${SCHEME_FILES_DIR}/physics/MP/Thompson/module_mp_thompson.F90
+    APPEND PROPERTY COMPILE_OPTIONS -fp-model=fast -fprotect-parens -fimf-precision=high)
+endif()
+
+#------------------------------------------------------------------------------
 # Build CCPP_TARGET
 #------------------------------------------------------------------------------
 set(BUILD_SHARED_LIBS OFF)

--- a/ccpp/CMakeLists.txt
+++ b/ccpp/CMakeLists.txt
@@ -470,10 +470,10 @@ endif()
 # Thompson MP can be sped up with more aggresive compiler flags;
 # HAFS will have this in 2.2 production. This is Intel/IntelLLVM only.
 #------------------------------------------------------------------------------
-if (CMAKE_BUILD_TYPE STREQUAL "Release" AND (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel" OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL "IntelLLVM"))
+if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel" OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL "IntelLLVM")
 	message(STATUS "Add speed up flags to Thompson MP with Intel")
   set_property(SOURCE
-    ${SCHEME_FILES_DIR}/physics/MP/Thompson/module_mp_thompson.F90
+    ${SCHEME_FILES_DIR}/MP/Thompson/module_mp_thompson.F90
     APPEND PROPERTY COMPILE_OPTIONS -fp-model=fast -fprotect-parens -fimf-precision=high)
 endif()
 

--- a/ccpp/CMakeLists.txt
+++ b/ccpp/CMakeLists.txt
@@ -470,7 +470,7 @@ endif()
 # Thompson MP can be sped up with more aggresive compiler flags;
 # HAFS will have this in 2.2 production. This is Intel/IntelLLVM only.
 #------------------------------------------------------------------------------
-if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel" OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL "IntelLLVM")
+if (CMAKE_BUILD_TYPE STREQUAL "Release" AND (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel" OR ${CMAKE_Fortran_COMPILER_ID} STREQUAL "IntelLLVM"))
 	message(STATUS "Add speed up flags to Thompson MP with Intel")
   set_property(SOURCE
     ${SCHEME_FILES_DIR}/MP/Thompson/module_mp_thompson.F90


### PR DESCRIPTION
## Description

This PR will add new compiler options that were found to speed up the Thompson microphysics scheme by ~3%-4%. These options will change baselines, but they are within the expected range according to work done by the HAFS and GFS teams.

These compiler options are going to be in HAFSv2.2 production.



### Issue(s) addressed

- fixes https://github.com/ufs-community/ufs-weather-model/issues/3347



## Testing

These changes were tested with the UFS WM regression test system.  Baseline changes were documented and reproducibility was tested on Ursa.


## Dependencies

None
