### PR TITLE
Add FRAM for freezing rain diagnosis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,8 @@
   branch = feature/capgen-v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
+  #url = https://github.com/ufs-community/ccpp-physics
+  url = https://github.com/RuiyuSun/ccpp-physics
   branch = ufs/dev
 [submodule "upp"]
   path = upp

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,8 @@
   path = ccpp/physics
   #url = https://github.com/ufs-community/ccpp-physics
   url = https://github.com/RuiyuSun/ccpp-physics
-  branch = ufs/dev
+  #branch = ufs/dev
+  branch = FRAM
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
This PR is to add the Freezing Rain Accumulation Model (FRAM) for freezing rain diagnosis. The purpose is to reduce the high freezing rain bias seen in the GFSv17. 
This PR changes only diagnosed freezing rain in surface files.    



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes - noaa-emc/fv3atm/issues/#1136


## Testing

This change was tested in the GFSv176 workflow. 
What compilers / HPCs was it tested with?  intel compiler was used. The test experiments were completed on WCOSS2. 
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  The change is covered by a RT test 
Have the ufs-weather-model regression test been run? On what platform?  A RT test was completed on URSA. 
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.  This change change the RT test baseline. 
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

- waiting on - ufs-community/ccpp-physics/pull/387
