### PR TITLE
Update to rte-rrtmgp v1.9.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = develop
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = ufs/dev
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = ufs/dev
+  url = https://github.com/dustinswales/ccpp-physics
+  branch = feature/rrtmgp_v1.9.2
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/CMakeLists.txt
+++ b/ccpp/CMakeLists.txt
@@ -372,32 +372,34 @@ endif()
 #------------------------------------------------------------------------------
 message(STATUS "Disabling OpenMP for rte-rrtmgp radiation")
 set(RRTMGP_SOURCES
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/gas-optics/mo_gas_optics.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/gas-optics/mo_gas_optics_constants.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/gas-optics/mo_gas_concentrations.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/gas-optics/mo_gas_optics_util_string.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rrtmgp-frontend/mo_gas_optics_rrtmgp.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rrtmgp-frontend/mo_cloud_optics_rrtmgp.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/extensions/mo_rrtmgp_clr_all_sky.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/extensions/mo_fluxes_byband.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/extensions/solar_variability/mo_solar_variability.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/extensions/mo_heating_rates.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/extensions/mo_fluxes_bygpoint.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/extensions/mo_compute_bc.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/extensions/mo_cloud_sampling.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-frontend/mo_rte_util_array_validation.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-frontend/mo_rte_config.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-frontend/mo_source_functions.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-frontend/mo_rte_sw.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-frontend/mo_fluxes.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-frontend/mo_rte_lw.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-kernels/mo_rte_util_array.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-kernels/mo_rte_solver_kernels.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-kernels/mo_optical_props_kernels.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-kernels/mo_fluxes_broadband_kernels.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-frontend/mo_rte_kind.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte-frontend/mo_optical_props.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rrtmgp/frontend/mo_cloud_optics_rrtmgp.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rrtmgp/frontend/mo_gas_optics_rrtmgp.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rrtmgp/kernels/mo_cloud_optics_rrtmgp_kernels.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rrtmgp/kernels/mo_gas_optics_rrtmgp_kernels.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/gas-optics-template/mo_gas_optics.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/gas-optics-template/mo_gas_concentrations.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/gas-optics-template/mo_gas_optics_util_string.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_rte_util_array_validation.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_rte_config.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_source_functions.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_rte_sw.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_fluxes.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_rte_lw.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_optical_props.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_fluxes_broadband_kernels.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_gas_optics_constants.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_gas_optics_utils.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_optical_props_kernels.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_rte_kind.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_rte_solver_kernels.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_rte_util_array.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/extensions/mo_fluxes_byband.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/extensions/mo_heating_rates.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/extensions/mo_rrtmgp_clr_all_sky.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/extensions/mo_fluxes_bygpoint.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/extensions/mo_compute_bc.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/extensions/mo_cloud_sampling.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/extensions/solar_variability/mo_solar_variability.F90
 )
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")

--- a/ccpp/CMakeLists.txt
+++ b/ccpp/CMakeLists.txt
@@ -379,6 +379,7 @@ set(RRTMGP_SOURCES
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/gas-optics-template/mo_gas_optics.F90
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/gas-optics-template/mo_gas_concentrations.F90
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/gas-optics-template/mo_gas_optics_util_string.F90
+    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/gas-optics-template/mo_gas_optics_constants.F90
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_rte_util_array_validation.F90
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_rte_config.F90
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_source_functions.F90
@@ -387,8 +388,6 @@ set(RRTMGP_SOURCES
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_rte_lw.F90
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/frontend/mo_optical_props.F90
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_fluxes_broadband_kernels.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_gas_optics_constants.F90
-    ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_gas_optics_utils.F90
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_optical_props_kernels.F90
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_rte_kind.F90
     ${SCHEME_FILES_DIR}/Radiation/RRTMGP/rte-rrtmgp/rte/kernels/mo_rte_solver_kernels.F90


### PR DESCRIPTION
## Description
Changes here are isolated to the CMakeLists.txt file to accommodate a reorganization in the rte-rrtmgp submodule.
In the physics:
Update CCPP interfaces to use rte-rrtmgp v1.9.3. Previously using v1.8 (2024)
Switch to using rte-rrtmgp submodule in the ufs-community organization.

### Issue(s) addressed
N/A

## Testing
UWM rte-rrtmgp enabled regression tests on Ursa using Intel. 
Small answer changes are expected due to changes under the hood in the rte-rrtmgp submodule.